### PR TITLE
Skiplist: Refactoring write functions, update lock machanism and more correctness checks in insert

### DIFF
--- a/engine/data_record.hpp
+++ b/engine/data_record.hpp
@@ -109,12 +109,12 @@ public:
   void Destroy() { entry.Destroy(); }
 
   // make sure there is data followed in data[0]
-  pmem::obj::string_view Key() {
+  pmem::obj::string_view Key() const {
     return pmem::obj::string_view(data, entry.meta.k_size);
   }
 
   // make sure there is data followed in data[0]
-  pmem::obj::string_view Value() {
+  pmem::obj::string_view Value() const {
     return pmem::obj::string_view(data + entry.meta.k_size, entry.meta.v_size);
   }
 
@@ -202,11 +202,11 @@ public:
     return false;
   }
 
-  pmem::obj::string_view Key() {
+  pmem::obj::string_view Key() const {
     return pmem::obj::string_view(data, entry.meta.k_size);
   }
 
-  pmem::obj::string_view Value() {
+  pmem::obj::string_view Value() const {
     return pmem::obj::string_view(data + entry.meta.k_size, entry.meta.v_size);
   }
 

--- a/engine/kv_engine.cpp
+++ b/engine/kv_engine.cpp
@@ -842,7 +842,6 @@ Status KVEngine::Delete(const pmem::obj::string_view key) {
 
 Status KVEngine::SDeleteImpl(Skiplist *skiplist,
                              const pmem::obj::string_view &user_key) {
-  uint64_t id = skiplist->id();
   std::string collection_key(skiplist->InternalKey(user_key));
   if (!CheckKeySize(collection_key)) {
     return Status::InvalidDataSize;

--- a/engine/kv_engine.cpp
+++ b/engine/kv_engine.cpp
@@ -884,7 +884,7 @@ Status KVEngine::SDeleteImpl(Skiplist *skiplist,
     std::unique_lock<SpinMutex> prev_record_lock;
     thread_local Splice splice(nullptr);
     splice.seeking_list = skiplist;
-    if (!skiplist->FindUpdatePos(&splice, user_key, hint, existing_record,
+    if (!skiplist->FindUpdatePos(&splice, user_key, hint.spin, existing_record,
                                  &prev_record_lock)) {
       continue;
     }
@@ -951,9 +951,9 @@ Status KVEngine::SSetImpl(Skiplist *skiplist,
     std::unique_lock<SpinMutex> prev_record_lock;
     thread_local Splice splice(nullptr);
     splice.seeking_list = skiplist;
-    if (found ? (!skiplist->FindUpdatePos(&splice, user_key, hint,
+    if (found ? (!skiplist->FindUpdatePos(&splice, user_key, hint.spin,
                                           existing_record, &prev_record_lock))
-              : (!skiplist->FindInsertPos(&splice, user_key, hint,
+              : (!skiplist->FindInsertPos(&splice, user_key, hint.spin,
                                           &prev_record_lock))) {
       continue;
     }

--- a/engine/kv_engine.cpp
+++ b/engine/kv_engine.cpp
@@ -884,8 +884,8 @@ Status KVEngine::SDeleteImpl(Skiplist *skiplist,
     std::unique_lock<SpinMutex> prev_record_lock;
     thread_local Splice splice(nullptr);
     splice.seeking_list = skiplist;
-    if (!skiplist->FindWritePos(&splice, user_key, hint, existing_record,
-                                &prev_record_lock)) {
+    if (!skiplist->FindUpdatePos(&splice, user_key, hint, existing_record,
+                                 &prev_record_lock)) {
       continue;
     }
 
@@ -951,9 +951,10 @@ Status KVEngine::SSetImpl(Skiplist *skiplist,
     std::unique_lock<SpinMutex> prev_record_lock;
     thread_local Splice splice(nullptr);
     splice.seeking_list = skiplist;
-    if (!skiplist->FindWritePos(&splice, user_key, hint,
-                                found ? existing_record : nullptr,
-                                &prev_record_lock)) {
+    if (found ? (!skiplist->FindUpdatePos(&splice, user_key, hint,
+                                          existing_record, &prev_record_lock))
+              : (!skiplist->FindInsertPos(&splice, user_key, hint,
+                                          &prev_record_lock))) {
       continue;
     }
 

--- a/engine/kv_engine.cpp
+++ b/engine/kv_engine.cpp
@@ -896,8 +896,7 @@ Status KVEngine::SDeleteImpl(Skiplist *skiplist,
 Status KVEngine::SSetImpl(Skiplist *skiplist,
                           const pmem::obj::string_view &user_key,
                           const pmem::obj::string_view &value) {
-  uint64_t id = skiplist->id();
-  std::string collection_key(PersistentList::ListKey(user_key, id));
+  std::string collection_key(skiplist->InternalKey(user_key));
   if (!CheckKeySize(collection_key) || !CheckValueSize(value)) {
     return Status::InvalidDataSize;
   }
@@ -1255,8 +1254,7 @@ Status KVEngine::SGet(const pmem::obj::string_view collection,
     return s;
   }
   assert(skiplist);
-  uint64_t id = skiplist->id();
-  std::string skiplist_key(PersistentList::ListKey(user_key, id));
+  std::string skiplist_key(skiplist->InternalKey(user_key));
   return HashGetImpl(skiplist_key, value, SortedDataRecord);
 }
 

--- a/engine/kv_engine.cpp
+++ b/engine/kv_engine.cpp
@@ -843,7 +843,7 @@ Status KVEngine::Delete(const pmem::obj::string_view key) {
 Status KVEngine::SDeleteImpl(Skiplist *skiplist,
                              const pmem::obj::string_view &user_key) {
   uint64_t id = skiplist->id();
-  std::string collection_key(PersistentList::ListKey(user_key, id));
+  std::string collection_key(skiplist->InternalKey(user_key));
   if (!CheckKeySize(collection_key)) {
     return Status::InvalidDataSize;
   }

--- a/engine/kv_engine.cpp
+++ b/engine/kv_engine.cpp
@@ -520,7 +520,7 @@ Status KVEngine::RestoreSkiplistRecord(DLRecord *pmem_record,
       new_hash_offset = (uint64_t)dram_node;
       if (configs_.opt_large_sorted_collection_restore &&
           thread_res_[write_thread.id]
-                      .visited_skiplist_ids[dram_node->GetSkipListId()]++ %
+                      .visited_skiplist_ids[dram_node->SkiplistId()]++ %
                   kRestoreSkiplistStride ==
               0) {
         std::lock_guard<std::mutex> lg(list_mu_);

--- a/engine/pmem_allocator/pmem_allocator.hpp
+++ b/engine/pmem_allocator/pmem_allocator.hpp
@@ -69,14 +69,14 @@ public:
   }
 
   // translate address of allocated space to block_offset
-  inline uint64_t addr2offset_checked(void *addr) {
+  inline uint64_t addr2offset_checked(const void *addr) {
     assert((char *)addr >= pmem_);
     uint64_t offset = (char *)addr - pmem_;
     assert(validate_offset(offset) && "Trying to create invalid offset");
     return offset;
   }
 
-  inline uint64_t addr2offset(void *addr) {
+  inline uint64_t addr2offset(const void *addr) {
     if (addr) {
       uint64_t offset = (char *)addr - pmem_;
       if (validate_offset(offset)) {

--- a/engine/skiplist.cpp
+++ b/engine/skiplist.cpp
@@ -239,13 +239,13 @@ bool Skiplist::FindUpdatePos(Splice *splice,
     // As updating record is already locked, so we don't need to
     // check its next
     if (updated_record->prev != prev_offset ||
-        prev->next != pmem_allocator_->addr2offset((void *)updated_record)) {
+        prev->next != pmem_allocator_->addr2offset(updated_record)) {
       continue;
     }
 
     assert(updated_record->prev == prev_offset);
     assert(updated_record->next == next_offset);
-    assert(next->prev == pmem_allocator_->addr2offset((void *)updated_record));
+    assert(next->prev == pmem_allocator_->addr2offset(updated_record));
     assert(prev == header_->record ||
            compare_string_view(Skiplist::UserKey(prev->Key()), updated_key) <
                0);

--- a/engine/skiplist.cpp
+++ b/engine/skiplist.cpp
@@ -289,6 +289,8 @@ bool Skiplist::FindInsertPos(Splice *splice,
     // or:
     // this skip list: record1 -> record2
     // another skip list:"new record reuse prev" -> "new record reuse next" ->
+    // In this case, inserting record will be mis-inserted between "new record
+    // reuse prev" and "new record reuse next"
     auto check_id = [&]() {
       return SkiplistId(next) == id_ && SkiplistId(prev) == id_;
     };

--- a/engine/skiplist.cpp
+++ b/engine/skiplist.cpp
@@ -303,7 +303,8 @@ bool Skiplist::FindInsertPos(Splice *splice,
 bool Skiplist::Insert(const pmem::obj::string_view &key,
                       const pmem::obj::string_view &value,
                       const SizedSpaceEntry &space_to_write, uint64_t timestamp,
-                      SkiplistNode **dram_node, SpinMutex *inserting_key_lock) {
+                      SkiplistNode **dram_node,
+                      const SpinMutex *inserting_key_lock) {
   Splice splice(this);
   std::unique_lock<SpinMutex> prev_record_lock;
   if (!FindInsertPos(&splice, key, inserting_key_lock, &prev_record_lock)) {
@@ -350,7 +351,8 @@ bool Skiplist::Update(const pmem::obj::string_view &key,
                       const pmem::obj::string_view &value,
                       const DLRecord *updated_record,
                       const SizedSpaceEntry &space_to_write, uint64_t timestamp,
-                      SkiplistNode *dram_node, SpinMutex *updating_key_lock) {
+                      SkiplistNode *dram_node,
+                      const SpinMutex *updating_key_lock) {
   Splice splice(this);
   std::unique_lock<SpinMutex> prev_record_lock;
   if (!FindUpdatePos(&splice, key, updating_key_lock, updated_record,
@@ -376,7 +378,7 @@ bool Skiplist::Update(const pmem::obj::string_view &key,
 
 bool Skiplist::Delete(const pmem::obj::string_view &key,
                       DLRecord *deleted_record, SkiplistNode *dram_node,
-                      SpinMutex *deleting_key_lock) {
+                      const SpinMutex *deleting_key_lock) {
   Splice splice(this);
   std::unique_lock<SpinMutex> prev_record_lock;
   if (!FindDeletePos(&splice, key, deleting_key_lock, deleted_record,

--- a/engine/skiplist.cpp
+++ b/engine/skiplist.cpp
@@ -156,11 +156,7 @@ void Skiplist::Seek(const pmem::obj::string_view &key, Splice *result_splice) {
   result_splice->prev_pmem_record = prev_record;
 }
 
-uint64_t SkiplistNode::GetSkipListId() {
-  uint64_t id;
-  memcpy_8(&id, record->Key().data());
-  return id;
-}
+uint64_t SkiplistNode::GetSkipListId() { return Skiplist::SkiplistId(record); }
 
 Status Skiplist::CheckConnection(int height) {
   SkiplistNode *cur_node = header_;

--- a/engine/skiplist.hpp
+++ b/engine/skiplist.hpp
@@ -79,7 +79,7 @@ public:
 
   pmem::obj::string_view UserKey();
 
-  uint64_t GetSkipListId();
+  uint64_t SkiplistId();
 
   PointerWithTag<SkiplistNode> Next(int l) {
     assert(l > 0 && l <= height && "should be less than node's height");
@@ -198,6 +198,19 @@ public:
                                   skiplist_key.size() - 8);
   }
 
+  inline static pmem::obj::string_view UserKey(const SkiplistNode *node) {
+    assert(node != nullptr);
+    if (node->cached_key_size > 0) {
+      return pmem::obj::string_view(node->cached_key, node->cached_key_size);
+    }
+    return UserKey(node->record->Key());
+  }
+
+  inline static pmem::obj::string_view UserKey(const DLRecord *record) {
+    assert(record != nullptr);
+    return UserKey(record->Key());
+  }
+
   inline static uint64_t
   SkiplistId(const pmem::obj::string_view &skiplist_key) {
     uint64_t id;
@@ -205,7 +218,8 @@ public:
     return id;
   }
 
-  inline static uint64_t SkiplistId(DLRecord *record) {
+  inline static uint64_t SkiplistId(const DLRecord *record) {
+    assert(record != nullptr);
     uint64_t id = 0;
     switch (record->entry.meta.type) {
     case RecordType::SortedDataRecord:
@@ -219,6 +233,11 @@ public:
       break;
     }
     return id;
+  }
+
+  inline static uint64_t SkiplistId(const SkiplistNode *node) {
+    assert(node != nullptr);
+    return SkiplistId(node->record);
   }
 
   // Start position of "key" on both dram and PMem node in the skiplist, and

--- a/engine/skiplist.hpp
+++ b/engine/skiplist.hpp
@@ -201,15 +201,20 @@ public:
 
   Status Rebuild();
 
-  // Find skiplist position to write "key", store prev dram nodes and
+  // Find and lock skiplist position to insert "key", store prev dram nodes and
   // prev/next PMem DLRecord in "splice", and lock prev DLRecord
-  // The insert_key should be already locked before call this function
-  // If it's a update, pass updated DLRecord with updated_record, otherwise set
-  // it to nullptr
-  bool FindWritePos(Splice *splice, const pmem::obj::string_view &insert_key,
-                    const HashTable::KeyHashHint &hint,
-                    const DLRecord *updated_record,
-                    std::unique_lock<SpinMutex> *write_pos_lock);
+  // The "insert_key" should be already locked before call this function
+  bool FindInsertPos(Splice *splice, const pmem::obj::string_view &insert_key,
+                     const HashTable::KeyHashHint &hint,
+                     std::unique_lock<SpinMutex> *prev_record_lock);
+
+  // Find and lock skiplist position to update or delete "key", store prev/next
+  // PMem DLRecord in "splice", and lock prev DLRecord.
+  //  The "updated_key" should be already locked before call this function
+  bool FindUpdatePos(Splice *splice, const pmem::obj::string_view &updated_key,
+                     const HashTable::KeyHashHint &hint,
+                     const DLRecord *updated_record,
+                     std::unique_lock<SpinMutex> *prev_record_lock);
 
   // Remove "deleting_record" from dram and PMem part of the skiplist
   void DeleteRecord(DLRecord *deleting_record, Splice *delete_splice,

--- a/engine/skiplist.hpp
+++ b/engine/skiplist.hpp
@@ -247,15 +247,12 @@ public:
   bool Delete(const pmem::obj::string_view &key, DLRecord *deleted_record,
               SkiplistNode *dram_node, SpinMutex *deleting_key_lock);
 
-  // Remove "deleting_record" from dram and PMem part of the skiplist
-  void DeleteRecord(DLRecord *deleting_record, Splice *delete_splice,
-                    SkiplistNode *dram_node);
-
-  void UpdateRecord(Splice *update_splice, DLRecord *new_record,
-                    SkiplistNode *dram_node);
-
-  SkiplistNode *InsertRecord(Splice *insert_splice, DLRecord *new_record,
-                             const pmem::obj::string_view &key);
+  void ObsoleteNodes(const std::vector<SkiplistNode *> nodes) {
+    std::lock_guard<SpinMutex> lg(obsolete_nodes_spin_);
+    for (SkiplistNode *node : nodes) {
+      obsolete_nodes_.push_back(node);
+    }
+  }
 
   void PurgeObsoletedNodes() {
     std::lock_guard<SpinMutex> lg_a(pending_delete_nodes_spin_);
@@ -273,13 +270,6 @@ public:
   Status CheckConnection(int height);
 
 private:
-  void ObsoleteNodes(const std::vector<SkiplistNode *> nodes) {
-    std::lock_guard<SpinMutex> lg(obsolete_nodes_spin_);
-    for (SkiplistNode *node : nodes) {
-      obsolete_nodes_.push_back(node);
-    }
-  }
-
   // Insert DLRecord "inserting" between "prev" and "next"
   void InsertDLRecord(DLRecord *prev, DLRecord *next, DLRecord *inserting);
 

--- a/engine/skiplist.hpp
+++ b/engine/skiplist.hpp
@@ -201,10 +201,15 @@ public:
 
   Status Rebuild();
 
-  bool FindAndLockWritePos(std::vector<SpinMutex *> &spins, Splice *splice,
-                           const pmem::obj::string_view &insert_key,
-                           const HashTable::KeyHashHint &hint,
-                           const DLRecord *updated_record);
+  // Find skiplist position to write "key", store prev dram nodes and
+  // prev/next PMem DLRecord in "splice", and lock prev DLRecord
+  // The insert_key should be already locked before call this function
+  // If it's a update, pass updated DLRecord with updated_record, otherwise set
+  // it to nullptr
+  bool FindWritePos(Splice *splice, const pmem::obj::string_view &insert_key,
+                    const HashTable::KeyHashHint &hint,
+                    const DLRecord *updated_record,
+                    std::unique_lock<SpinMutex> *write_pos_lock);
 
   // Remove "deleting_record" from dram and PMem part of the skiplist
   void DeleteRecord(DLRecord *deleting_record, Splice *delete_splice,

--- a/engine/skiplist.hpp
+++ b/engine/skiplist.hpp
@@ -198,6 +198,29 @@ public:
                                   skiplist_key.size() - 8);
   }
 
+  inline static uint64_t
+  SkiplistId(const pmem::obj::string_view &skiplist_key) {
+    uint64_t id;
+    memcpy_8(&id, skiplist_key.data());
+    return id;
+  }
+
+  inline static uint64_t SkiplistId(DLRecord *record) {
+    uint64_t id = 0;
+    switch (record->entry.meta.type) {
+    case RecordType::SortedDataRecord:
+      id = SkiplistId(record->Key());
+      break;
+    case RecordType::SortedHeaderRecord:
+      memcpy_8(&id, record->Value().data());
+      break;
+    default:
+      kvdk_assert(false, "Wrong type in SkiplistId");
+      break;
+    }
+    return id;
+  }
+
   // Start position of "key" on both dram and PMem node in the skiplist, and
   // store position in "result_splice". If "key" existing, the next pointers in
   // splice point to node of "key"

--- a/engine/skiplist.hpp
+++ b/engine/skiplist.hpp
@@ -217,7 +217,7 @@ public:
   bool Insert(const pmem::obj::string_view &key,
               const pmem::obj::string_view &value,
               const SizedSpaceEntry &space_to_write, uint64_t timestamp,
-              SkiplistNode **dram_node, SpinMutex *inserting_key_lock);
+              SkiplistNode **dram_node, const SpinMutex *inserting_key_lock);
 
   // Update "key" in skiplist
   //
@@ -233,7 +233,7 @@ public:
               const pmem::obj::string_view &value,
               const DLRecord *updated_record,
               const SizedSpaceEntry &space_to_write, uint64_t timestamp,
-              SkiplistNode *dram_node, SpinMutex *updating_key_lock);
+              SkiplistNode *dram_node, const SpinMutex *updating_key_lock);
 
   // Delete "key" from skiplist
   //
@@ -245,7 +245,7 @@ public:
   //
   // Return true on success, return false on fail.
   bool Delete(const pmem::obj::string_view &key, DLRecord *deleted_record,
-              SkiplistNode *dram_node, SpinMutex *deleting_key_lock);
+              SkiplistNode *dram_node, const SpinMutex *deleting_key_lock);
 
   void ObsoleteNodes(const std::vector<SkiplistNode *> nodes) {
     std::lock_guard<SpinMutex> lg(obsolete_nodes_spin_);

--- a/engine/skiplist.hpp
+++ b/engine/skiplist.hpp
@@ -315,16 +315,22 @@ private:
   // Insert DLRecord "inserting" between "prev" and "next"
   void InsertDLRecord(DLRecord *prev, DLRecord *next, DLRecord *inserting);
 
-  // Find and lock skiplist position to insert "key", store prev dram nodes
-  // and prev/next PMem DLRecord in "splice", and lock prev DLRecord The
-  // "insert_key" should be already locked before call this function
+  // Find and lock skiplist position to insert "key"
+  //
+  // Store prev dram nodes and prev/next PMem DLRecord in "splice", lock
+  // prev DLRecord and manage the lock with "prev_record_lock".
+  //
+  // The "insert_key" should be already locked before call this function
   bool FindInsertPos(Splice *splice,
                      const pmem::obj::string_view &inserting_key,
                      const SpinMutex *inserting_key_lock,
                      std::unique_lock<SpinMutex> *prev_record_lock);
 
-  // Find and lock skiplist position to update or delete "key", store prev/next
-  // PMem DLRecord in "splice", and lock prev DLRecord.
+  // Find and lock skiplist position to update"key".
+  //
+  // Store prev/next PMem DLRecord in "splice", lock prev DLRecord and manage
+  // the lock with "prev_record_lock".
+  //
   //  The "updated_key" should be already locked before call this function
   bool FindUpdatePos(Splice *splice, const pmem::obj::string_view &updating_key,
                      const SpinMutex *updating_key_lock,

--- a/engine/skiplist.hpp
+++ b/engine/skiplist.hpp
@@ -221,15 +221,16 @@ public:
   // Find and lock skiplist position to insert "key", store prev dram nodes
   // and prev/next PMem DLRecord in "splice", and lock prev DLRecord The
   // "insert_key" should be already locked before call this function
-  bool FindInsertPos(Splice *splice, const pmem::obj::string_view &insert_key,
-                     const HashTable::KeyHashHint &hint,
+  bool FindInsertPos(Splice *splice,
+                     const pmem::obj::string_view &inserting_key,
+                     const SpinMutex *inserting_key_lock,
                      std::unique_lock<SpinMutex> *prev_record_lock);
 
   // Find and lock skiplist position to update or delete "key", store prev/next
   // PMem DLRecord in "splice", and lock prev DLRecord.
   //  The "updated_key" should be already locked before call this function
-  bool FindUpdatePos(Splice *splice, const pmem::obj::string_view &updated_key,
-                     const HashTable::KeyHashHint &hint,
+  bool FindUpdatePos(Splice *splice, const pmem::obj::string_view &updating_key,
+                     const SpinMutex *updating_key_lock,
                      const DLRecord *updated_record,
                      std::unique_lock<SpinMutex> *prev_record_lock);
 

--- a/engine/snapshot.hpp
+++ b/engine/snapshot.hpp
@@ -1,0 +1,7 @@
+#include "utils.hpp"
+
+namespace KVDK_NAMESPACE {
+struct Snapshot {
+  uint64_t timestamp;
+};
+} // namespace KVDK_NAMESPACE


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:

Issue Number: close #104  <!-- REMOVE this line if no issue to close -->

1. Write functions of skiplist is messy
2. We only need lock two nodes for write operations, so we can reduce contentions
3. Current linkage check in skiplist is not enought, a new record may be inserted to a wrong place if prev and next records both freed, then inserted to another position while keep linkage between each other

For example:

Before Insert:
this skip list: record1 -> "prev" -> "next" -> record2
After lock prev and next:
this skip list: "new record reuse prev" -> "new record reuse next" ->
record1 -> record2
or:
this skip list: record1 -> record2
another skip list: "new record reuse prev" -> "new record reuse next" ->
Then inserting record will be inserted between "new record reuse prev" and  "new record reuse next"

### What is changed and how it works?

What's Changed:

1. Refactor write functions of skiplist to make it more maintainable
2. Modify lock machanism of skiplist writes, only lock inserting/updating/deleting key and its previou key in write operations.
3. check skiplist id of prev and next records, and key order among prev, next and inserting record after acquiring locks

Tests <!-- At least one of them must be included. -->

- Unit test
- Stress test

Side effects

Performance of zipf update has 10% improvement as lock contentions is reduced
Performance of random insert has 3% decreasement as we need to do more checks after seek insert position
