### PR TITLE
Padding deleted sorted data record

### DIFF
--- a/engine/data_record.hpp
+++ b/engine/data_record.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "kvdk/namespace.hpp"
+#include "libpmem.h"
 #include "utils.hpp"
 
 namespace KVDK_NAMESPACE {
@@ -69,7 +70,10 @@ struct DataEntry {
 
   DataEntry() = default;
 
-  void Destroy() { meta.type == RecordType::Padding; }
+  void Destroy() {
+    meta.type == RecordType::Padding;
+    pmem_persist(&meta.type, sizeof(RecordType));
+  }
 
   // TODO jiayu: use function to access these
   DataHeader header;

--- a/engine/skiplist.cpp
+++ b/engine/skiplist.cpp
@@ -285,6 +285,7 @@ void Skiplist::DeleteRecord(DLRecord *deleting_record, Splice *delete_splice,
   assert(next->prev == pmem_allocator_->addr2offset(deleting_record));
   next->prev = pmem_allocator_->addr2offset(prev);
   pmem_persist(&next->prev, 8);
+  deleting_record->Destroy();
 
   if (dram_node) {
     dram_node->MarkAsRemoved();


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #103  <!-- REMOVE this line if no issue to close -->

Problem Summary:

deleted sorted data record still hold pointers, so user may use Set to inject vicious kv-pairs into engine to break SortedCollection.

### What is changed and how it works?

What's Changed:

Persist deleted sorted data record as padding type, so it will be derectly freed in recovery.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

Side effects

- Performance regression
    - Consumes more PMEM bandwidth in deleting sorted data, for persisting padding type
