### PR TITLE
Bug fix

### DIFF
--- a/engine/allocator.hpp
+++ b/engine/allocator.hpp
@@ -22,6 +22,7 @@ struct SpaceEntry {
 
 struct SizedSpaceEntry {
   SizedSpaceEntry() = default;
+
   SizedSpaceEntry(uint64_t _offset, uint64_t _size, uint64_t _info)
       : space_entry(_offset, _info), size(_size) {}
   SpaceEntry space_entry;

--- a/engine/data_record.hpp
+++ b/engine/data_record.hpp
@@ -38,9 +38,7 @@ const uint16_t StringRecordType = (StringDataRecord | StringDeleteRecord);
 
 struct DataHeader {
   DataHeader() = default;
-  DataHeader(uint32_t c, uint32_t s) : checksum(c), record_size(s) {
-    ;
-  }
+  DataHeader(uint32_t c, uint32_t s) : checksum(c), record_size(s) {}
 
   uint32_t checksum;
   // Record size on Pmem in the unit of block

--- a/engine/data_record.hpp
+++ b/engine/data_record.hpp
@@ -38,7 +38,9 @@ const uint16_t StringRecordType = (StringDataRecord | StringDeleteRecord);
 
 struct DataHeader {
   DataHeader() = default;
-  DataHeader(uint32_t c, uint32_t s) : checksum(c), record_size(s) {}
+  DataHeader(uint32_t c, uint32_t s) : checksum(c), record_size(s) {
+    ;
+  }
 
   uint32_t checksum;
   // Record size on Pmem in the unit of block

--- a/engine/pmem_allocator/free_list.cpp
+++ b/engine/pmem_allocator/free_list.cpp
@@ -181,7 +181,7 @@ void Freelist::MergeAndCheckTSInPool() {
         if (merged_blocks > 0) {
           // Persist merged free entry on PMem
           if (merged_blocks > b_size) {
-            DataHeader header(0, merged_blocks);
+            DataHeader header(0, merged_blocks * block_size_);
             pmem_memcpy_persist(pmem_allocator_->offset2addr(se.offset),
                                 &header, sizeof(DataHeader));
             // As we marked new size on PMem, it contains no valid data so we

--- a/engine/pmem_allocator/pmem_allocator.cpp
+++ b/engine/pmem_allocator/pmem_allocator.cpp
@@ -26,12 +26,14 @@ PMEMAllocator::PMEMAllocator(char *pmem, uint64_t pmem_size,
 
 void PMEMAllocator::Free(const SizedSpaceEntry &entry) {
   if (entry.size > 0) {
+    assert(entry.size % block_size_ == 0);
     free_list_.Push(entry);
   }
 }
 
 void PMEMAllocator::DelayFree(const SizedSpaceEntry &entry) {
   if (entry.size > 0) {
+    assert(entry.size % block_size_ == 0);
     free_list_.DelayPush(entry);
   }
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx <!-- REMOVE this line if no issue to close -->

Problem Summary:

1. Merged free space size is mis-recorded to PMem as block size
2. Deleted hash data record is not freed during recovery, if system crashes in deletion before padding it

### What is changed and how it works?

Proposal: [xxx](url) <!-- REMOVE this line if not applicable -->

What's Changed:

1. Record actual size of merged space on PMem
2. Free hash data record during recovery if it is not correctly linked
### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

Side effects

- No
