### PR TITLE
Fix space overflow bug of pmem allocator, and mark corrupted data entry as padding type

### DIFF
--- a/engine/allocator.hpp
+++ b/engine/allocator.hpp
@@ -23,7 +23,8 @@ struct SpaceEntry {
     if (hash_entry_reference != nullptr) {
       assert(hash_entry_mutex != nullptr);
       std::lock_guard<SpinMutex> lg(*hash_entry_mutex);
-      hash_entry_reference->header.reference = hash_entry_reference->header.reference - 1;
+      hash_entry_reference->header.reference =
+          hash_entry_reference->header.reference - 1;
     }
   }
 };

--- a/engine/hash_table.cpp
+++ b/engine/hash_table.cpp
@@ -101,7 +101,6 @@ Status HashTable::Search(const KeyHashHint &hint, const Slice &key,
           } else {
             auto space = dram_allocator_->Allocate(hash_bucket_size_);
             if (space.size == 0) {
-              // TODO: handle this
               GlobalLogger.Error("Memory overflow!\n");
               return Status::MemoryOverflow;
             }

--- a/engine/kv_engine.cpp
+++ b/engine/kv_engine.cpp
@@ -143,6 +143,10 @@ Status KVEngine::RestoreData(uint64_t thread_id) {
       pmem_allocator_->Free(SizedSpaceEntry(
           pmem_allocator_->addr2offset(pmem_data_entry),
           recovering_data_entry->header.b_size, nullptr, nullptr));
+      if (recovering_data_entry->header.checksum != checksum) {
+        pmem_data_entry->type = PADDING;
+        pmem_persist(&pmem_data_entry->type, sizeof(DATA_ENTRY_TYPE));
+      }
 
       segment_space.size -= recovering_data_entry->header.b_size;
       segment_space.space_entry.offset += recovering_data_entry->header.b_size;

--- a/engine/pmem_allocator.cpp
+++ b/engine/pmem_allocator.cpp
@@ -378,7 +378,8 @@ SizedSpaceEntry PMEMAllocator::Allocate(unsigned long size) {
       GlobalLogger.Error("PMEM OVERFLOW!\n");
       return space_entry;
     }
-    thread_cache.segment_usable_blocks = num_segment_blocks_;
+    thread_cache.segment_usable_blocks = std::min(
+        num_segment_blocks_, max_offset_ - thread_cache.segment_offset);
     full_segment = false;
   }
   space_entry.size = b_size;

--- a/engine/skiplist.cpp
+++ b/engine/skiplist.cpp
@@ -90,7 +90,6 @@ void Skiplist::Seek(const Slice &key, Splice *splice) {
     }
     DLDataEntry *next_data_entry =
         (DLDataEntry *)pmem_allocator_->offset2addr(next_data_entry_offset);
-    // TODO: make this thread safe
     int cmp = Slice::compare(key, UserKey(next_data_entry->Key()));
     if (cmp > 0) {
       prev_data_entry = next_data_entry;
@@ -121,7 +120,8 @@ bool Skiplist::FindAndLockWritePos(Splice *splice, const Slice &insert_key,
       Seek(insert_key, splice);
       prev = splice->prev_data_entry;
       next = splice->next_data_entry;
-      assert(prev == header_->data_entry || Slice::compare(UserKey(prev->Key()), insert_key) < 0);
+      assert(prev == header_->data_entry ||
+             Slice::compare(UserKey(prev->Key()), insert_key) < 0);
     }
 
     uint64_t prev_offset = pmem_allocator_->addr2offset(prev);


### PR DESCRIPTION
For the situation that pmem segment is not aligned with the total pmem space