### PR TITLE
Free PMem space of delete records in background thread

### DIFF
--- a/engine/allocator.hpp
+++ b/engine/allocator.hpp
@@ -12,8 +12,8 @@ namespace KVDK_NAMESPACE {
 struct SpaceEntry {
   uint64_t offset = 0;
   // Allocator specific information
-  // For example, in PMEMAllocator, it indicates timestamp of the data stored in
-  // the space
+  // For example, in PMEMAllocator, it indicates timestamp of data stored in
+  // the space entry, or 0 if it's a padding entry or a freed delete record
   uint64_t info = 0;
 
   SpaceEntry() = default;

--- a/engine/allocator.hpp
+++ b/engine/allocator.hpp
@@ -12,6 +12,8 @@ namespace KVDK_NAMESPACE {
 struct SpaceEntry {
   uint64_t offset = 0;
   // Allocator specific information
+  // For example, in PMEMAllocator, it indicates timestamp of the data stored in
+  // the space
   uint64_t info = 0;
 
   SpaceEntry() = default;

--- a/engine/allocator.hpp
+++ b/engine/allocator.hpp
@@ -11,17 +11,19 @@ namespace KVDK_NAMESPACE {
 // Free pmem blocks
 struct SpaceEntry {
   uint64_t offset = 0;
+  // Allocator specific information
+  uint64_t info = 0;
 
   SpaceEntry() = default;
-  explicit SpaceEntry(uint64_t bo) : offset(bo) {}
+  explicit SpaceEntry(uint64_t bo, uint64_t i) : offset(bo), info(i) {}
 };
 
 struct SizedSpaceEntry {
   SizedSpaceEntry() = default;
-  SizedSpaceEntry(uint64_t offset, uint32_t size)
-      : space_entry(offset), size(size) {}
+  SizedSpaceEntry(uint64_t offset, uint64_t size, uint64_t i)
+      : space_entry(offset, i), size(size) {}
   SpaceEntry space_entry;
-  uint32_t size = 0;
+  uint64_t size = 0;
 };
 
 class Allocator {

--- a/engine/hash_table.hpp
+++ b/engine/hash_table.hpp
@@ -16,16 +16,16 @@
 namespace KVDK_NAMESPACE {
 enum class HashEntryStatus : uint16_t {
   Normal = 1,
-  // A deletion type entry of a key which has no older data entry existing, so
-  // it can be safely used by a new key
+  // A hash entry of a delete record which has no older version data of the same
+  // key exsiting on PMem, so the delete record can be safely freed after the
+  // hash entry updated by a new key
   Clean,
   // New created hash entry for inserting a new key
   Initializing,
-  // A entry being updated by the same key, or a CLEAN entry being used by a new
-  // key
+  // A entry being updated by the same key, or a CLEAN hash entry being updated
+  // by a new key
   Updating,
-  // A NORMAL deletion type entry that is reusing by a new key
-  // TODO: handle recycle of delete record of reused hash entries in runtime
+  // A Normal hash entry of a delete record that is reusing by a new key
   BeingReused,
 };
 

--- a/engine/kv_engine.cpp
+++ b/engine/kv_engine.cpp
@@ -67,7 +67,7 @@ Status KVEngine::Open(const std::string &name, Engine **engine_ptr,
 
 void KVEngine::BackgroundWork() {
   while (!closing_) {
-    sleep(configs_.background_work_interval);
+    usleep(configs_.background_work_interval * 1000000);
     pmem_allocator_->BackgroundWork();
   }
 }

--- a/engine/kv_engine.cpp
+++ b/engine/kv_engine.cpp
@@ -168,7 +168,8 @@ Status KVEngine::RestoreData(uint64_t thread_id) {
         recovering_data_entry->type == PADDING) {
       pmem_allocator_->Free(
           SizedSpaceEntry(pmem_allocator_->addr2offset(pmem_data_entry),
-                          recovering_data_entry->header.b_size));
+                          recovering_data_entry->header.b_size,
+                          recovering_data_entry->timestamp));
       if (recovering_data_entry->header.checksum != checksum) {
         pmem_data_entry->type = PADDING;
         pmem_persist(&pmem_data_entry->type, sizeof(DATA_ENTRY_TYPE));
@@ -258,7 +259,8 @@ Status KVEngine::RestoreData(uint64_t thread_id) {
             offset = pmem_allocator_->addr2offset(node->data_entry);
             node->data_entry = (DLDataEntry *)pmem_data_entry;
             pmem_allocator_->Free(
-                SizedSpaceEntry(offset, existing_data_entry->header.b_size));
+                SizedSpaceEntry(offset, existing_data_entry->header.b_size,
+                                existing_data_entry->timestamp));
             entry_base->header.type = recovering_data_entry->type;
           }
         } else {
@@ -269,7 +271,8 @@ Status KVEngine::RestoreData(uint64_t thread_id) {
                               offset);
           if (free_space) {
             pmem_allocator_->Free(SizedSpaceEntry(
-                hash_entry.offset, existing_data_entry->header.b_size));
+                hash_entry.offset, existing_data_entry->header.b_size,
+                existing_data_entry->timestamp));
           }
         }
         // If a delete record is the only existing data entry of a key, then we
@@ -281,7 +284,8 @@ Status KVEngine::RestoreData(uint64_t thread_id) {
       } else {
         pmem_allocator_->Free(
             SizedSpaceEntry(pmem_allocator_->addr2offset(pmem_data_entry),
-                            recovering_data_entry->header.b_size));
+                            recovering_data_entry->header.b_size,
+                            recovering_data_entry->timestamp));
       }
     }
     segment_space.size -= recovering_data_entry->header.b_size;
@@ -353,7 +357,8 @@ KVEngine::SearchOrInitPersistentList(const pmem::obj::string_view collection,
         hash_table_->Insert(hint, entry_base, header_type, (uint64_t)(*list));
         if (free_space) {
           pmem_allocator_->Free(SizedSpaceEntry(
-              hash_entry.offset, existing_data_entry.header.b_size));
+              hash_entry.offset, existing_data_entry.header.b_size,
+              existing_data_entry.timestamp));
         }
         return Status::Ok;
       }
