### PR TITLE
Hash table: Fix lock-free search

### DIFF
--- a/engine/hash_table.cpp
+++ b/engine/hash_table.cpp
@@ -230,7 +230,7 @@ Status HashTable::SearchForRead(const KeyHashHint &hint,
         return Status::Ok;
       } else {
         // check if hash entry modified by another write thread during
-        // MatchhashEntry
+        // MatchHashEntry
         if (memcmp(hash_entry_snap, *(entry_ptr), sizeof(HashEntry)) == 0) {
           break;
         }

--- a/engine/hash_table.hpp
+++ b/engine/hash_table.hpp
@@ -155,6 +155,7 @@ public:
   // hash_entry_snap: store a hash entry copy of searching key
   // data_entry_meta: store a copy of data entry metadata part of searching key
   // in_recovery: whether called during recovery of kvdk instance
+  // hint: make sure hint.spin is hold
   Status SearchForWrite(const KeyHashHint &hint,
                         const pmem::obj::string_view &key, uint16_t type_mask,
                         HashEntry **entry_ptr, HashEntry *hash_entry_snap,

--- a/engine/pmem_allocator/free_list.cpp
+++ b/engine/pmem_allocator/free_list.cpp
@@ -302,13 +302,16 @@ bool Freelist::Get(uint32_t size, SizedSpaceEntry *space_entry) {
     while (!large_entries_.empty()) {
       auto large_entry = large_entries_.begin();
       auto entry_size = large_entry->size;
+      auto entry_offset = large_entry->space_entry.offset;
       assert(entry_size % block_size_ == 0);
-      auto entry_b_size = large_entry->size / block_size_;
+      assert(entry_offset % block_size_ == 0);
+      auto entry_b_size = entry_size / block_size_;
+      auto entry_b_offset = entry_offset / block_size_;
       if (entry_b_size >= b_size) {
         space_entry->space_entry = large_entry->space_entry;
         large_entries_.erase(large_entry);
-        if (space_map_.TestAndUnset(space_entry->space_entry.offset,
-                                    entry_b_size) == entry_b_size) {
+        if (space_map_.TestAndUnset(entry_b_offset, entry_b_size) ==
+            entry_b_size) {
           thread_cache.last_used_entry_ts = space_entry->space_entry.info;
           space_entry->size = entry_size;
           return true;

--- a/engine/pmem_allocator/free_list.cpp
+++ b/engine/pmem_allocator/free_list.cpp
@@ -174,9 +174,10 @@ void Freelist::MergeAndCheckTSInPool() {
     if (active_pool_.TryFetchEntryList(merging_list, b_size)) {
       for (SpaceEntry &se : merging_list) {
         assert(se.offset % block_size_ == 0);
+        auto b_offset = se.offset / block_size_;
         uint64_t merged_blocks = MergeSpace(
-            se.offset / block_size_,
-            num_segment_blocks_ - se.offset % num_segment_blocks_, b_size);
+            b_offset, num_segment_blocks_ - b_offset % num_segment_blocks_,
+            b_size);
 
         if (merged_blocks > 0) {
           // Persist merged free entry on PMem
@@ -372,8 +373,7 @@ bool Freelist::MergeGet(uint32_t size, SizedSpaceEntry *space_entry) {
       assert(cache_list[i][j].offset % block_size_ == 0);
       auto b_offset = cache_list[i][j].offset / block_size_;
       uint64_t merged_blocks = MergeSpace(
-          b_offset,
-          num_segment_blocks_ - cache_list[i][j].offset % num_segment_blocks_,
+          b_offset, num_segment_blocks_ - b_offset % num_segment_blocks_,
           b_size);
       if (merged_blocks >= b_size) {
         space_entry->space_entry = cache_list[i][j];

--- a/engine/pmem_allocator/pmem_allocator.hpp
+++ b/engine/pmem_allocator/pmem_allocator.hpp
@@ -115,7 +115,7 @@ private:
     char padding[64 - sizeof(SizedSpaceEntry) * 2];
   };
 
-  void AllocateSegmentSpace(SizedSpaceEntry *segment_entry);
+  bool AllocateSegmentSpace(SizedSpaceEntry *segment_entry);
 
   static bool CheckDevDaxAndGetSize(const char *path, uint64_t *size);
 

--- a/engine/utils.hpp
+++ b/engine/utils.hpp
@@ -116,6 +116,14 @@ static inline int compare_string_view(const pmem::obj::string_view &src,
   return src.size() - target.size();
 }
 
+static inline bool equal_string_view(const pmem::obj::string_view &src,
+                                     const pmem::obj::string_view &target) {
+  if (src.size() == target.size()) {
+    return compare_string_view(src, target) == 0;
+  }
+  return false;
+}
+
 class Slice {
 public:
   Slice() : _data(nullptr), _size(0) {}

--- a/tests/stress_test.cpp
+++ b/tests/stress_test.cpp
@@ -21,10 +21,10 @@
 // to keep track of the kv-pairs in a certain collection in the engine instance
 namespace kvdk_testing {
 // Check value got by XGet(key) by looking up possible_kv_pairs
-static void
-CheckKVPair(pmem::obj::string_view key, pmem::obj::string_view value,
-            std::unordered_multimap<std::string_view, std::string_view> const
-                &possible_kv_pairs) {
+static void CheckKVPair(
+    pmem::obj::string_view key, pmem::obj::string_view value,
+    std::unordered_multimap<pmem::obj::string_view,
+                            pmem::obj::string_view> const &possible_kv_pairs) {
   bool match = false;
   auto range_found = possible_kv_pairs.equal_range(key);
   ASSERT_NE(range_found.first, range_found.second)
@@ -47,14 +47,14 @@ CheckKVPair(pmem::obj::string_view key, pmem::obj::string_view value,
 // possible_kv_pairs is searched to try to find a match with iterated records
 // possible_kv_pairs is copied because HashesIterateThrough erase entries to
 // keep track of records
-static void
-HashesIterateThrough(kvdk::Engine *engine, std::string collection_name,
-                     std::unordered_multimap<std::string_view, std::string_view>
-                         possible_kv_pairs,
-                     bool report_progress) {
+static void HashesIterateThrough(
+    kvdk::Engine *engine, std::string collection_name,
+    std::unordered_multimap<pmem::obj::string_view, pmem::obj::string_view>
+        possible_kv_pairs,
+    bool report_progress) {
   kvdk::Status status;
 
-  std::unordered_multimap<std::string_view, std::string_view>
+  std::unordered_multimap<pmem::obj::string_view, pmem::obj::string_view>
       possible_kv_pairs_copy{possible_kv_pairs};
 
   auto u_iter = engine->NewUnorderedIterator(collection_name);
@@ -138,7 +138,7 @@ HashesIterateThrough(kvdk::Engine *engine, std::string collection_name,
 // keep track of records
 static void SortedSetsIterateThrough(
     kvdk::Engine *engine, std::string collection_name,
-    std::unordered_multimap<std::string_view, std::string_view>
+    std::unordered_multimap<pmem::obj::string_view, pmem::obj::string_view>
         possible_kv_pairs,
     bool report_progress) {
   kvdk::Status status;
@@ -375,15 +375,17 @@ protected:
   size_t sz_value_max;
 
   // Actual keys an values used by thread for insertion
-  std::vector<std::vector<std::string_view>> grouped_keys;
-  std::vector<std::vector<std::string_view>> grouped_values;
+  std::vector<std::vector<pmem::obj::string_view>> grouped_keys;
+  std::vector<std::vector<pmem::obj::string_view>> grouped_values;
 
   // unordered_map[collection_name, unordered_multimap[key, value]]
   std::unordered_map<
-      std::string, std::unordered_multimap<std::string_view, std::string_view>>
+      std::string,
+      std::unordered_multimap<pmem::obj::string_view, pmem::obj::string_view>>
       hashes_possible_kv_pairs;
   std::unordered_map<
-      std::string, std::unordered_multimap<std::string_view, std::string_view>>
+      std::string,
+      std::unordered_multimap<pmem::obj::string_view, pmem::obj::string_view>>
       sorted_sets_possible_kv_pairs;
 
 private:
@@ -573,7 +575,8 @@ private:
   }
 
   void updatePossibleKVPairs(
-      std::unordered_multimap<std::string_view, std::string_view> &possible_kvs,
+      std::unordered_multimap<pmem::obj::string_view, pmem::obj::string_view>
+          &possible_kvs,
       bool odd_indexed_is_deleted) {
     {
       // Erase keys that will be overwritten
@@ -596,7 +599,7 @@ private:
 
         // For every thread, every key has only one possible value or state
         // We use kvs to track that and then put those into possible_kvs
-        std::unordered_map<std::string_view, std::string_view> kvs;
+        std::unordered_map<pmem::obj::string_view, pmem::obj::string_view> kvs;
         for (size_t i = 0; i < grouped_keys[tid].size(); i++) {
           if ((i % 2 == 0) || !odd_indexed_is_deleted)
             kvs[grouped_keys[tid][i]] = grouped_values[tid][i];


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:

In MatchHashEntry of SearchForRead, if searching key is updated, and the original space used by another key before compare key in MatchHashEntry, then the search will return NotFound.

### What is changed and how it works?

What's Changed:
- check if hash entry modified after MatchHashEntry fail in SearchForRead
- there are also some trivial modifications on PMEMAllocator and stress tests in this patch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

Side effects

- Performance regression
    Need to check if hash entry modified after every MatchHashEntry for read operations, but no significant performance regression observed.
