### PR TITLE
Check pointers and offsets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@ build/
 .cache/
 
 scripts/result*
+debug/

--- a/engine/kv_engine.cpp
+++ b/engine/kv_engine.cpp
@@ -788,8 +788,8 @@ Status KVEngine::SSetImpl(Skiplist *skiplist,
       continue;
     }
 
-    uint64_t prev_offset = pmem_allocator_->addr2offset(splice.prev_data_entry);
-    uint64_t next_offset = pmem_allocator_->addr2offset(splice.next_data_entry);
+    uint64_t prev_offset = pmem_allocator_->addr2offset_nocheck(splice.prev_data_entry);
+    uint64_t next_offset = pmem_allocator_->addr2offset_nocheck(splice.next_data_entry);
 
     DLDataEntry write_entry(0, sized_space_entry.size, new_ts, dt,
                             collection_key.size(), value.size(), prev_offset,
@@ -811,7 +811,7 @@ Status KVEngine::SSetImpl(Skiplist *skiplist,
 
     if (!found) {
       uint64_t offset = (dram_node == nullptr)
-                            ? pmem_allocator_->addr2offset(block_base)
+                            ? pmem_allocator_->addr2offset_nocheck(block_base)
                             : (uint64_t)dram_node;
       auto entry_base_status = entry_base->header.status;
       hash_table_->Insert(hint, entry_base, dt, offset,
@@ -828,7 +828,7 @@ Status KVEngine::SSetImpl(Skiplist *skiplist,
       // update a height 0 dram node
       if (dram_node == nullptr) {
         hash_table_->Insert(hint, entry_base, dt,
-                            pmem_allocator_->addr2offset(block_base),
+                            pmem_allocator_->addr2offset_nocheck(block_base),
                             HashOffsetType::DLDataEntry);
       } else {
         entry_base->header.data_type = dt;

--- a/engine/pmem_allocator/pmem_allocator.hpp
+++ b/engine/pmem_allocator/pmem_allocator.hpp
@@ -44,6 +44,7 @@ public:
   // transfer block_offset of allocated space to address
   inline char *offset2addr(uint64_t block_offset) {
     if (block_offset == kNullPmemOffset) {
+      assert(false && "Trying to access kNullPmemOffset");
       return nullptr;
     } else {
       assert(block_offset < max_block_offset_ / num_segment_blocks_ *
@@ -62,6 +63,7 @@ public:
              "Trying to create invalid offset");
       return ((char *)addr - pmem_) / block_size_;
     } else {
+      assert(false && "Trying to access nullptr");
       return kNullPmemOffset;
     }
   }

--- a/engine/pmem_allocator/pmem_allocator.hpp
+++ b/engine/pmem_allocator/pmem_allocator.hpp
@@ -41,7 +41,7 @@ public:
   // just record these entries
   void DelayFree(const SizedSpaceEntry &entry);
 
-  // transfer block_offset of allocated space to address
+  // translate block_offset of allocated space to address
   inline char *offset2addr(uint64_t block_offset) {
     if (block_offset == kNullPmemOffset) {
       assert(false && "Trying to access kNullPmemOffset");
@@ -54,7 +54,15 @@ public:
     }
   }
 
-  // transfer address of allocated space to block_offset
+  inline char *offset2addr_nocheck(uint64_t block_offset) {
+    if (block_offset == kNullPmemOffset) {
+      return nullptr;
+    } else {
+      return pmem_ + block_offset * block_size_;
+    }
+  }
+
+  // translate address of allocated space to block_offset
   inline uint64_t addr2offset(void *addr) {
     if (addr) {
       assert((static_cast<char *>(addr) - pmem_) / block_size_ <
@@ -64,6 +72,14 @@ public:
       return ((char *)addr - pmem_) / block_size_;
     } else {
       assert(false && "Trying to access nullptr");
+      throw;
+    }
+  }
+
+  inline uint64_t addr2offset_nocheck(void *addr) {
+    if (addr) {
+      return ((char *)addr - pmem_) / block_size_;
+    } else {
       return kNullPmemOffset;
     }
   }

--- a/engine/skiplist.hpp
+++ b/engine/skiplist.hpp
@@ -204,15 +204,15 @@ public:
     skiplist_->Seek(key, &splice);
     current = splice.next_data_entry;
     while (current->type == SortedDeleteRecord) {
-      current = (DLDataEntry *)(pmem_allocator_->offset2addr(current->next));
+      current = (DLDataEntry *)(pmem_allocator_->offset2addr_nocheck(current->next));
     }
   }
 
   virtual void SeekToFirst() override {
     uint64_t first = skiplist_->header()->data_entry->next;
-    current = (DLDataEntry *)pmem_allocator_->offset2addr(first);
+    current = (DLDataEntry *)pmem_allocator_->offset2addr_nocheck(first);
     while (current && current->type == SortedDeleteRecord) {
-      current = (DLDataEntry *)pmem_allocator_->offset2addr(current->next);
+      current = (DLDataEntry *)pmem_allocator_->offset2addr_nocheck(current->next);
     }
   }
 
@@ -225,7 +225,7 @@ public:
       return false;
     }
     do {
-      current = (DLDataEntry *)pmem_allocator_->offset2addr(current->next);
+      current = (DLDataEntry *)pmem_allocator_->offset2addr_nocheck(current->next);
     } while (current && current->type == SortedDeleteRecord);
     return current != nullptr;
   }
@@ -236,7 +236,7 @@ public:
     }
 
     do {
-      current = (DLDataEntry *)(pmem_allocator_->offset2addr(current->prev));
+      current = (DLDataEntry *)(pmem_allocator_->offset2addr_nocheck(current->prev));
     } while (current->type == SortedDeleteRecord);
 
     if (current == skiplist_->header()->data_entry) {


### PR DESCRIPTION
Add `assert` to `PMEMAllocator::offset2addr` and `PMEMAllocator::addr2offset` so that we can check for access to invalid pointers.
Add `PMEMAllocator::offset2addr_nocheck` and `PMEMAllocator::addr2offset_nocheck` because `Skiplist` relies on the translation between `kNullPMemOffset` and `nullptr`. 