### PR TITLE
Implement dram node deletion of skiplist

### DIFF
--- a/engine/data_entry.hpp
+++ b/engine/data_entry.hpp
@@ -15,7 +15,6 @@ enum DataEntryType : uint16_t {
   StringDeleteRecord = 1 << 1,
 
   SortedDataRecord = 1 << 2,
-  SortedDeleteRecord = 1 << 3,
   SortedHeaderRecord = 1 << 4,
 
   HashListDataRecord = 1 << 5,
@@ -31,15 +30,14 @@ enum DataEntryType : uint16_t {
   Padding = 1 << 15,
 };
 
-const uint16_t SortedDataEntryType =
-    (SortedDataRecord | SortedDeleteRecord | SortedHeaderRecord);
+const uint16_t SortedDataEntryType = (SortedDataRecord | SortedHeaderRecord);
 
 const uint16_t DLDataEntryType =
-    (SortedDataRecord | SortedDeleteRecord | SortedHeaderRecord |
-     HashListDataRecord | HashListDeleteRecord | HashListHeaderRecord);
+    (SortedDataRecord | SortedHeaderRecord | HashListDataRecord |
+     HashListDeleteRecord | HashListHeaderRecord);
 
 const uint16_t DeleteDataEntryType =
-    (SortedDeleteRecord | HashListDeleteRecord | StringDeleteRecord);
+    (HashListDeleteRecord | StringDeleteRecord);
 
 const uint16_t StringDataEntryType = (StringDataRecord | StringDeleteRecord);
 

--- a/engine/hash_table.cpp
+++ b/engine/hash_table.cpp
@@ -101,7 +101,8 @@ Status HashTable::Search(const KeyHashHint &hint,
 
       if (purpose == SearchPurpose::Write /* we don't reused hash entry in
                                              recovering */
-          && (*entry_base)->header.data_type == StringDeleteRecord) {
+          && ((*entry_base)->header.data_type == StringDeleteRecord ||
+              (*entry_base)->header.data_type == Empty)) {
         reusable_entry = *entry_base;
       }
 
@@ -148,10 +149,10 @@ Status HashTable::Search(const KeyHashHint &hint,
       (*entry_base)->header.status = HashEntryStatus::Updating;
     } else {
       if ((*entry_base) == reusable_entry) {
-        if ((*entry_base)->header.status == HashEntryStatus::Clean) {
+        if ((*entry_base)->header.status == HashEntryStatus::CleanReusing) {
           (*entry_base)->header.status = HashEntryStatus::Updating;
         } else {
-          (*entry_base)->header.status = HashEntryStatus::BeingReused;
+          (*entry_base)->header.status = HashEntryStatus::DirtyReusing;
         }
       } else {
         (*entry_base)->header.status = HashEntryStatus::Initializing;

--- a/engine/hash_table.cpp
+++ b/engine/hash_table.cpp
@@ -101,8 +101,7 @@ Status HashTable::Search(const KeyHashHint &hint,
 
       if (purpose == SearchPurpose::Write /* we don't reused hash entry in
                                              recovering */
-          && ((*entry_base)->header.data_type == StringDeleteRecord ||
-              (*entry_base)->header.data_type == Empty)) {
+          && ((*entry_base)->header.data_type == StringDeleteRecord)) {
         reusable_entry = *entry_base;
       }
 

--- a/engine/hash_table.cpp
+++ b/engine/hash_table.cpp
@@ -10,6 +10,9 @@ namespace KVDK_NAMESPACE {
 bool HashTable::MatchHashEntry(const pmem::obj::string_view &key,
                                uint32_t hash_k_prefix, uint16_t target_type,
                                const HashEntry *hash_entry, void *data_entry) {
+  if (hash_entry->header.status == HashEntryStatus::Clean) {
+    return false;
+  }
   if ((target_type & hash_entry->header.data_type) &&
       hash_k_prefix == hash_entry->header.key_prefix) {
 
@@ -101,7 +104,7 @@ Status HashTable::Search(const KeyHashHint &hint,
 
       if (purpose == SearchPurpose::Write /* we don't reused hash entry in
                                              recovering */
-          && ((*entry_base)->header.data_type == StringDeleteRecord)) {
+          && (*entry_base)->Reusable()) {
         reusable_entry = *entry_base;
       }
 
@@ -113,7 +116,8 @@ Status HashTable::Search(const KeyHashHint &hint,
         if (i == entries) {
           if (purpose >= SearchPurpose::Write) {
             if (reusable_entry != nullptr) {
-              if (data_entry) {
+              if (data_entry &&
+                  reusable_entry->header.status != HashEntryStatus::Clean) {
                 memcpy(data_entry,
                        pmem_allocator_->offset2addr(reusable_entry->offset),
                        sizeof(DataEntry));
@@ -148,10 +152,9 @@ Status HashTable::Search(const KeyHashHint &hint,
       (*entry_base)->header.status = HashEntryStatus::Updating;
     } else {
       if ((*entry_base) == reusable_entry) {
-        if ((*entry_base)->header.status == HashEntryStatus::CleanReusing) {
+        if ((*entry_base)->header.status == HashEntryStatus::CleanReusable) {
+          // Reuse a clean reusable hash entry is as same as updating
           (*entry_base)->header.status = HashEntryStatus::Updating;
-        } else {
-          (*entry_base)->header.status = HashEntryStatus::DirtyReusing;
         }
       } else {
         (*entry_base)->header.status = HashEntryStatus::Initializing;
@@ -168,17 +171,15 @@ void HashTable::Insert(const KeyHashHint &hint, HashEntry *entry_base,
   assert(write_thread.id >= 0);
 
   HashEntry new_hash_entry(hint.key_hash_value >> 32, type, offset,
+                           type == StringDeleteRecord
+                               ? HashEntryStatus::DirtyReusable
+                               : HashEntryStatus::Normal,
                            offset_type);
 
-  if (entry_base->header.status == HashEntryStatus::Updating) {
-    HashEntry::CopyOffset(entry_base, &new_hash_entry);
-    HashEntry::CopyHeader(entry_base, &new_hash_entry);
-  } else {
-    bool new_entry = entry_base->header.status == HashEntryStatus::Initializing;
-    memcpy_16(entry_base, &new_hash_entry);
-    if (new_entry) { // new allocated
-      hash_bucket_entries_[hint.bucket]++;
-    }
+  bool new_entry = entry_base->header.status == HashEntryStatus::Initializing;
+  memcpy_16(entry_base, &new_hash_entry);
+  if (new_entry) { // new allocated
+    hash_bucket_entries_[hint.bucket]++;
   }
 }
 } // namespace KVDK_NAMESPACE

--- a/engine/hash_table.cpp
+++ b/engine/hash_table.cpp
@@ -10,7 +10,7 @@ namespace KVDK_NAMESPACE {
 bool HashTable::MatchHashEntry(const pmem::obj::string_view &key,
                                uint32_t hash_k_prefix, uint16_t target_type,
                                const HashEntry *hash_entry, void *data_entry) {
-  if (hash_entry->header.status == HashEntryStatus::Clean) {
+  if (hash_entry->header.status == HashEntryStatus::Empty) {
     return false;
   }
   if ((target_type & hash_entry->header.data_type) &&
@@ -117,7 +117,7 @@ Status HashTable::Search(const KeyHashHint &hint,
           if (purpose >= SearchPurpose::Write) {
             if (reusable_entry != nullptr) {
               if (data_entry &&
-                  reusable_entry->header.status != HashEntryStatus::Clean) {
+                  reusable_entry->header.status != HashEntryStatus::Empty) {
                 memcpy(data_entry,
                        pmem_allocator_->offset2addr(reusable_entry->offset),
                        sizeof(DataEntry));

--- a/engine/hash_table.hpp
+++ b/engine/hash_table.hpp
@@ -30,7 +30,7 @@ enum class HashEntryStatus : uint8_t {
   // hash entry updated by a new key
   CleanReusable = 1 << 4,
   // A empty hash entry which points to nothing
-  Clean = 1 << 5,
+  Empty = 1 << 5,
 };
 
 enum class HashOffsetType : uint8_t {
@@ -68,7 +68,7 @@ struct HashEntry {
   bool Reusable() {
     return (uint8_t)header.status & ((uint8_t)HashEntryStatus::CleanReusable |
                                      (uint8_t)HashEntryStatus::DirtyReusable |
-                                     (uint8_t)HashEntryStatus::Clean);
+                                     (uint8_t)HashEntryStatus::Empty);
   }
 };
 

--- a/engine/hash_table.hpp
+++ b/engine/hash_table.hpp
@@ -16,17 +16,21 @@
 namespace KVDK_NAMESPACE {
 enum class HashEntryStatus : uint8_t {
   Normal = 1,
-  // A hash entry of a delete record which has no older version data of the same
-  // key exsiting on PMem, so the delete record can be safely freed after the
-  // hash entry updated by a new key
-  Clean,
   // New created hash entry for inserting a new key
   Initializing,
   // A entry being updated by the same key, or a CLEAN hash entry being updated
   // by a new key
   Updating,
-  // A Normal hash entry of a delete record that is reusing by a new key
-  BeingReused,
+  // A Normal hash entry of a delete record that is reusing by a new key, it's
+  // unknown if there are older version data of the same key existing so we can
+  // not free corresponding PMem data entry
+  DirtyReusing,
+  // A hash entry of a delete record which has no older version data of the same
+  // key exsiting on PMem, so the delete record can be safely freed after the
+  // hash entry updated by a new key
+  CleanReusing,
+  // A empty hash entry which points to nothing
+  Empty,
 };
 
 enum class HashOffsetType : uint8_t {

--- a/engine/hash_table.hpp
+++ b/engine/hash_table.hpp
@@ -17,20 +17,20 @@ namespace KVDK_NAMESPACE {
 enum class HashEntryStatus : uint8_t {
   Normal = 1,
   // New created hash entry for inserting a new key
-  Initializing,
-  // A entry being updated by the same key, or a CLEAN hash entry being updated
-  // by a new key
-  Updating,
+  Initializing = 1 << 1,
+  // A entry being updated by the same key, or a CleanReusable hash entry being
+  // updated by a new key
+  Updating = 1 << 2,
   // A Normal hash entry of a delete record that is reusing by a new key, it's
   // unknown if there are older version data of the same key existing so we can
   // not free corresponding PMem data entry
-  DirtyReusing,
+  DirtyReusable = 1 << 3,
   // A hash entry of a delete record which has no older version data of the same
   // key exsiting on PMem, so the delete record can be safely freed after the
   // hash entry updated by a new key
-  CleanReusing,
+  CleanReusable = 1 << 4,
   // A empty hash entry which points to nothing
-  Empty,
+  Clean = 1 << 5,
 };
 
 enum class HashOffsetType : uint8_t {
@@ -53,9 +53,9 @@ struct HashHeader {
 
 struct HashEntry {
   HashEntry() = default;
-  HashEntry(uint32_t kp, uint16_t t, uint64_t offset,
+  HashEntry(uint32_t kp, uint16_t t, uint64_t offset, HashEntryStatus status,
             HashOffsetType offset_type)
-      : header({kp, t, offset_type, HashEntryStatus::Normal}), offset(offset) {}
+      : header({kp, t, offset_type, status}), offset(offset) {}
 
   HashHeader header;
   uint64_t offset;
@@ -63,6 +63,12 @@ struct HashEntry {
   static void CopyHeader(HashEntry *dst, HashEntry *src) { memcpy_8(dst, src); }
   static void CopyOffset(HashEntry *dst, HashEntry *src) {
     dst->offset = src->offset;
+  }
+
+  bool Reusable() {
+    return (uint8_t)header.status & ((uint8_t)HashEntryStatus::CleanReusable |
+                                     (uint8_t)HashEntryStatus::DirtyReusable |
+                                     (uint8_t)HashEntryStatus::Clean);
   }
 };
 

--- a/engine/kv_engine.cpp
+++ b/engine/kv_engine.cpp
@@ -331,7 +331,7 @@ Status KVEngine::RestoreStringRecord(DataEntry *pmem_data_entry,
   // can reuse the hash entry and free the data entry
   entry_base->header.status =
       (!found && (cached_meta->type & DeleteDataEntryType)
-           ? HashEntryStatus::CleanReusing
+           ? HashEntryStatus::CleanReusable
            : HashEntryStatus::Normal);
 
   return Status::Ok;
@@ -429,7 +429,7 @@ Status KVEngine::RestoreSortedRecord(DLDataEntry *pmem_data_entry,
   // can reuse the hash entry and free the data entry
   entry_base->header.status =
       (!found && (cached_meta->type & DeleteDataEntryType)
-           ? HashEntryStatus::CleanReusing
+           ? HashEntryStatus::CleanReusable
            : HashEntryStatus::Normal);
 
   return Status::Ok;
@@ -498,7 +498,7 @@ KVEngine::SearchOrInitPersistentList(const pmem::obj::string_view &collection,
           pmem_allocator_->Free(SizedSpaceEntry(
               hash_entry.offset, existing_data_entry.header.b_size,
               existing_data_entry.timestamp));
-        } else if (entry_base_status == HashEntryStatus::DirtyReusing) {
+        } else if (entry_base_status == HashEntryStatus::DirtyReusable) {
           pmem_allocator_->DelayFree(SizedSpaceEntry(
               hash_entry.offset, existing_data_entry.header.b_size,
               existing_data_entry.timestamp));
@@ -795,6 +795,7 @@ Status KVEngine::SDeleteImpl(Skiplist *skiplist,
         dram_node);
 
     entry_base->header.data_type = Empty;
+    entry_base->header.status = HashEntryStatus::Clean;
     pmem_allocator_->Free(SizedSpaceEntry(
         old_entry_offset, data_entry.header.b_size, data_entry.timestamp));
     for (auto &m : spins) {
@@ -887,7 +888,7 @@ Status KVEngine::SSetImpl(Skiplist *skiplist,
       if (entry_base_status == HashEntryStatus::Updating) {
         pmem_allocator_->Free(SizedSpaceEntry(
             hash_entry.offset, data_entry.header.b_size, data_entry.timestamp));
-      } else if (entry_base_status == HashEntryStatus::DirtyReusing) {
+      } else if (entry_base_status == HashEntryStatus::DirtyReusable) {
         pmem_allocator_->DelayFree(SizedSpaceEntry(
             hash_entry.offset, data_entry.header.b_size, data_entry.timestamp));
       }
@@ -1214,7 +1215,7 @@ Status KVEngine::StringSetImpl(const pmem::obj::string_view &key,
     if (entry_base_status == HashEntryStatus::Updating) {
       pmem_allocator_->Free(SizedSpaceEntry(
           hash_entry.offset, data_entry.header.b_size, data_entry.timestamp));
-    } else if (entry_base_status == HashEntryStatus::DirtyReusing) {
+    } else if (entry_base_status == HashEntryStatus::DirtyReusable) {
       pmem_allocator_->DelayFree(SizedSpaceEntry(
           hash_entry.offset, data_entry.header.b_size, data_entry.timestamp));
     }

--- a/engine/kv_engine.cpp
+++ b/engine/kv_engine.cpp
@@ -782,7 +782,7 @@ Status KVEngine::SSetImpl(Skiplist *skiplist,
     }
 
     std::vector<SpinMutex *> spins;
-    thread_local Skiplist::Splice splice;
+    thread_local Splice splice;
     if (!skiplist->FindAndLockWritePos(&splice, user_key, hint, spins,
                                        found ? &data_entry : nullptr)) {
       continue;

--- a/engine/kv_engine.cpp
+++ b/engine/kv_engine.cpp
@@ -794,8 +794,7 @@ Status KVEngine::SDeleteImpl(Skiplist *skiplist,
         (DLDataEntry *)pmem_allocator_->offset2addr(old_entry_offset), &splice,
         dram_node);
 
-    entry_base->header.data_type = Empty;
-    entry_base->header.status = HashEntryStatus::Clean;
+    entry_base->header.status = HashEntryStatus::Empty;
     pmem_allocator_->Free(SizedSpaceEntry(
         old_entry_offset, data_entry.header.b_size, data_entry.timestamp));
     for (auto &m : spins) {

--- a/engine/kv_engine.cpp
+++ b/engine/kv_engine.cpp
@@ -776,7 +776,8 @@ Status KVEngine::SDeleteImpl(Skiplist *skiplist,
     }
 
     std::vector<SpinMutex *> spins;
-    thread_local Splice splice;
+    thread_local Splice splice(nullptr);
+    splice.header = skiplist->header();
     if (!skiplist->FindAndLockWritePos(&splice, user_key, hint, spins,
                                        &data_entry)) {
       continue;
@@ -848,7 +849,8 @@ Status KVEngine::SSetImpl(Skiplist *skiplist,
     }
 
     std::vector<SpinMutex *> spins;
-    thread_local Splice splice;
+    thread_local Splice splice(nullptr);
+    splice.header = skiplist->header();
     if (!skiplist->FindAndLockWritePos(&splice, user_key, hint, spins,
                                        found ? &data_entry : nullptr)) {
       continue;

--- a/engine/kv_engine.hpp
+++ b/engine/kv_engine.hpp
@@ -112,7 +112,10 @@ private:
                      BatchWriteHint *batch_hint = nullptr);
 
   Status SSetImpl(Skiplist *skiplist, const pmem::obj::string_view &user_key,
-                  const pmem::obj::string_view &value, uint16_t dt);
+                  const pmem::obj::string_view &value);
+
+  Status SDeleteImpl(Skiplist *skiplist,
+                     const pmem::obj::string_view &user_key);
 
   Status Recovery();
 
@@ -125,6 +128,8 @@ private:
 
   Status RestoreSkiplistOrHashRecord(DataEntry *recovering_data_entry,
                                      DataEntry *pmem_data_entry);
+
+  bool CheckAndRepairSortedRecord(DLDataEntry *sorted_data_entry);
 
   Status RestoreStringRecord(DataEntry *pmem_data_entry,
                              DataEntry *cached_meta);

--- a/engine/kv_engine.hpp
+++ b/engine/kv_engine.hpp
@@ -107,9 +107,12 @@ private:
 
   Status MaybeInitPendingBatchFile();
 
-  Status HashSetImpl(const pmem::obj::string_view &key,
-                     const pmem::obj::string_view &value, uint16_t dt,
-                     BatchWriteHint *batch_hint = nullptr);
+  Status StringSetImpl(const pmem::obj::string_view &key,
+                       const pmem::obj::string_view &value,
+                       BatchWriteHint *batch_hint);
+
+  Status StringDeleteImpl(const pmem::obj::string_view &key,
+                          BatchWriteHint *batch_hint = nullptr);
 
   Status SSetImpl(Skiplist *skiplist, const pmem::obj::string_view &user_key,
                   const pmem::obj::string_view &value);

--- a/engine/kv_engine.hpp
+++ b/engine/kv_engine.hpp
@@ -129,6 +129,8 @@ private:
   Status RestoreSkiplistOrHashRecord(DataEntry *recovering_data_entry,
                                      DataEntry *pmem_data_entry);
 
+  // Check if a sorted data entry has been successfully inserted, and try repair
+  // un-finished prev pointer
   bool CheckAndRepairSortedRecord(DLDataEntry *sorted_data_entry);
 
   Status RestoreStringRecord(DataEntry *pmem_data_entry,

--- a/engine/pmem_allocator/pmem_allocator.hpp
+++ b/engine/pmem_allocator/pmem_allocator.hpp
@@ -46,9 +46,9 @@ public:
     if (block_offset == kNullPmemOffset) {
       return nullptr;
     } else {
-      // assert(block_offset < max_block_offset_ / num_segment_blocks_ *
-      // num_segment_blocks_ &&
-      //  "Trying to access invalid offset");
+      assert(block_offset < max_block_offset_ / num_segment_blocks_ *
+                                num_segment_blocks_ &&
+             "Trying to access invalid offset");
       return pmem_ + block_offset * block_size_;
     }
   }
@@ -56,11 +56,10 @@ public:
   // transfer address of allocated space to block_offset
   inline uint64_t addr2offset(void *addr) {
     if (addr) {
-      // assert((static_cast<char *>(addr) - pmem_) / block_size_ <
-      // max_block_offset_ /
-      // num_segment_blocks_ *
-      //  num_segment_blocks_ &&
-      //  "Trying to create invalid offset");
+      assert((static_cast<char *>(addr) - pmem_) / block_size_ <
+                 max_block_offset_ / num_segment_blocks_ *
+                     num_segment_blocks_ &&
+             "Trying to create invalid offset");
       return ((char *)addr - pmem_) / block_size_;
     } else {
       return kNullPmemOffset;

--- a/engine/pmem_allocator/pmem_allocator.hpp
+++ b/engine/pmem_allocator/pmem_allocator.hpp
@@ -46,9 +46,9 @@ public:
     if (block_offset == kNullPmemOffset) {
       return nullptr;
     } else {
-      assert(block_offset < max_block_offset_ / num_segment_blocks_ *
-                                num_segment_blocks_ &&
-             "Trying to access invalid offset");
+      // assert(block_offset < max_block_offset_ / num_segment_blocks_ *
+      // num_segment_blocks_ &&
+      //  "Trying to access invalid offset");
       return pmem_ + block_offset * block_size_;
     }
   }
@@ -56,10 +56,11 @@ public:
   // transfer address of allocated space to block_offset
   inline uint64_t addr2offset(void *addr) {
     if (addr) {
-      assert((static_cast<char *>(addr) - pmem_) / block_size_ <
-                 max_block_offset_ / num_segment_blocks_ *
-                     num_segment_blocks_ &&
-             "Trying to create invalid offset");
+      // assert((static_cast<char *>(addr) - pmem_) / block_size_ <
+      // max_block_offset_ /
+      // num_segment_blocks_ *
+      //  num_segment_blocks_ &&
+      //  "Trying to create invalid offset");
       return ((char *)addr - pmem_) / block_size_;
     } else {
       return kNullPmemOffset;

--- a/engine/skiplist.cpp
+++ b/engine/skiplist.cpp
@@ -64,7 +64,7 @@ void Skiplist::Seek(const pmem::obj::string_view &key, Splice *splice) {
   // TODO: do not search from max height every time
   for (int i = kMaxHeight; i >= 1; i--) {
     while (1) {
-      tmp = prev->Next(i);
+      tmp = prev->Next(i).Pointer();
       if (tmp == nullptr) {
         splice->nexts[i] = nullptr;
         splice->prevs[i] = prev;

--- a/engine/skiplist.cpp
+++ b/engine/skiplist.cpp
@@ -115,6 +115,7 @@ bool Skiplist::SeekNode(const SkiplistNode *node, Splice *splice) {
 }
 
 void Skiplist::SeekKey(const pmem::obj::string_view &key, Splice *splice) {
+  splice->header = header_;
   header_->SeekKey(key, header_->Height(), 1, splice);
   assert(splice->prevs[1] != nullptr);
   DLDataEntry *prev_data_entry = splice->prevs[1]->data_entry;

--- a/engine/skiplist.cpp
+++ b/engine/skiplist.cpp
@@ -34,6 +34,7 @@ void SkiplistNode::SeekKey(const pmem::obj::string_view &key,
           prev = result_splice->prevs[i];
         } else if (prev == this) {
           // this node has been deleted, so seek from header
+          assert(result_splice->header);
           prev = result_splice->header;
           i = kMaxHeight;
         } else {
@@ -198,15 +199,6 @@ bool Skiplist::FindAndLockWritePos(Splice *splice,
   // For update, we do not need to check because the key is already locked
   if (!updated_data_entry &&
       (prev->next != next_offset || (next && next->prev != prev_offset))) {
-    thread_local uint64_t cnt = 0;
-    if (++cnt > 1000000) {
-      GlobalLogger.Error("too many fail\n");
-      if (prev->next != next_offset) {
-        GlobalLogger.Error("fail reson 1\n");
-      } else {
-        GlobalLogger.Error("fail reson 2\n");
-      }
-    }
     for (auto &m : spins) {
       m->unlock();
     }

--- a/engine/skiplist.hpp
+++ b/engine/skiplist.hpp
@@ -167,7 +167,9 @@ public:
     }
   };
 
-  void Seek(const pmem::obj::string_view &key, Splice *splice);
+  void SeekKey(const pmem::obj::string_view &key, Splice *splice);
+
+  bool SeekNode(const SkiplistNode *node, Splice *splice);
 
   Status Rebuild();
 
@@ -205,7 +207,7 @@ public:
   virtual void Seek(const std::string &key) override {
     assert(skiplist_);
     Skiplist::Splice splice;
-    skiplist_->Seek(key, &splice);
+    skiplist_->SeekKey(key, &splice);
     current = splice.next_data_entry;
     while (current->type == SortedDeleteRecord) {
       current = (DLDataEntry *)(pmem_allocator_->offset2addr(current->next));

--- a/engine/structures.hpp
+++ b/engine/structures.hpp
@@ -13,6 +13,35 @@
 
 namespace KVDK_NAMESPACE {
 
+// A pointer with additional information on high 16 bits
+template <typename T> struct ExtendedPointer {
+  uint64_t encoded_pointer;
+  static constexpr uint64_t kPointerMask = (((uint64_t)1 << 48) - 1);
+
+  ExtendedPointer(T *pointer) : encoded_pointer((uint64_t)pointer) {}
+
+  explicit ExtendedPointer(T *pointer, uint16_t code)
+      : encoded_pointer((uint64_t)pointer & ((uint64_t)code << 48)) {}
+
+  ExtendedPointer() : encoded_pointer(0) {}
+
+  T *Pointer() { return (T *)(encoded_pointer & kPointerMask); }
+
+  bool Null() { return Pointer() == nullptr; }
+
+  T &operator*() { return *(Pointer()); }
+
+  T *operator->() { return Pointer(); }
+
+  T *operator->() const { return Pointer(); }
+
+  uint16_t Code() { return encoded_pointer >> 48; }
+
+  void Clear() { encoded_pointer &= kPointerMask; }
+
+  void Encode(uint16_t info) { encoded_pointer &= ((uint64_t)info << 48); }
+};
+
 struct PendingBatch {
   enum class Stage {
     Done = 0,

--- a/engine/structures.hpp
+++ b/engine/structures.hpp
@@ -21,11 +21,15 @@ template <typename T> struct TaggedPointer {
   TaggedPointer(T *pointer) : tagged_pointer((uint64_t)pointer) {}
 
   explicit TaggedPointer(T *pointer, uint16_t code)
-      : tagged_pointer((uint64_t)pointer & ((uint64_t)code << 48)) {}
+      : tagged_pointer((uint64_t)pointer | ((uint64_t)code << 48)) {}
 
   TaggedPointer() : tagged_pointer(0) {}
 
   T *RawPointer() { return (T *)(tagged_pointer & kPointerMask); }
+
+  const T *RawPointer() const {
+    return (const T *)(tagged_pointer & kPointerMask);
+  }
 
   bool Null() { return RawPointer() == nullptr; }
 
@@ -33,13 +37,15 @@ template <typename T> struct TaggedPointer {
 
   void ClearTag() { tagged_pointer &= kPointerMask; }
 
-  void SetTag(uint16_t info) { tagged_pointer &= ((uint64_t)info << 48); }
+  void SetTag(uint16_t info) { tagged_pointer |= ((uint64_t)info << 48); }
+
+  const T &operator*() const { return *RawPointer(); }
 
   T &operator*() { return *(RawPointer()); }
 
-  T *operator->() { return RawPointer(); }
+  const T *operator->() const { return RawPointer(); }
 
-  T *operator->() const { return RawPointer(); }
+  T *operator->() { return RawPointer(); }
 
   bool operator==(const T *raw_pointer) { return RawPointer() == raw_pointer; }
 

--- a/engine/structures.hpp
+++ b/engine/structures.hpp
@@ -14,32 +14,38 @@
 namespace KVDK_NAMESPACE {
 
 // A pointer with additional information on high 16 bits
-template <typename T> struct ExtendedPointer {
-  uint64_t encoded_pointer;
+template <typename T> struct TaggedPointer {
+  uint64_t tagged_pointer;
   static constexpr uint64_t kPointerMask = (((uint64_t)1 << 48) - 1);
 
-  ExtendedPointer(T *pointer) : encoded_pointer((uint64_t)pointer) {}
+  TaggedPointer(T *pointer) : tagged_pointer((uint64_t)pointer) {}
 
-  explicit ExtendedPointer(T *pointer, uint16_t code)
-      : encoded_pointer((uint64_t)pointer & ((uint64_t)code << 48)) {}
+  explicit TaggedPointer(T *pointer, uint16_t code)
+      : tagged_pointer((uint64_t)pointer & ((uint64_t)code << 48)) {}
 
-  ExtendedPointer() : encoded_pointer(0) {}
+  TaggedPointer() : tagged_pointer(0) {}
 
-  T *Pointer() { return (T *)(encoded_pointer & kPointerMask); }
+  T *RawPointer() { return (T *)(tagged_pointer & kPointerMask); }
 
-  bool Null() { return Pointer() == nullptr; }
+  bool Null() { return RawPointer() == nullptr; }
 
-  T &operator*() { return *(Pointer()); }
+  uint16_t Tag() { return tagged_pointer >> 48; }
 
-  T *operator->() { return Pointer(); }
+  void ClearTag() { tagged_pointer &= kPointerMask; }
 
-  T *operator->() const { return Pointer(); }
+  void SetTag(uint16_t info) { tagged_pointer &= ((uint64_t)info << 48); }
 
-  uint16_t Code() { return encoded_pointer >> 48; }
+  T &operator*() { return *(RawPointer()); }
 
-  void Clear() { encoded_pointer &= kPointerMask; }
+  T *operator->() { return RawPointer(); }
 
-  void Encode(uint16_t info) { encoded_pointer &= ((uint64_t)info << 48); }
+  T *operator->() const { return RawPointer(); }
+
+  bool operator==(const T *raw_pointer) { return RawPointer() == raw_pointer; }
+
+  bool operator==(const T *raw_pointer) const {
+    return RawPointer() == raw_pointer;
+  }
 };
 
 struct PendingBatch {

--- a/engine/structures.hpp
+++ b/engine/structures.hpp
@@ -14,16 +14,16 @@
 namespace KVDK_NAMESPACE {
 
 // A pointer with additional information on high 16 bits
-template <typename T> struct TaggedPointer {
+template <typename T> struct PointerWithTag {
   uint64_t tagged_pointer;
   static constexpr uint64_t kPointerMask = (((uint64_t)1 << 48) - 1);
 
-  TaggedPointer(T *pointer) : tagged_pointer((uint64_t)pointer) {}
+  PointerWithTag(T *pointer) : tagged_pointer((uint64_t)pointer) {}
 
-  explicit TaggedPointer(T *pointer, uint16_t code)
+  explicit PointerWithTag(T *pointer, uint16_t code)
       : tagged_pointer((uint64_t)pointer | ((uint64_t)code << 48)) {}
 
-  TaggedPointer() : tagged_pointer(0) {}
+  PointerWithTag() : tagged_pointer(0) {}
 
   T *RawPointer() { return (T *)(tagged_pointer & kPointerMask); }
 
@@ -33,7 +33,7 @@ template <typename T> struct TaggedPointer {
 
   bool Null() { return RawPointer() == nullptr; }
 
-  uint16_t Tag() { return tagged_pointer >> 48; }
+  uint16_t GetTag() { return tagged_pointer >> 48; }
 
   void ClearTag() { tagged_pointer &= kPointerMask; }
 

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -42,7 +42,7 @@ protected:
     configs.hash_bucket_size = 64;
     configs.pmem_segment_blocks = 8 * 1024;
     // For faster test, no interval so it would not block engine closing
-    configs.background_work_interval = 0;
+    configs.background_work_interval = 0.1;
     db_path = "/mnt/pmem0/data";
     char cmd[1024];
     sprintf(cmd, "rm -rf %s\n", db_path.c_str());
@@ -530,7 +530,7 @@ TEST_F(EngineBasicTest, TestStringRestore) {
 }
 
 TEST_F(EngineBasicTest, TestSortedRestore) {
-  int num_threads = 16;
+  int num_threads = 48;
   configs.max_write_threads = num_threads;
   ASSERT_EQ(Engine::Open(db_path.c_str(), &engine, configs, stdout),
             Status::Ok);
@@ -543,6 +543,7 @@ TEST_F(EngineBasicTest, TestSortedRestore) {
     std::string got_val;
     std::string t_skiplist(thread_skiplist + std::to_string(id));
     for (int i = 1; i <= count; i++) {
+      // GlobalLogger.Info("thread %d round %d\n", id, i);
       auto key = key_prefix + std::to_string(i);
       auto overall_val = std::to_string(i);
       auto t_val = std::to_string(i * 2);
@@ -563,7 +564,7 @@ TEST_F(EngineBasicTest, TestSortedRestore) {
   };
 
   LaunchNThreads(num_threads, SetupEngine);
-
+  GlobalLogger.Info("Close\n");
   delete engine;
 
   // reopen and restore engine and try gets

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -543,7 +543,6 @@ TEST_F(EngineBasicTest, TestSortedRestore) {
     std::string got_val;
     std::string t_skiplist(thread_skiplist + std::to_string(id));
     for (int i = 1; i <= count; i++) {
-      // GlobalLogger.Info("thread %d round %d\n", id, i);
       auto key = key_prefix + std::to_string(i);
       auto overall_val = std::to_string(i);
       auto t_val = std::to_string(i * 2);
@@ -564,7 +563,6 @@ TEST_F(EngineBasicTest, TestSortedRestore) {
   };
 
   LaunchNThreads(num_threads, SetupEngine);
-  GlobalLogger.Info("Close\n");
   delete engine;
 
   // reopen and restore engine and try gets

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -248,7 +248,6 @@ TEST_F(EngineBasicTest, TestLocalSortedCollection) {
     std::string got_val1, got_val2;
 
     AssignData(val1, 10);
-
     // Test Empty Key
     {
       std::string k0{""};


### PR DESCRIPTION
In this patch.

- Remove SortedDeleteRecord data type, we check deleted and invalid sorted data entry by checking linkage during recovery
- Add a PointerWithTag struct, which stores additional information(tag) on highest 16bits of a raw pointer
- Store PointerWithTag in SkiplistNode instead of raw pointer, during deletion of a sorted data, we mark its dram node as logically deleted by tagging next pointers on each height
- During Seek operation, if a logically deleted node been found, phisically unlink it from list