@@ -682,13 +687,13 @@ Status KVEngine::SSetImpl(Skiplist *skiplist,
       bool free_space = entry_base->header.status == HashEntryStatus::Updating;
       hash_table_->Insert(hint, entry_base, dt, (uint64_t)node);
       if (free_space) {
-        pmem_allocator_->Free(
-            SizedSpaceEntry(hash_entry.offset, data_entry.header.b_size));
+        pmem_allocator_->Free(SizedSpaceEntry(
+            hash_entry.offset, data_entry.header.b_size, data_entry.timestamp));
       }
     } else {
       entry_base->header.type = dt;
-      pmem_allocator_->Free(
-          SizedSpaceEntry(old_entry_offset, data_entry.header.b_size));
+      pmem_allocator_->Free(SizedSpaceEntry(
+          old_entry_offset, data_entry.header.b_size, data_entry.timestamp));
     }
 
     for (auto &m : spins) {
@@ -936,8 +941,8 @@ Status KVEngine::HashSetImpl(const Slice &key, const Slice &value, uint16_t dt,
     hash_table_->Insert(hint, entry_base, dt,
                         sized_space_entry.space_entry.offset);
     if (free_space) {
-      pmem_allocator_->Free(
-          SizedSpaceEntry(hash_entry.offset, data_entry.header.b_size));
+      pmem_allocator_->Free(SizedSpaceEntry(
+          hash_entry.offset, data_entry.header.b_size, data_entry.timestamp));
     }
   }
 

--- a/engine/pmem_allocator/free_list.cpp
+++ b/engine/pmem_allocator/free_list.cpp
@@ -146,6 +146,12 @@ void Freelist::MergeFreeSpaceInPool() {
   }
 }
 
