### PR TITLE
Minor fix

### DIFF
--- a/engine/data_record.hpp
+++ b/engine/data_record.hpp
@@ -49,7 +49,7 @@ struct DataHeader {
 struct DataMeta {
   DataMeta() = default;
   DataMeta(uint64_t _timestamp, RecordType _record_type, uint16_t _key_size,
-           uint16_t _value_size)
+           uint32_t _value_size)
       : timestamp(_timestamp), type(_record_type), k_size(_key_size),
         v_size(_value_size) {}
 
@@ -64,7 +64,7 @@ struct DataEntry {
   // TODO jiayu: use typename for timestamp and record type instead of a number
   DataEntry(uint32_t _checksum, uint32_t _record_size /* size in blocks */,
             uint64_t _timestamp, RecordType _record_type, uint16_t _key_size,
-            uint16_t _value_size)
+            uint32_t _value_size)
       : header(_checksum, _record_size),
         meta(_timestamp, _record_type, _key_size, _value_size) {}
 


### PR DESCRIPTION
<!--
Thank you for contributing to KVDK.

### What problem does this PR solve?
Setting a value with size larger than 65535 bytes will fail.

Problem Summary:

### What is changed and how it works?
1. Fix type of _value_size to uint32_t in constructors of DataEntry and DataMeta

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

Side effects
Not measured.
