### PR TITLE
Skiplist bug fix: SeekNode

### DIFF
--- a/engine/skiplist.cpp
+++ b/engine/skiplist.cpp
@@ -40,6 +40,8 @@ void SkiplistNode::SeekNode(const pmem::obj::string_view &key,
           prev = this;
         } else {
           // this node has been deleted, so seek from header
+          kvdk_assert(result_splice->seeking_list != nullptr,
+                      "skiplist must be set for seek operation!");
           return result_splice->seeking_list->header()->SeekNode(
               key, kMaxHeight, end_height, result_splice);
         }

--- a/engine/skiplist.cpp
+++ b/engine/skiplist.cpp
@@ -34,13 +34,14 @@ void SkiplistNode::SeekNode(const pmem::obj::string_view &key,
         if (i < start_height) {
           i++;
           prev = result_splice->prevs[i];
-        } else if (prev == this) {
-          // this node has been deleted, so seek from header
-          assert(result_splice->seeking_list);
-          prev = result_splice->seeking_list->header();
-          i = kMaxHeight;
-        } else {
+        } else if (prev != this) {
+          // re-seek from this node for start height
+          i = start_height;
           prev = this;
+        } else {
+          // this node has been deleted, so seek from header
+          return result_splice->seeking_list->header()->SeekNode(
+              key, kMaxHeight, end_height, result_splice);
         }
         continue;
       }


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:

Skiplist may seek to a invalid height in SeekNode

### What is changed and how it works?

What's Changed:

Reset seeking height while a deleted dram node detected

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Stress test

Side effects

- Performance regression
    no