+void Freelist::DelayPush(const SizedSpaceEntry &entry) {
+  auto &thread_cache = thread_cache_[write_thread.id];
+  std::lock_guard<SpinMutex> lg(thread_cache.spins.back());
+  thread_cache.delay_free_entries.emplace_back(entry);
+}
+
 void Freelist::Push(const SizedSpaceEntry &entry) {
   space_map_->Set(entry.space_entry.offset, entry.size);
   auto &thread_cache = thread_cache_[write_thread.id];

--- a/engine/pmem_allocator/free_list.cpp
+++ b/engine/pmem_allocator/free_list.cpp
@@ -9,7 +9,6 @@
 
 namespace KVDK_NAMESPACE {
 
-const uint32_t kMaxCacheEntries = 16;
 const uint32_t kMinMovableEntries = 8;
 
 void SpaceMap::Set(uint64_t offset, uint64_t length) {

--- a/engine/pmem_allocator/free_list.cpp
+++ b/engine/pmem_allocator/free_list.cpp
@@ -120,7 +120,8 @@ void Freelist::MergeFreeSpaceInPool() {
         // large space entries
         if (merged_size >= merged_entry_list.size()) {
           std::lock_guard<SpinMutex> lg(large_entries_spin_);
-          large_entries_.insert(SizedSpaceEntry(se.offset, merged_size));
+          large_entries_.insert(
+              SizedSpaceEntry(se.offset, merged_size, se.info));
           // move merged entries to merging pool to avoid redundant merging
         } else if (merged_size > 0) {
           merged_entry_list[merged_size].emplace_back(std::move(se));

--- a/engine/pmem_allocator/free_list.cpp
+++ b/engine/pmem_allocator/free_list.cpp
@@ -115,6 +115,8 @@ void Freelist::HandleDelayFreedEntries() {
     for (auto &&entry : list) {
       if (entry.space_entry.info < min_timestamp_of_entries_ ||
           min_timestamp_of_entries_ == 0) {
+        // A freed delete record is same as a padding entry so we don't need ts
+        entry.space_entry.info = 0;
         if (entry.size < max_classified_b_size_) {
           merged_entry_list[entry.size].emplace_back(entry.space_entry);
           if (merged_entry_list[entry.size].size() >= kMinMovableEntries) {

--- a/engine/pmem_allocator/free_list.hpp
+++ b/engine/pmem_allocator/free_list.hpp
@@ -42,12 +42,14 @@ private:
   struct Token {
   public:
     Token(bool is_start, uint8_t size)
-        : token_(size | (is_start ? (1 << 7) : 0)) {}
-    uint8_t Size() { return token_ & ((1 << 7) - 1); }
+        : token_(size | (is_start ? (1 << 7) : 0)) {
+      assert(size <= INT8_MAX);
+    }
+    uint8_t Size() { return token_ & INT8_MAX; }
     void Clear() { token_ = 0; }
     bool Empty() { return token_ == 0; }
     bool IsStart() { return token_ & (1 << 7); }
-    void UnStart() { token_ &= ((1 << 7) - 1); }
+    void UnStart() { token_ &= INT8_MAX; }
 
   private:
     uint8_t token_;

--- a/engine/pmem_allocator/free_list.hpp
+++ b/engine/pmem_allocator/free_list.hpp
@@ -120,19 +120,18 @@ private:
 class Freelist {
 public:
   Freelist(uint32_t max_classified_b_size, uint64_t num_segment_blocks,
-           uint32_t num_threads, std::shared_ptr<SpaceMap> space_map,
-           PMEMAllocator *allocator)
+           uint32_t num_threads, std::shared_ptr<SpaceMap> space_map)
       : num_segment_blocks_(num_segment_blocks),
         max_classified_b_size_(max_classified_b_size),
-        pmem_allocator_(allocator), active_pool_(max_classified_b_size),
+        active_pool_(max_classified_b_size),
         merged_pool_(max_classified_b_size), space_map_(space_map),
         thread_cache_(num_threads, max_classified_b_size),
-        min_timestamp_of_entries_(UINT64_MAX) {}
+        min_timestamp_of_entries_(0) {}
 
   Freelist(uint64_t num_segment_blocks, uint32_t num_threads,
-           std::shared_ptr<SpaceMap> space_map, PMEMAllocator *allocator)
+           std::shared_ptr<SpaceMap> space_map)
       : Freelist(kFreelistMaxClassifiedBlockSize, num_segment_blocks,
-                 num_threads, space_map, allocator) {}
+                 num_threads, space_map) {}
 
   void Push(const SizedSpaceEntry &entry);
 
@@ -204,7 +203,6 @@ private:
 
   const uint64_t num_segment_blocks_;
   const uint32_t max_classified_b_size_;
-  PMEMAllocator *pmem_allocator_;
   std::shared_ptr<SpaceMap> space_map_;
   std::vector<ThreadCache> thread_cache_;
   SpaceEntryPool active_pool_;

--- a/engine/pmem_allocator/free_list.hpp
+++ b/engine/pmem_allocator/free_list.hpp
@@ -120,18 +120,19 @@ private:
 class Freelist {
 public:
   Freelist(uint32_t max_classified_b_size, uint64_t num_segment_blocks,
-           uint32_t num_threads, std::shared_ptr<SpaceMap> space_map)
+           uint32_t num_threads, std::shared_ptr<SpaceMap> space_map,
+           PMEMAllocator *allocator)
       : num_segment_blocks_(num_segment_blocks),
         max_classified_b_size_(max_classified_b_size),
         active_pool_(max_classified_b_size),
         merged_pool_(max_classified_b_size), space_map_(space_map),
         thread_cache_(num_threads, max_classified_b_size),
-        min_timestamp_of_entries_(0) {}
+        min_timestamp_of_entries_(0), pmem_allocator_(allocator) {}
 
   Freelist(uint64_t num_segment_blocks, uint32_t num_threads,
-           std::shared_ptr<SpaceMap> space_map)
+           std::shared_ptr<SpaceMap> space_map, PMEMAllocator *allocator)
       : Freelist(kFreelistMaxClassifiedBlockSize, num_segment_blocks,
-                 num_threads, space_map) {}
+                 num_threads, space_map, allocator) {}
 
   void Push(const SizedSpaceEntry &entry);
 
@@ -212,6 +213,7 @@ private:
   std::vector<std::vector<SizedSpaceEntry>> delayed_free_entries_;
   SpinMutex large_entries_spin_;
   uint64_t min_timestamp_of_entries_;
+  PMEMAllocator *pmem_allocator_;
 };
 
 } // namespace KVDK_NAMESPACE

--- a/engine/pmem_allocator/free_list.hpp
+++ b/engine/pmem_allocator/free_list.hpp
@@ -173,12 +173,10 @@ private:
   struct alignas(64) ThreadCache {
     ThreadCache(uint32_t max_classified_b_size)
         : active_entries(max_classified_b_size),
-          backup_entries(max_classified_b_size),
           spins(max_classified_b_size +
                 1 /* the last lock is for delayed free entries */) {}
 
     std::vector<std::vector<SpaceEntry>> active_entries;
-    std::vector<std::vector<SpaceEntry>> backup_entries;
     // These entries can be add to free list only if no entries with smaller
     // timestamp exist
     std::vector<SizedSpaceEntry> delayed_free_entries;

--- a/engine/pmem_allocator/pmem_allocator.cpp
+++ b/engine/pmem_allocator/pmem_allocator.cpp
@@ -4,7 +4,6 @@
 
 #include <thread>
 
-#include "../data_entry.hpp"
 #include "../thread_manager.hpp"
 #include "libpmem.h"
 #include "pmem_allocator.hpp"
@@ -72,9 +71,9 @@ PMEMAllocator::PMEMAllocator(const std::string &pmem_file, uint64_t pmem_space,
                        pmem_file.c_str(), pmem_size_, pmem_space);
   }
   max_block_offset_ = pmem_size_ / block_size_;
-  free_list_ =
-      std::make_shared<Freelist>(num_segment_blocks, num_write_threads,
-                                 std::make_shared<SpaceMap>(max_block_offset_));
+  free_list_ = std::make_shared<Freelist>(
+      num_segment_blocks, num_write_threads,
+      std::make_shared<SpaceMap>(max_block_offset_), this);
   GlobalLogger.Log("Map pmem space done\n");
   init_data_size_2_block_size();
 }

--- a/engine/pmem_allocator/pmem_allocator.cpp
+++ b/engine/pmem_allocator/pmem_allocator.cpp
@@ -15,6 +15,10 @@ void PMEMAllocator::Free(const SizedSpaceEntry &entry) {
   free_list_->Push(entry);
 }
 
+void PMEMAllocator::DelayFree(const SizedSpaceEntry &entry) {
+  free_list_->DelayPush(entry);
+}
+
 void PMEMAllocator::PopulateSpace() {
   GlobalLogger.Log("Populating PMem space ...\n");
   std::vector<std::thread> ths;

--- a/engine/pmem_allocator/pmem_allocator.cpp
+++ b/engine/pmem_allocator/pmem_allocator.cpp
@@ -71,9 +71,9 @@ PMEMAllocator::PMEMAllocator(const std::string &pmem_file, uint64_t pmem_space,
                        pmem_file.c_str(), pmem_size_, pmem_space);
   }
   max_block_offset_ = pmem_size_ / block_size_;
-  free_list_ =
-      std::make_shared<Freelist>(num_segment_blocks, num_write_threads,
-                                 std::make_shared<SpaceMap>(max_block_offset_));
+  free_list_ = std::make_shared<Freelist>(
+      num_segment_blocks, num_write_threads,
+      std::make_shared<SpaceMap>(max_block_offset_), this);
   GlobalLogger.Log("Map pmem space done\n");
   init_data_size_2_block_size();
 }

--- a/engine/pmem_allocator/pmem_allocator.cpp
+++ b/engine/pmem_allocator/pmem_allocator.cpp
@@ -47,8 +47,8 @@ PMEMAllocator::~PMEMAllocator() { pmem_unmap(pmem_, pmem_size_); }
 PMEMAllocator::PMEMAllocator(const std::string &pmem_file, uint64_t pmem_space,
                              uint64_t num_segment_blocks, uint32_t block_size,
                              uint32_t num_write_threads)
-    : num_segment_blocks_(num_segment_blocks), block_size_(block_size),
-      offset_head_(0) {
+    : thread_cache_(num_write_threads), num_segment_blocks_(num_segment_blocks),
+      block_size_(block_size), offset_head_(0) {
   int is_pmem;
   GlobalLogger.Log("Initializing PMem size %lu in file %s\n", pmem_space,
                    pmem_file.c_str());
@@ -72,17 +72,13 @@ PMEMAllocator::PMEMAllocator(const std::string &pmem_file, uint64_t pmem_space,
       std::make_shared<Freelist>(num_segment_blocks, num_write_threads,
                                  std::make_shared<SpaceMap>(max_block_offset_));
   GlobalLogger.Log("Map pmem space done\n");
-  thread_cache_.resize(num_write_threads);
   init_data_size_2_block_size();
 }
 
 bool PMEMAllocator::FreeAndFetchSegment(SizedSpaceEntry *segment_space_entry) {
   assert(segment_space_entry);
   if (segment_space_entry->size == num_segment_blocks_) {
-    thread_cache_[write_thread.id].segment_offset =
-        segment_space_entry->space_entry.offset;
-    thread_cache_[write_thread.id].segment_usable_blocks =
-        segment_space_entry->size;
+    thread_cache_[write_thread.id].segment_entry = *segment_space_entry;
     return false;
   }
 
@@ -99,6 +95,25 @@ bool PMEMAllocator::FreeAndFetchSegment(SizedSpaceEntry *segment_space_entry) {
   return true;
 }
 
+void PMEMAllocator::FetchSegmentSpace(SizedSpaceEntry *segment_entry) {
+  uint64_t offset;
+  while (1) {
+    offset = offset_head_.load(std::memory_order_relaxed);
+    if (offset < max_block_offset_) {
+      if (offset_head_.compare_exchange_strong(offset,
+                                               offset + num_segment_blocks_)) {
+        Free(*segment_entry);
+        *segment_entry = SizedSpaceEntry(
+            offset, std::min(num_segment_blocks_, max_block_offset_ - offset),
+            0);
+        break;
+      }
+      continue;
+    }
+    break;
+  }
+}
+
 SizedSpaceEntry PMEMAllocator::Allocate(unsigned long size) {
   SizedSpaceEntry space_entry;
   auto b_size = size_2_block_size(size);
@@ -108,7 +123,7 @@ SizedSpaceEntry PMEMAllocator::Allocate(unsigned long size) {
     return space_entry;
   }
   auto &thread_cache = thread_cache_[write_thread.id];
-  bool full_segment = thread_cache.segment_usable_blocks < b_size;
+  bool full_segment = thread_cache.segment_entry.size < b_size;
   while (full_segment) {
     while (1) {
       // allocate from free list space
@@ -145,19 +160,9 @@ SizedSpaceEntry PMEMAllocator::Allocate(unsigned long size) {
 
     // allocate a new segment, add remainning space of the old one
     // to the free list
-    if (thread_cache.segment_usable_blocks > 0) {
-      Free(SizedSpaceEntry(thread_cache.segment_offset,
-                           thread_cache.segment_usable_blocks));
-    }
+    FetchSegmentSpace(&thread_cache.segment_entry);
 
-    thread_cache.segment_offset =
-        offset_head_.fetch_add(num_segment_blocks_, std::memory_order_relaxed);
-    thread_cache.segment_usable_blocks =
-        thread_cache.segment_offset >= max_block_offset_
-            ? 0
-            : std::min(num_segment_blocks_,
-                       max_block_offset_ - thread_cache.segment_offset);
-    if (thread_cache.segment_offset >= max_block_offset_ - b_size) {
+    if (thread_cache.segment_entry.size < b_size) {
       if (free_list_->MergeGet(b_size, &thread_cache.free_entry)) {
         continue;
       }
@@ -166,10 +171,10 @@ SizedSpaceEntry PMEMAllocator::Allocate(unsigned long size) {
     }
     full_segment = false;
   }
+  space_entry = thread_cache.segment_entry;
   space_entry.size = b_size;
-  space_entry.space_entry.offset = thread_cache.segment_offset;
-  thread_cache.segment_offset += space_entry.size;
-  thread_cache.segment_usable_blocks -= space_entry.size;
+  thread_cache.segment_entry.space_entry.offset += space_entry.size;
+  thread_cache.segment_entry.size -= space_entry.size;
   return space_entry;
 }
 

--- a/engine/pmem_allocator/pmem_allocator.cpp
+++ b/engine/pmem_allocator/pmem_allocator.cpp
@@ -71,9 +71,9 @@ PMEMAllocator::PMEMAllocator(const std::string &pmem_file, uint64_t pmem_space,
                        pmem_file.c_str(), pmem_size_, pmem_space);
   }
   max_block_offset_ = pmem_size_ / block_size_;
-  free_list_ = std::make_shared<Freelist>(
-      num_segment_blocks, num_write_threads,
-      std::make_shared<SpaceMap>(max_block_offset_), this);
+  free_list_ =
+      std::make_shared<Freelist>(num_segment_blocks, num_write_threads,
+                                 std::make_shared<SpaceMap>(max_block_offset_));
   GlobalLogger.Log("Map pmem space done\n");
   init_data_size_2_block_size();
 }

--- a/engine/pmem_allocator/pmem_allocator.hpp
+++ b/engine/pmem_allocator/pmem_allocator.hpp
@@ -36,6 +36,9 @@ public:
 
   void Free(const SizedSpaceEntry &entry) override;
 
+  // These entries hold a delete record of some key, it can be safely freed only
+  // if no free space entry of smaller timestamp existing in the free list, so
+  // just record these entries
   void DelayFree(const SizedSpaceEntry &entry);
 
   // transfer block_offset of allocated space to address

--- a/engine/pmem_allocator/pmem_allocator.hpp
+++ b/engine/pmem_allocator/pmem_allocator.hpp
@@ -9,6 +9,7 @@
 #include <vector>
 
 #include "../allocator.hpp"
+#include "../data_entry.hpp"
 #include "../structures.hpp"
 #include "free_list.hpp"
 #include "kvdk/namespace.hpp"
@@ -64,10 +65,7 @@ public:
   bool FreeAndFetchSegment(SizedSpaceEntry *segment_space_entry);
 
   // Regularly execute by background thread of KVDK
-  void BackgroundWork() {
-    free_list_->MoveCachedListToPool();
-    free_list_->MergeFreeSpaceInPool();
-  }
+  void BackgroundWork() { free_list_->OrganizeFreeSpace(); }
 
 private:
   // Write threads cache a dedicated PMem segment and a free space to

--- a/engine/pmem_allocator/pmem_allocator.hpp
+++ b/engine/pmem_allocator/pmem_allocator.hpp
@@ -35,6 +35,8 @@ public:
 
   void Free(const SizedSpaceEntry &entry) override;
 
+  void DelayFree(const SizedSpaceEntry &entry);
+
   // transfer block_offset of allocated space to address
   inline char *offset2addr(uint64_t block_offset) {
     if (block_offset == kNullPmemOffset) {

--- a/include/kvdk/configs.hpp
+++ b/include/kvdk/configs.hpp
@@ -69,7 +69,7 @@ struct Configs {
   // In KVDK, a background thread will regularly organize PMem free space,
   // frequent execution will lead to better space utilization, but more
   // influence to foreground performance
-  uint64_t background_work_interval = 5;
+  double background_work_interval = 5;
 };
 
 } // namespace KVDK_NAMESPACE


### PR DESCRIPTION
As we need delete records to indicate deleted data during engine recovery, we can not simply free PMem space of delete records in run time. To handle this problem, in this patch:

While reuse a hash entry of a delete record, cache this record in a dram list
Store timestamp of data of space entries in the free list
In background thread, calculate minimal timestamp of free data entries during iterating all free space entries, then check cached delete records, if timestamp of a delete record is smaller than minimal timestamp, that means no valid data of the same key existing, so we can free this delete record safely