### PR TITLE
fix error message

### DIFF
--- a/engine/kv_engine.cpp
+++ b/engine/kv_engine.cpp
@@ -794,7 +794,7 @@ Status KVEngine::CheckConfigs(const Configs &configs) {
   if (configs.pmem_file_size % sz_segment != 0) {
     GlobalLogger.Error("pmem file size should align to segment "
                        "size(pmem_segment_blocks*pmem_block_size) (%d bytes)\n",
-                       configs.pmem_block_size);
+                       sz_segment);
     return Status::InvalidConfiguration;
   }
 


### PR DESCRIPTION
Signed-off-by: ZiyanShi <ziyan.shi@intel.com>
fix error message for checking alignment of segment in PMem. previously use block size instead of segment size to warn user.