### PR TITLE
Merge adjacent free spaces in background thread

### DIFF
--- a/engine/pmem_allocator/free_list.cpp
+++ b/engine/pmem_allocator/free_list.cpp
@@ -40,95 +40,50 @@ uint64_t SpaceMap::TestAndUnset(uint64_t offset, uint64_t length) {
   std::lock_guard<SpinMutex> start_lg(spins_[cur / lock_granularity_]);
   SpinMutex *last_lock = &spins_[cur / lock_granularity_];
   std::unique_ptr<std::lock_guard<SpinMutex>> lg(nullptr);
-  while (map_[offset].IsStart()) {
-    if (cur >= map_.size() || map_[cur].Empty()) {
-      break;
-    } else {
-      res += map_[cur].Size();
-      map_[cur].Clear();
-      cur = offset + res;
-    }
-    if (res < length) {
-      SpinMutex *next_lock = &spins_[cur / lock_granularity_];
-      if (next_lock != last_lock) {
-        last_lock = next_lock;
-        lg.reset(new std::lock_guard<SpinMutex>(*next_lock));
+  if (map_[offset].IsStart()) {
+    while (1) {
+      if (cur >= map_.size() || map_[cur].Empty()) {
+        break;
+      } else {
+        res += map_[cur].Size();
+        map_[cur].Clear();
+        cur = offset + res;
       }
-    } else {
-      break;
+      if (res < length) {
+        SpinMutex *next_lock = &spins_[cur / lock_granularity_];
+        if (next_lock != last_lock) {
+          last_lock = next_lock;
+          lg.reset(new std::lock_guard<SpinMutex>(*next_lock));
+        }
+      } else {
+        break;
+      }
     }
   }
   return res;
 }
 
-uint64_t SpaceMap::FindAndUnset(uint64_t &start_offset, uint64_t max_length,
-                                uint64_t target_length) {
-  uint64_t cur = start_offset;
-  uint64_t end_offset = start_offset + max_length;
-  SpinMutex *start_lock = &spins_[cur / lock_granularity_];
-  std::unique_ptr<std::lock_guard<SpinMutex>> lg(
-      new std::lock_guard<SpinMutex>(*start_lock));
-  while (cur < map_.size()) {
-    if (&spins_[cur / lock_granularity_] != start_lock) {
-      start_lock = &spins_[cur / lock_granularity_];
-      lg.reset(new std::lock_guard<SpinMutex>(*start_lock));
-    }
-    SpinMutex *last_lock = start_lock;
-    start_offset = cur;
-    bool done = false;
-    uint64_t length = 0;
-    std::vector<uint64_t> merged_offset;
-    std::vector<SpinMutex *> locked;
-    while (1) {
-      if (cur >= end_offset || (end_offset - cur + length < target_length) ||
-          map_[cur].Empty()) {
-        if (length >= target_length) {
-          for (auto o : merged_offset) {
-            map_[o].Clear();
-          }
-          done = true;
-        }
-        for (auto s : locked) {
-          s->unlock();
-        }
-        break;
-      }
-      length += map_[cur].Size();
-      merged_offset.push_back(cur);
-      cur = start_offset + length;
-
-      SpinMutex *next_lock = &spins_[cur / lock_granularity_];
-      if (next_lock != last_lock) {
-        next_lock->lock();
-        locked.push_back(next_lock);
-        last_lock = next_lock;
-      }
-    }
-    if (done) {
-      return length;
-    } else {
-      cur++;
-    }
-  }
-  return 0;
-}
-
-uint64_t SpaceMap::MergeAndUnset(uint64_t offset, uint64_t max_length,
-                                 uint64_t target_length) {
+uint64_t SpaceMap::TryMerge(uint64_t offset, uint64_t max_merge_length,
+                            uint64_t target_merge_length) {
   uint64_t cur = offset;
-  uint64_t end_offset = offset + max_length;
+  uint64_t end_offset = offset + max_merge_length;
   SpinMutex *last_lock = &spins_[cur / lock_granularity_];
-  uint64_t res = 0;
+  uint64_t merged = 0;
   std::lock_guard<SpinMutex> lg(*last_lock);
+  if (map_[cur].Empty() || !map_[cur].IsStart()) {
+    return merged;
+  }
   std::vector<SpinMutex *> locked;
   std::vector<uint64_t> merged_offset;
   while (cur < end_offset) {
     if (map_[cur].Empty()) {
       break;
     } else {
-      res += map_[cur].Size();
-      merged_offset.push_back(cur);
-      cur = offset + res;
+      merged += map_[cur].Size();
+      if (cur != offset) {
+        merged_offset.push_back(cur);
+      }
+      cur = offset + merged;
     }
 
     SpinMutex *next_lock = &spins_[cur / lock_granularity_];
@@ -138,17 +93,56 @@ uint64_t SpaceMap::MergeAndUnset(uint64_t offset, uint64_t max_length,
       locked.push_back(next_lock);
     }
   }
-  if (res >= target_length) {
+  if (merged >= target_merge_length) {
     for (uint64_t o : merged_offset) {
-      map_[o].Clear();
+      map_[o].UnStart();
     }
   } else {
-    res = 0;
+    merged = 0;
   }
   for (SpinMutex *l : locked) {
     l->unlock();
   }
-  return res;
+  return merged;
+}
+
+void FreeList::MergeFreeSpace() {
+  std::vector<SpaceEntry> merging_list;
+  std::vector<std::vector<SpaceEntry>> merged_entry_list(
+      max_classified_b_size_);
+
+  for (uint32_t b_size = 1; b_size < max_classified_b_size_; b_size++) {
+    if (active_pool_.TryFetchEntryList(merging_list, b_size)) {
+      for (const SpaceEntry &se : merging_list) {
+        uint64_t merged_size = MergeSpace(
+            se, num_segment_blocks_ - se.offset % num_segment_blocks_, b_size);
+
+        // large space entries
+        if (merged_size >= merged_entry_list.size()) {
+          std::lock_guard<SpinMutex> lg(large_entries_spin_);
+          large_entries_.insert(SizedSpaceEntry(se.offset, merged_size));
+          // move merged entries to merging pool to avoid redundant merging
+        } else if (merged_size > 0) {
+          merged_entry_list[merged_size].emplace_back(std::move(se));
+          if (merged_entry_list[merged_size].size() >= kMinMovableEntries) {
+            merged_pool_.MoveEntryList(merged_entry_list[merged_size],
+                                       merged_size);
+          }
+        }
+      }
+    }
+  }
+
+  std::vector<SpaceEntry> merged_list;
+  for (uint32_t b_size = 1; b_size < max_classified_b_size_; b_size++) {
+    while (merged_pool_.TryFetchEntryList(merged_list, b_size)) {
+      active_pool_.MoveEntryList(merged_list, b_size);
+    }
+
+    if (merged_entry_list[b_size].size() > 0) {
+      active_pool_.MoveEntryList(merged_entry_list[b_size], b_size);
+    }
+  }
 }
 
 void FreeList::Push(const SizedSpaceEntry &entry) {
@@ -174,12 +168,12 @@ bool FreeList::Get(uint32_t b_size, SizedSpaceEntry *space_entry) {
       if (thread_cache.backup_entries[i].size() != 0) {
         std::lock_guard<SpinMutex> lg(thread_cache.spins[i]);
         thread_cache.active_entries[i].swap(thread_cache.backup_entries[i]);
-      } else if (space_entry_pool_[i].size() != 0) {
-        std::lock_guard<SpinMutex> lg(spins_[i]);
-        if (space_entry_pool_[i].size() != 0) {
-          thread_cache.active_entries[i].swap(space_entry_pool_[i].back());
-          space_entry_pool_[i].pop_back();
-        }
+      } else if (!active_pool_.TryFetchEntryList(thread_cache.active_entries[i],
+                                                 i) &&
+                 !merged_pool_.TryFetchEntryList(thread_cache.active_entries[i],
+                                                 i)) {
+        // no usable b_size free space entry
+        continue;
       }
     }
 
@@ -193,20 +187,22 @@ bool FreeList::Get(uint32_t b_size, SizedSpaceEntry *space_entry) {
     }
   }
 
-  std::lock_guard<SpinMutex> lg(large_entries_spin_);
-  while (!large_entries_.empty()) {
-    auto space = large_entries_.begin();
-    if (space->size >= b_size) {
-      auto size = space->size;
-      space_entry->space_entry = space->space_entry;
-      large_entries_.erase(space);
-      if (space_map_->TestAndUnset(space_entry->space_entry.offset, size) ==
-          size) {
-        space_entry->size = size;
-        return true;
+  if (!large_entries_.empty()) {
+    std::lock_guard<SpinMutex> lg(large_entries_spin_);
+    while (!large_entries_.empty()) {
+      auto space = large_entries_.begin();
+      if (space->size >= b_size) {
+        auto size = space->size;
+        space_entry->space_entry = space->space_entry;
+        large_entries_.erase(space);
+        if (space_map_->TestAndUnset(space_entry->space_entry.offset, size) ==
+            size) {
+          space_entry->size = size;
+          return true;
+        }
+      } else {
+        break;
       }
-    } else {
-      break;
     }
   }
   return false;
@@ -217,27 +213,31 @@ void FreeList::MoveCachedListToPool() {
     for (size_t i = 1; i < tc.backup_entries.size(); i++) {
       std::lock_guard<SpinMutex> lg(tc.spins[i]);
       if (tc.backup_entries[i].size() >= kMinMovableEntries) {
-        std::lock_guard<SpinMutex> lg(spins_[i]);
-        space_entry_pool_[i].emplace_back();
-        tc.backup_entries[i].swap(space_entry_pool_[i].back());
+        active_pool_.MoveEntryList(tc.backup_entries[i], i);
       }
     }
   }
 }
 
-bool FreeList::MergeGet(uint32_t b_size, uint64_t segment_blocks,
-                        SizedSpaceEntry *space_entry) {
+bool FreeList::MergeGet(uint32_t b_size, SizedSpaceEntry *space_entry) {
   auto &cache_list = thread_cache_[write_thread.id].active_entries;
   for (uint32_t i = 1; i < FREE_LIST_MAX_BLOCK; i++) {
     auto iter = cache_list[i].begin();
     while (iter != cache_list[i].end()) {
       uint64_t size = MergeSpace(
-          *iter, segment_blocks - iter->offset % segment_blocks, b_size);
+          *iter, num_segment_blocks_ - iter->offset % num_segment_blocks_,
+          b_size);
       if (size >= b_size) {
-        space_entry->space_entry = *iter;
-        space_entry->size = size;
-        cache_list[i].erase(iter);
-        return true;
+        if (space_map_->TestAndUnset(iter->offset, size)) {
+          space_entry->space_entry = *iter;
+          space_entry->size = size;
+          std::swap(*iter, cache_list[i].back());
+          cache_list[i].pop_back();
+          return true;
+        } else {
+          std::swap(*iter, cache_list[i].back());
+          cache_list[i].pop_back();
+        }
       }
       iter++;
     }

--- a/engine/pmem_allocator/free_list.cpp
+++ b/engine/pmem_allocator/free_list.cpp
@@ -221,8 +221,9 @@ void FreeList::MoveCachedListToPool() {
 
 bool FreeList::MergeGet(uint32_t b_size, SizedSpaceEntry *space_entry) {
   auto &cache_list = thread_cache_[write_thread.id].active_entries;
-  for (uint32_t i = 1; i < FREE_LIST_MAX_BLOCK; i++) {
-    for (size_t j = 0; j < cache_list[i].size(); j++) {
+  for (uint32_t i = 1; i < max_classified_b_size_; i++) {
+    size_t j = 0;
+    while (j < cache_list[i].size()) {
       uint64_t size = MergeSpace(cache_list[i][j],
                                  num_segment_blocks_ - cache_list[i][j].offset %
                                                            num_segment_blocks_,
@@ -236,6 +237,8 @@ bool FreeList::MergeGet(uint32_t b_size, SizedSpaceEntry *space_entry) {
             size) {
           return true;
         }
+      } else {
+        j++;
       }
     }
   }

--- a/engine/pmem_allocator/free_list.hpp
+++ b/engine/pmem_allocator/free_list.hpp
@@ -21,11 +21,8 @@ public:
 
   uint64_t TestAndUnset(uint64_t offset, uint64_t length);
 
-  uint64_t FindAndUnset(uint64_t &start_offset, uint64_t max_length,
-                        uint64_t target_length);
-
-  uint64_t MergeAndUnset(uint64_t offset, uint64_t max_length,
-                         uint64_t target_length);
+  uint64_t TryMerge(uint64_t offset, uint64_t max_merge_length,
+                    uint64_t target_merge_length);
 
   void Set(uint64_t offset, uint64_t length);
 
@@ -42,35 +39,108 @@ private:
     void Clear() { token = 0; }
     bool Empty() { return token == 0; }
     bool IsStart() { return token & (1 << 7); }
+    void UnStart() { token &= ((1 << 7) - 1); }
 
   private:
     uint8_t token;
   };
 
-  std::vector<MapToken> map_;
   // how many blocks share a lock
   const uint32_t lock_granularity_;
+  std::vector<MapToken> map_;
+  std::vector<SpinMutex> spins_;
+};
+
+// free entry pool consists of three level vectors, the first level
+// indicates different block size, each block size consists of several free
+// space entry lists (the second level), and each list consists of several
+// free space entries (the third level).
+//
+// For a specific block size, a write thread will move a entry list from the
+// pool to its thread cache while no usable free space in the cache, or move a
+// entry list to the pool while too many entries cached.
+//
+// Organization of the three level vectors:
+//
+// block size (1st level)   entry list (2nd level)   entries (3th level)
+//     1   -----------------   list1    ------------   entry1
+//                    |                         |---   entry2
+//                    |-----   list2    ------------   entry1
+//                                              |---   entry2
+//                                              |---   entry3
+//                              ...
+//     2   -----------------   list1    ------------   entry1
+//                    |                         |---   entry2
+//                    |                         |---   entry3
+//                    |-----   list2
+//                              ...
+//    ...
+// max_block_size   --------   list1
+//                    |-----   list2
+class SpaceEntryPool {
+public:
+  SpaceEntryPool(uint32_t max_b_size) : pool_(max_b_size), spins_(max_b_size) {}
+
+  // move a entry list of b_size free space entries to pool, "src" will be empty
+  // after move
+  void MoveEntryList(std::vector<SpaceEntry> &src, uint32_t b_size) {
+    std::lock_guard<SpinMutex> lg(spins_[b_size]);
+    assert(b_size < pool_.size());
+    pool_[b_size].emplace_back();
+    pool_[b_size].back().swap(src);
+  }
+
+  // try to fetch b_size free space entries from a entry list of pool to dst
+  bool TryFetchEntryList(std::vector<SpaceEntry> &dst, uint32_t b_size) {
+    std::lock_guard<SpinMutex> lg(spins_[b_size]);
+    if (pool_[b_size].size() != 0) {
+      dst.swap(pool_[b_size].back());
+      pool_[b_size].pop_back();
+      return true;
+    }
+    return false;
+  }
+
+private:
+  std::vector<std::vector<std::vector<SpaceEntry>>> pool_;
   std::vector<SpinMutex> spins_;
 };
 
 class FreeList {
 public:
-  FreeList(uint32_t max_b_size, uint32_t num_threads,
-           std::shared_ptr<SpaceMap> space_map)
-      : space_entry_pool_(max_b_size), space_map_(space_map),
-        thread_cache_(num_threads, max_b_size), spins_(max_b_size) {}
+  FreeList(uint32_t max_b_size, uint64_t num_segment_blocks,
+           uint32_t num_threads, std::shared_ptr<SpaceMap> space_map)
+      : num_segment_blocks_(num_segment_blocks),
+        max_classified_b_size_(max_b_size), active_pool_(max_b_size),
+        merged_pool_(max_b_size), space_map_(space_map),
+        thread_cache_(num_threads, max_b_size) {}
 
-  FreeList(std::shared_ptr<SpaceMap> space_map, uint32_t num_threads)
-      : FreeList(FREE_LIST_MAX_BLOCK, num_threads, space_map) {}
+  FreeList(uint64_t num_segment_blocks, uint32_t num_threads,
+           std::shared_ptr<SpaceMap> space_map)
+      : FreeList(FREE_LIST_MAX_BLOCK, num_segment_blocks, num_threads,
+                 space_map) {}
 
   void Push(const SizedSpaceEntry &entry);
 
   bool Get(uint32_t b_size, SizedSpaceEntry *space_entry);
 
-  bool MergeGet(uint32_t b_size, uint64_t segment_blocks,
-                SizedSpaceEntry *space_entry);
+  bool MergeGet(uint32_t b_size, SizedSpaceEntry *space_entry);
 
+  // Move cached free space list to space entry pool to balance usable space
+  // of write threads
+  //
+  // Iterate every backup entry lists of thread caches, and move the list to
+  // active_pool_ if more than kMinMovableEntries in it
   void MoveCachedListToPool();
+
+  // Merge adjacent free spaces into a larger one
+  //
+  // Fetch every free space entry lists from active_pool_, for each entry in the
+  // list, try to merge followed free space with it. Then insert merged entries
+  // into merged_pool_. After merging, move all entry lists from merged_pool_ to
+  // active_pool_ for next run
+  // TODO: set a condition to decide if we need to do merging
+  void MergeFreeSpace();
 
 private:
   // Each write threads cache some freed space entries in active_entries to
@@ -100,42 +170,18 @@ private:
       return false;
     }
     uint64_t size =
-        space_map_->MergeAndUnset(space_entry.offset, max_size, target_size);
+        space_map_->TryMerge(space_entry.offset, max_size, target_size);
     return size;
   }
 
+  const uint64_t num_segment_blocks_;
+  const uint32_t max_classified_b_size_;
   std::shared_ptr<SpaceMap> space_map_;
-  // space_entry_pool_ consists of three level vectors, the first level
-  // indicates different block size, each block size consists of several free
-  // space entry lists (the second level), and each list consists of several
-  // free space entries (the third level).
-  //
-  // For a specific block size, a write thread will move a entry list from the
-  // pool to its thread cache while no usable free space in the cache, or move a
-  // entry list to the pool while too many entries cached.
-  //
-  // Organization of the three level vectors:
-  //
-  // block size (1st level)   entry list (2nd level)   entries (3th level)
-  //     1   -----------------   list1    ------------   entry1
-  //                    |                         |---   entry2
-  //                    |-----   list2    ------------   entry1
-  //                                              |---   entry2
-  //                                              |---   entry3
-  //                              ...
-  //     2   -----------------   list1    ------------   entry1
-  //                    |                         |---   entry2
-  //                    |                         |---   entry3
-  //                    |-----   list2
-  //                              ...
-  //    ...
-  // max_block_size   --------   list1
-  //                    |-----   list2
-  std::vector<std::vector<std::vector<SpaceEntry>>> space_entry_pool_;
   std::set<SizedSpaceEntry, SpaceCmp> large_entries_;
   std::vector<ThreadCache> thread_cache_;
+  SpaceEntryPool active_pool_;
+  SpaceEntryPool merged_pool_;
   SpinMutex large_entries_spin_;
-  std::vector<SpinMutex> spins_;
 };
 
 } // namespace KVDK_NAMESPACE

--- a/engine/pmem_allocator/pmem_allocator.hpp
+++ b/engine/pmem_allocator/pmem_allocator.hpp
@@ -49,7 +49,10 @@ public:
   bool FreeAndFetchSegment(SizedSpaceEntry *segment_space_entry);
 
   // Regularly execute by background thread of KVDK
-  void BackgroundWork() { free_list_->MoveCachedListToPool(); }
+  void BackgroundWork() {
+    free_list_->MoveCachedListToPool();
+    free_list_->MergeFreeSpace();
+  }
 
 private:
   struct ThreadCache {


### PR DESCRIPTION
1. We maintain two free space entry pools in the free list: active_pool_ and merged_pool_. The foreground threads will fetch free space entry lists from both of them. 
2. To merge space, the background thread of kvdk will fetch every free space entry lists from active_pool_, for each entry in the list, try to merge followed free space with it. Then, insert merged entries into merged_pool_.
3. After merging, move all entry lists from merged_pool_ to active_pool_ for next run.

TODO: we may set a condition to decide if we need to do merging, to avoid redundant operations