### PR TITLE
reorganize test.cpp

### DIFF
--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -10,9 +10,20 @@
 #include <string>
 #include <thread>
 #include <vector>
+#include <functional>
 
 using namespace KVDK_NAMESPACE;
 static const uint64_t str_pool_length = 1024000;
+
+static void LaunchNThreads(int n_thread, std::function<void(int tid)> func, int id_start=0)
+{
+    std::vector<std::thread> ts;
+    for (int i = id_start; i < id_start + n_thread; i++) {
+      ts.emplace_back(std::thread(func, i));
+    }
+    for (auto &t : ts)
+      t.join();
+}
 
 class EngineBasicTest : public testing::Test {
 protected:
@@ -54,7 +65,7 @@ TEST_F(EngineBasicTest, TestBasicHashOperations) {
   configs.max_write_threads = num_threads;
   ASSERT_EQ(Engine::Open(db_path.c_str(), &engine, configs, stdout),
             Status::Ok);
-  auto ops = [&](int id) {
+  auto GetSetDelete = [&](int id) {
     std::string k1, k2, v1, v2;
     std::string got_v1, got_v2;
     int cnt = 1000;
@@ -66,6 +77,7 @@ TEST_F(EngineBasicTest, TestBasicHashOperations) {
       AssignData(v1, v1_len);
       AssignData(v2, v2_len);
 
+      // Test Empty key
       if (id == 0) {
         std::string k0{""};
         ASSERT_EQ(engine->Set(k0, v1), Status::Ok);
@@ -75,32 +87,29 @@ TEST_F(EngineBasicTest, TestBasicHashOperations) {
         ASSERT_EQ(engine->Get(k0, &got_v1), Status::NotFound);
       }
 
+      // Set
       ASSERT_EQ(engine->Set(k1, v1), Status::Ok);
-
       ASSERT_EQ(engine->Set(k2, v2), Status::Ok);
-      ASSERT_EQ(engine->Get(k1, &got_v1), Status::Ok);
 
-      ASSERT_EQ(engine->Get(k2, &got_v2), Status::Ok);
+      // Get
+      ASSERT_EQ(engine->Get(k1, &got_v1), Status::Ok);
       ASSERT_EQ(v1, got_v1);
+      ASSERT_EQ(engine->Get(k2, &got_v2), Status::Ok);
       ASSERT_EQ(v2, got_v2);
 
+      // Delete
       ASSERT_EQ(engine->Delete(k1), Status::Ok);
-
       ASSERT_EQ(engine->Get(k1, &got_v1), Status::NotFound);
+
+      // Update
       AssignData(v1, v1_len);
       ASSERT_EQ(engine->Set(k1, v1), Status::Ok);
-
       ASSERT_EQ(engine->Get(k1, &got_v1), Status::Ok);
       ASSERT_EQ(got_v1, v1);
     }
   };
 
-  std::vector<std::thread> ts;
-  for (int i = 0; i < num_threads; i++) {
-    ts.emplace_back(std::thread(ops, i));
-  }
-  for (auto &t : ts)
-    t.join();
+  LaunchNThreads(num_threads, GetSetDelete);
   delete engine;
 }
 
@@ -111,10 +120,11 @@ TEST_F(EngineBasicTest, TestBatchWrite) {
             Status::Ok);
   int batch_num = 10;
   int count = 500;
-  auto ops = [&](int id) {
+
+  auto BatchWrite = [&](int id) {
     std::string v;
     WriteBatch batch;
-    int cnt = count;
+    int cnt = 500;
     while (cnt--) {
       for (size_t i = 0; i < batch_num; i++) {
         auto key =
@@ -139,17 +149,13 @@ TEST_F(EngineBasicTest, TestBatchWrite) {
     }
   };
 
-  std::vector<std::thread> ts;
-  for (int i = 1; i <= num_threads; i++) {
-    ts.emplace_back(std::thread(ops, i));
-  }
-  for (auto &t : ts)
-    t.join();
+  LaunchNThreads(num_threads, BatchWrite);
+
   delete engine;
 
   ASSERT_EQ(Engine::Open(db_path.c_str(), &engine, configs, stdout),
             Status::Ok);
-  for (int id = 1; id <= num_threads; id++) {
+  for (int id = 0; id < num_threads; id++) {
     std::string v;
     int cnt = count;
     while (cnt--) {
@@ -218,7 +224,7 @@ TEST_F(EngineBasicTest, TestLocalSortedCollection) {
             Status::Ok);
   std::vector<int> n_local_entries(num_threads, 0);
 
-  auto SetGetDelete = [&](int id) {
+  auto SSetSGetSDelete = [&](int id) {
     std::string thread_local_skiplist("t_skiplist" + std::to_string(id));
     std::string k1, k2, v1, v2;
     std::string got_v1, got_v2;
@@ -277,6 +283,7 @@ TEST_F(EngineBasicTest, TestLocalSortedCollection) {
                 Status::NotFound);
     }
   };
+  
   auto IteratingThrough = [&](int id) {
     std::string thread_local_skiplist("t_skiplist" + std::to_string(id));
     std::vector<int> n_entries(num_threads, 0);
@@ -300,23 +307,8 @@ TEST_F(EngineBasicTest, TestLocalSortedCollection) {
     n_entries[id] = 0;
   };
 
-  {
-    std::vector<std::thread> ts;
-    for (int i = 0; i < num_threads; i++) {
-      ts.emplace_back(std::thread(SetGetDelete, i));
-    }
-    for (auto &t : ts)
-      t.join();
-  }
-
-  {
-    std::vector<std::thread> ts;
-    for (int i = 0; i < num_threads; i++) {
-      ts.emplace_back(std::thread(IteratingThrough, i));
-    }
-    for (auto &t : ts)
-      t.join();
-  }
+  LaunchNThreads(num_threads, SSetSGetSDelete);
+  LaunchNThreads(num_threads, IteratingThrough);
 
   delete engine;
 }
@@ -329,7 +321,7 @@ TEST_F(EngineBasicTest, TestGlobalSortedCollection) {
             Status::Ok);
   std::atomic<int> n_global_entries{0};
 
-  auto SetGetDelete = [&](int id) {
+  auto SSetSGetSDelete = [&](int id) {
     std::string k1, k2, v1, v2;
     std::string got_v1, got_v2;
 
@@ -385,6 +377,7 @@ TEST_F(EngineBasicTest, TestGlobalSortedCollection) {
       ASSERT_EQ(engine->SGet(global_skiplist, k1, &got_v1), Status::NotFound);
     }
   };
+  
   auto IteratingThrough = [&](int id) {
     std::vector<int> n_entries(num_threads, 0);
 
@@ -419,32 +412,9 @@ TEST_F(EngineBasicTest, TestGlobalSortedCollection) {
       ASSERT_EQ(t_iter2->Key(), std::to_string(id) + "k2");
   };
 
-  {
-    std::vector<std::thread> ts;
-    for (int i = 0; i < num_threads; i++) {
-      ts.emplace_back(std::thread(SetGetDelete, i));
-    }
-    for (auto &t : ts)
-      t.join();
-  }
-
-  {
-    std::vector<std::thread> ts;
-    for (int i = 0; i < num_threads; i++) {
-      ts.emplace_back(std::thread(IteratingThrough, i));
-    }
-    for (auto &t : ts)
-      t.join();
-  }
-
-  {
-      std::vector<std::thread> ts;
-      for (int i = 0; i < num_threads; i++) {
-          ts.emplace_back(std::thread(SeekToDeleted, i));
-      }
-      for (auto& t : ts)
-          t.join();
-  }
+  LaunchNThreads(num_threads, SSetSGetSDelete);
+  LaunchNThreads(num_threads, IteratingThrough);
+  LaunchNThreads(num_threads, SeekToDeleted);
 
   delete engine;
 }
@@ -487,7 +457,7 @@ TEST_F(EngineBasicTest, TestRestore) {
             Status::Ok);
   // insert and delete some keys, then re-insert some deleted keys
   int count = 1000;
-  auto ops = [&](int id) {
+  auto SetupEngine = [&](int id) {
     std::string a(id, 'a');
     std::string v;
     for (int i = 1; i <= count; i++) {
@@ -509,18 +479,15 @@ TEST_F(EngineBasicTest, TestRestore) {
       }
     }
   };
-  std::vector<std::thread> ts;
-  for (int i = 1; i <= num_threads; i++) {
-    ts.emplace_back(std::thread(ops, i));
-  }
-  for (auto &t : ts)
-    t.join();
+
+  LaunchNThreads(num_threads, SetupEngine);
+
   delete engine;
 
   // reopen and restore engine and try gets
   ASSERT_EQ(Engine::Open(db_path.c_str(), &engine, configs, stdout),
             Status::Ok);
-  for (int i = 1; i <= num_threads; i++) {
+  for (int i = 0; i < num_threads; i++) {
     std::string a(i, 'a');
     std::string v;
     for (int j = 1; j <= count; j++) {
@@ -564,12 +531,9 @@ TEST_F(EngineBasicTest, TestSortedRestore) {
       ASSERT_EQ(v, value + std::to_string(id));
     }
   };
-  std::vector<std::thread> ts;
-  for (int i = 1; i <= num_threads; i++) {
-    ts.emplace_back(std::thread(ops, i));
-  }
-  for (auto &t : ts)
-    t.join();
+
+  LaunchNThreads(num_threads, ops, 1);
+
   delete engine;
 
   // reopen and restore engine and try gets

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -541,8 +541,8 @@ TEST_F(EngineBasicTest, TestSortedRestore) {
     std::string v;
     std::string t_skiplist(thread_skiplist + std::to_string(id));
     for (int i = 1; i <= count; i++) {
-      auto key = a + std::to_string(id * i);
-      auto value = std::to_string(id * i);
+      auto key = a + std::to_string(i);
+      auto value = std::to_string(i);
       ASSERT_EQ(engine->SSet(overall_skiplist, key, value), Status::Ok);
       ASSERT_EQ(engine->SSet(t_skiplist, key, value + std::to_string(id)),
                 Status::Ok);
@@ -553,19 +553,20 @@ TEST_F(EngineBasicTest, TestSortedRestore) {
     }
   };
 
-  LaunchNThreads(num_threads, SetupEngine, 1);
+  LaunchNThreads(num_threads, SetupEngine);
 
   delete engine;
 
   // reopen and restore engine and try gets
   ASSERT_EQ(Engine::Open(db_path.c_str(), &engine, configs, stdout),
             Status::Ok);
-  for (int i = 1; i <= num_threads; i++) {
+  for (int i = 0; i < num_threads; i++) {
     std::string t_skiplist(thread_skiplist + std::to_string(i));
     std::string a(i, 'a');
     std::string v;
     for (int j = 1; j <= count; j++) {
-      auto key = a + std::to_string(i * j), value = std::to_string(i * j);
+      auto key = a + std::to_string(j);
+      auto value = std::to_string(j);
       Status s = engine->SGet(overall_skiplist, key, &v);
       ASSERT_EQ(s, Status::Ok);
       ASSERT_EQ(v, value);

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -7,22 +7,22 @@
 #include "kvdk/namespace.hpp"
 #include "test_util.h"
 #include "gtest/gtest.h"
+#include <functional>
 #include <string>
 #include <thread>
 #include <vector>
-#include <functional>
 
 using namespace KVDK_NAMESPACE;
 static const uint64_t str_pool_length = 1024000;
 
-static void LaunchNThreads(int n_thread, std::function<void(int tid)> func, int id_start=0)
-{
-    std::vector<std::thread> ts;
-    for (int i = id_start; i < id_start + n_thread; i++) {
-      ts.emplace_back(std::thread(func, i));
-    }
-    for (auto &t : ts)
-      t.join();
+static void LaunchNThreads(int n_thread, std::function<void(int tid)> func,
+                           int id_start = 0) {
+  std::vector<std::thread> ts;
+  for (int i = id_start; i < id_start + n_thread; i++) {
+    ts.emplace_back(std::thread(func, i));
+  }
+  for (auto &t : ts)
+    t.join();
 }
 
 class EngineBasicTest : public testing::Test {
@@ -283,7 +283,7 @@ TEST_F(EngineBasicTest, TestLocalSortedCollection) {
                 Status::NotFound);
     }
   };
-  
+
   auto IteratingThrough = [&](int id) {
     std::string thread_local_skiplist("t_skiplist" + std::to_string(id));
     std::vector<int> n_entries(num_threads, 0);
@@ -377,7 +377,7 @@ TEST_F(EngineBasicTest, TestGlobalSortedCollection) {
       ASSERT_EQ(engine->SGet(global_skiplist, k1, &got_v1), Status::NotFound);
     }
   };
-  
+
   auto IteratingThrough = [&](int id) {
     std::vector<int> n_entries(num_threads, 0);
 
@@ -401,15 +401,15 @@ TEST_F(EngineBasicTest, TestGlobalSortedCollection) {
   };
 
   auto SeekToDeleted = [&](int id) {
-      auto t_iter2 = engine->NewSortedIterator(global_skiplist);
-      ASSERT_TRUE(t_iter2 != nullptr);
-      // First deleted key
-      t_iter2->Seek(std::to_string(id) + "k1");
-      ASSERT_TRUE(t_iter2->Valid());
-      // First valid key
-      t_iter2->Seek(std::to_string(id) + "k2");
-      ASSERT_TRUE(t_iter2->Valid());
-      ASSERT_EQ(t_iter2->Key(), std::to_string(id) + "k2");
+    auto t_iter2 = engine->NewSortedIterator(global_skiplist);
+    ASSERT_TRUE(t_iter2 != nullptr);
+    // First deleted key
+    t_iter2->Seek(std::to_string(id) + "k1");
+    ASSERT_TRUE(t_iter2->Valid());
+    // First valid key
+    t_iter2->Seek(std::to_string(id) + "k2");
+    ASSERT_TRUE(t_iter2->Valid());
+    ASSERT_EQ(t_iter2->Key(), std::to_string(id) + "k2");
   };
 
   LaunchNThreads(num_threads, SSetSGetSDelete);

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -132,7 +132,7 @@ TEST_F(EngineBasicTest, TestBasicHashOperations) {
     }
   };
 
-  LaunchNThreads(num_threads, GetSetDelete);
+  LaunchNThreads(num_threads, SetGetDelete);
   delete engine;
 }
 
@@ -171,7 +171,7 @@ TEST_F(EngineBasicTest, TestBatchWrite) {
     }
   };
 
-  LaunchNThreads(num_threads, BatchWrite);
+  LaunchNThreads(num_threads, BatchSetDelete);
 
   delete engine;
 
@@ -354,7 +354,7 @@ TEST_F(EngineBasicTest, TestGlobalSortedCollection) {
   ASSERT_EQ(engine->SGet(global_skiplist, key, &got_val), Status::NotFound);
   engine->ReleaseWriteThread();
 
-  auto SetGetDelete = [&](int id) {
+  auto SSetSGetSDelete = [&](int id) {
     std::string k1, k2, v1, v2;
     std::string got_v1, got_v2;
 
@@ -536,7 +536,7 @@ TEST_F(EngineBasicTest, TestSortedRestore) {
   int count = 100;
   std::string overall_skiplist = "skiplist";
   std::string thread_skiplist = "t_skiplist";
-  auto SetGet = [&](int id) {
+  auto SetupEngine = [&](int id) {
     std::string a(id, 'a');
     std::string v;
     std::string t_skiplist(thread_skiplist + std::to_string(id));
@@ -553,7 +553,7 @@ TEST_F(EngineBasicTest, TestSortedRestore) {
     }
   };
 
-  LaunchNThreads(num_threads, ops, 1);
+  LaunchNThreads(num_threads, SetupEngine, 1);
 
   delete engine;
 


### PR DESCRIPTION
Signed-off-by: ZiyanShi <ziyan.shi@intel.com>

TestSortedRestore is just strange. When I start from thread_id with 0
line 535, LaunchNThreads(num_threads, ops, 1)->LaunchNThreads(num_threads, ops, 0);
As well as modify those for loops 
for (int i = 1; i <= num_threads; i++)->for (int i = 0; i <= 1; i++)
and change the strings like
std::string a(i, 'a'); to std::string a(i+1, 'a');
The test will still fail at 
line 568     ASSERT_EQ(cnt, count);
The iterator will only find one valid record.
What's so special with this thread number?