### PR TITLE
Use alias TimeStampType and StringView

### DIFF
--- a/engine/alias.hpp
+++ b/engine/alias.hpp
@@ -6,7 +6,7 @@
 
 #include <cinttypes>
 
-#include "../libpmemobj++/string_view.hpp"
+#include "libpmem.h"
 
 namespace KVDK_NAMESPACE {
 using StringView = pmem::obj::string_view;

--- a/engine/alias.hpp
+++ b/engine/alias.hpp
@@ -1,3 +1,9 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright(c) 2021 Intel Corporation
+ */
+
+#pragma once
+
 #include <cinttypes>
 
 #include "../libpmemobj++/string_view.hpp"

--- a/engine/c.cc
+++ b/engine/c.cc
@@ -161,17 +161,15 @@ KVDKStatus KVDKSortedDelete(KVDKEngine *engine, const char *collection,
 KVDKStatus KVDKHashSet(KVDKEngine *engine, const char *collection,
                        size_t collection_len, const char *key, size_t key_len,
                        const char *val, size_t val_len) {
-  return engine->rep->HSet(pmem::obj::string_view(collection, collection_len),
-                           pmem::obj::string_view(key, key_len),
-                           pmem::obj::string_view(val, val_len));
+  return engine->rep->HSet(StringView(collection, collection_len),
+                           StringView(key, key_len), StringView(val, val_len));
 }
 
 KVDKStatus KVDKHashDelete(KVDKEngine *engine, const char *collection,
                           size_t collection_len, const char *key,
                           size_t key_len) {
-  return engine->rep->HDelete(
-      pmem::obj::string_view(collection, collection_len),
-      pmem::obj::string_view(key, key_len));
+  return engine->rep->HDelete(StringView(collection, collection_len),
+                              StringView(key, key_len));
 }
 
 KVDKStatus KVDKHashGet(KVDKEngine *engine, const char *collection,
@@ -179,9 +177,8 @@ KVDKStatus KVDKHashGet(KVDKEngine *engine, const char *collection,
                        size_t *val_len, char **val) {
   std::string val_str;
   *val = nullptr;
-  KVDKStatus s =
-      engine->rep->HGet(pmem::obj::string_view(collection, collection_len),
-                        pmem::obj::string_view(key, key_len), &val_str);
+  KVDKStatus s = engine->rep->HGet(StringView(collection, collection_len),
+                                   StringView(key, key_len), &val_str);
   if (s != KVDKStatus::Ok) {
     *val_len = 0;
     return s;

--- a/engine/data_record.cpp
+++ b/engine/data_record.cpp
@@ -3,6 +3,7 @@
  */
 
 #include "data_record.hpp"
+#include "alias.hpp"
 #include "libpmem.h"
 
 namespace KVDK_NAMESPACE {
@@ -11,7 +12,7 @@ thread_local std::string thread_data_buffer;
 static constexpr int kDataBufferSize = 1024 * 1024;
 
 StringRecord *StringRecord::PersistStringRecord(
-    void *addr, uint32_t record_size, uint64_t timestamp, RecordType type,
+    void *addr, uint32_t record_size, TimeStampType timestamp, RecordType type,
     const StringView &key, const StringView &value) {
   void *data_cpy_target;
   auto write_size = key.size() + value.size() + sizeof(StringRecord);
@@ -37,7 +38,7 @@ StringRecord *StringRecord::PersistStringRecord(
 }
 
 DLRecord *DLRecord::PersistDLRecord(void *addr, uint32_t record_size,
-                                    uint64_t timestamp, RecordType type,
+                                    TimeStampType timestamp, RecordType type,
                                     uint64_t prev, uint64_t next,
                                     const StringView &key,
                                     const StringView &value) {

--- a/engine/data_record.hpp
+++ b/engine/data_record.hpp
@@ -50,12 +50,12 @@ struct DataHeader {
 
 struct DataMeta {
   DataMeta() = default;
-  DataMeta(uint64_t _timestamp, RecordType _record_type, uint16_t _key_size,
-           uint32_t _value_size)
+  DataMeta(TimeStampType _timestamp, RecordType _record_type,
+           uint16_t _key_size, uint32_t _value_size)
       : timestamp(_timestamp), type(_record_type), k_size(_key_size),
         v_size(_value_size) {}
 
-  uint64_t timestamp;
+  TimeStampType timestamp;
   RecordType type;
   uint16_t k_size;
   uint32_t v_size;
@@ -65,15 +65,15 @@ struct DataMeta {
 struct DataEntry {
   // TODO jiayu: use typename for timestamp and record type instead of a number
   DataEntry(uint32_t _checksum, uint32_t _record_size /* size in blocks */,
-            uint64_t _timestamp, RecordType _record_type, uint16_t _key_size,
-            uint32_t _value_size)
+            TimeStampType _timestamp, RecordType _record_type,
+            uint16_t _key_size, uint32_t _value_size)
       : header(_checksum, _record_size),
         meta(_timestamp, _record_type, _key_size, _value_size) {}
 
   DataEntry() = default;
 
   void Destroy() {
-    meta.type == RecordType::Padding;
+    meta.type = RecordType::Padding;
     pmem_persist(&meta.type, sizeof(RecordType));
   }
 
@@ -94,9 +94,8 @@ public:
   // should larger than sizeof(StringRecord) + key size + value size
   static StringRecord *
   ConstructStringRecord(void *target_address, uint32_t _record_size,
-                        uint64_t _timestamp, RecordType _record_type,
-                        const pmem::obj::string_view &_key,
-                        const pmem::obj::string_view &_value) {
+                        TimeStampType _timestamp, RecordType _record_type,
+                        const StringView &_key, const StringView &_value) {
     StringRecord *record = new (target_address)
         StringRecord(_record_size, _timestamp, _record_type, _key, _value);
     return record;
@@ -104,20 +103,19 @@ public:
 
   // Construct and persist a string record at pmem address "addr"
   static StringRecord *PersistStringRecord(void *addr, uint32_t record_size,
-                                           uint64_t timestamp, RecordType type,
-                                           const pmem::obj::string_view &key,
-                                           const pmem::obj::string_view &value);
+                                           TimeStampType timestamp,
+                                           RecordType type,
+                                           const StringView &key,
+                                           const StringView &value);
 
   void Destroy() { entry.Destroy(); }
 
   // make sure there is data followed in data[0]
-  pmem::obj::string_view Key() const {
-    return pmem::obj::string_view(data, entry.meta.k_size);
-  }
+  StringView Key() const { return StringView(data, entry.meta.k_size); }
 
   // make sure there is data followed in data[0]
-  pmem::obj::string_view Value() const {
-    return pmem::obj::string_view(data + entry.meta.k_size, entry.meta.v_size);
+  StringView Value() const {
+    return StringView(data + entry.meta.k_size, entry.meta.v_size);
   }
 
   // Check whether the record corrupted
@@ -137,9 +135,9 @@ public:
   }
 
 private:
-  StringRecord(uint32_t _record_size, uint64_t _timestamp,
-               RecordType _record_type, const pmem::obj::string_view &_key,
-               const pmem::obj::string_view &_value)
+  StringRecord(uint32_t _record_size, TimeStampType _timestamp,
+               RecordType _record_type, const StringView &_key,
+               const StringView &_value)
       : entry(0, _record_size, _timestamp, _record_type, _key.size(),
               _value.size()) {
     assert(_record_type == StringDataRecord ||
@@ -179,10 +177,10 @@ public:
   // target_address: pre-allocated space to store constructed record, it
   // should no smaller than sizeof(DLRecord) + key size + value size
   static DLRecord *ConstructDLRecord(void *target_address, uint32_t record_size,
-                                     uint64_t timestamp, RecordType record_type,
-                                     uint64_t prev, uint64_t next,
-                                     const pmem::obj::string_view &key,
-                                     const pmem::obj::string_view &value) {
+                                     TimeStampType timestamp,
+                                     RecordType record_type, uint64_t prev,
+                                     uint64_t next, const StringView &key,
+                                     const StringView &value) {
     DLRecord *record = new (target_address)
         DLRecord(record_size, timestamp, record_type, prev, next, key, value);
     return record;
@@ -204,25 +202,23 @@ public:
     return false;
   }
 
-  pmem::obj::string_view Key() const {
-    return pmem::obj::string_view(data, entry.meta.k_size);
-  }
+  StringView Key() const { return StringView(data, entry.meta.k_size); }
 
-  pmem::obj::string_view Value() const {
-    return pmem::obj::string_view(data + entry.meta.k_size, entry.meta.v_size);
+  StringView Value() const {
+    return StringView(data + entry.meta.k_size, entry.meta.v_size);
   }
 
   // Construct and persist a dl record to PMem address "addr"
   static DLRecord *PersistDLRecord(void *addr, uint32_t record_size,
-                                   uint64_t timestamp, RecordType type,
+                                   TimeStampType timestamp, RecordType type,
                                    uint64_t prev, uint64_t next,
-                                   const pmem::obj::string_view &key,
-                                   const pmem::obj::string_view &value);
+                                   const StringView &key,
+                                   const StringView &value);
 
 private:
-  DLRecord(uint32_t _record_size, uint64_t _timestamp, RecordType _record_type,
-           uint64_t _prev, uint64_t _next, const pmem::obj::string_view &_key,
-           const pmem::obj::string_view &_value)
+  DLRecord(uint32_t _record_size, TimeStampType _timestamp,
+           RecordType _record_type, uint64_t _prev, uint64_t _next,
+           const StringView &_key, const StringView &_value)
       : entry(0, _record_size, _timestamp, _record_type, _key.size(),
               _value.size()),
         prev(_prev), next(_next) {

--- a/engine/dlinked_list.hpp
+++ b/engine/dlinked_list.hpp
@@ -145,7 +145,7 @@ private:
   friend class UnorderedCollection;
   friend class UnorderedIterator;
 
-  static constexpr PMemOffsetType NullPMemOffset = kNullPmemOffset;
+  static constexpr PMemOffsetType NullPMemOffset = kPMemNull;
 
 public:
   /// Create DLinkedList and construct head and tail node on PMem.

--- a/engine/dlinked_list.hpp
+++ b/engine/dlinked_list.hpp
@@ -145,7 +145,7 @@ private:
   friend class UnorderedCollection;
   friend class UnorderedIterator;
 
-  static constexpr PMemOffsetType NullPMemOffset = kPMemNull;
+  static constexpr PMemOffsetType NullPMemOffset = kPmemNullOffset;
 
 public:
   /// Create DLinkedList and construct head and tail node on PMem.

--- a/engine/kv_engine.cpp
+++ b/engine/kv_engine.cpp
@@ -1117,7 +1117,7 @@ Status KVEngine::BatchWrite(const WriteBatch &write_batch) {
     return s;
   }
 
-  uint64_t ts = get_timestamp();
+  TimeStampType ts = get_timestamp();
 
   // Allocate space for batch
   std::vector<BatchWriteHint> batch_hints(write_batch.Size());
@@ -1382,7 +1382,7 @@ Status KVEngine::Set(const StringView key, const StringView value) {
 namespace KVDK_NAMESPACE {
 std::shared_ptr<UnorderedCollection>
 KVEngine::createUnorderedCollection(StringView const collection_name) {
-  std::uint64_t ts = get_timestamp();
+  TimeStampType ts = get_timestamp();
   uint64_t id = list_id_.fetch_add(1);
   std::string name(collection_name.data(), collection_name.size());
   std::shared_ptr<UnorderedCollection> sp_uncoll =
@@ -1481,7 +1481,7 @@ Status KVEngine::HSet(StringView const collection_name, StringView const key,
 
       std::unique_lock<SpinMutex> lock_record{*hint_record.spin};
 
-      std::uint64_t ts = get_timestamp();
+      TimeStampType ts = get_timestamp();
 
       HashEntry hash_entry_record;
       HashEntry *p_hash_entry_record = nullptr;
@@ -1636,13 +1636,13 @@ Status KVEngine::RestoreDlistRecords(DLRecord *pmp_record) {
     return Status::Ok;
   }
   case RecordType::DlistHeadRecord: {
-    kvdk_assert(pmp_record->prev == kNullPmemOffset &&
+    kvdk_assert(pmp_record->prev == kPMemNull &&
                     checkDLRecordLinkageRight(pmp_record),
                 "Bad linkage found when RestoreDlistRecords. Broken head.");
     return Status::Ok;
   }
   case RecordType::DlistTailRecord: {
-    kvdk_assert(pmp_record->next == kNullPmemOffset &&
+    kvdk_assert(pmp_record->next == kPMemNull &&
                     checkDLRecordLinkageLeft(pmp_record),
                 "Bad linkage found when RestoreDlistRecords. Broken tail.");
     return Status::Ok;

--- a/engine/kv_engine.cpp
+++ b/engine/kv_engine.cpp
@@ -845,8 +845,7 @@ Status KVEngine::Delete(const StringView key) {
   return StringDeleteImpl(key);
 }
 
-Status KVEngine::SDeleteImpl(Skiplist *skiplist,
-                             const pmem::obj::string_view &user_key) {
+Status KVEngine::SDeleteImpl(Skiplist *skiplist, const StringView &user_key) {
   std::string collection_key(skiplist->InternalKey(user_key));
   if (!CheckKeySize(collection_key)) {
     return Status::InvalidDataSize;
@@ -897,9 +896,8 @@ Status KVEngine::SDeleteImpl(Skiplist *skiplist,
   return Status::Ok;
 }
 
-Status KVEngine::SSetImpl(Skiplist *skiplist,
-                          const pmem::obj::string_view &user_key,
-                          const pmem::obj::string_view &value) {
+Status KVEngine::SSetImpl(Skiplist *skiplist, const StringView &user_key,
+                          const StringView &value) {
   std::string collection_key(skiplist->InternalKey(user_key));
   if (!CheckKeySize(collection_key) || !CheckValueSize(value)) {
     return Status::InvalidDataSize;

--- a/engine/kv_engine.cpp
+++ b/engine/kv_engine.cpp
@@ -1636,13 +1636,13 @@ Status KVEngine::RestoreDlistRecords(DLRecord *pmp_record) {
     return Status::Ok;
   }
   case RecordType::DlistHeadRecord: {
-    kvdk_assert(pmp_record->prev == kPMemNull &&
+    kvdk_assert(pmp_record->prev == kPmemNullOffset &&
                     checkDLRecordLinkageRight(pmp_record),
                 "Bad linkage found when RestoreDlistRecords. Broken head.");
     return Status::Ok;
   }
   case RecordType::DlistTailRecord: {
-    kvdk_assert(pmp_record->next == kPMemNull &&
+    kvdk_assert(pmp_record->next == kPmemNullOffset &&
                     checkDLRecordLinkageLeft(pmp_record),
                 "Bad linkage found when RestoreDlistRecords. Broken tail.");
     return Status::Ok;

--- a/engine/kv_engine.hpp
+++ b/engine/kv_engine.hpp
@@ -75,7 +75,7 @@ public:
 
 private:
   struct BatchWriteHint {
-    uint64_t timestamp{0};
+    TimeStampType timestamp{0};
     SizedSpaceEntry allocated_space{};
     SizedSpaceEntry free_after_finish{};
     bool delay_free{false};
@@ -175,7 +175,7 @@ private:
     return ((uint64_t)lo) | (((uint64_t)hi) << 32);
   }
 
-  inline uint64_t get_timestamp() {
+  inline TimeStampType get_timestamp() {
     auto res = get_cpu_tsc() - ts_on_startup_ + newest_version_on_startup_;
     return res;
   }

--- a/engine/kv_engine.hpp
+++ b/engine/kv_engine.hpp
@@ -41,36 +41,31 @@ public:
                      const Configs &configs);
 
   // Global Anonymous Collection
-  Status Get(const pmem::obj::string_view key, std::string *value) override;
-  Status Set(const pmem::obj::string_view key,
-             const pmem::obj::string_view value) override;
-  Status Delete(const pmem::obj::string_view key) override;
+  Status Get(const StringView key, std::string *value) override;
+  Status Set(const StringView key, const StringView value) override;
+  Status Delete(const StringView key) override;
   Status BatchWrite(const WriteBatch &write_batch) override;
 
   // Sorted Collection
-  Status SGet(const pmem::obj::string_view collection,
-              const pmem::obj::string_view user_key,
+  Status SGet(const StringView collection, const StringView user_key,
               std::string *value) override;
-  Status SSet(const pmem::obj::string_view collection,
-              const pmem::obj::string_view user_key,
-              const pmem::obj::string_view value) override;
+  Status SSet(const StringView collection, const StringView user_key,
+              const StringView value) override;
   // TODO: Release delete record and deleted nodes
-  Status SDelete(const pmem::obj::string_view collection,
-                 const pmem::obj::string_view user_key) override;
+  Status SDelete(const StringView collection,
+                 const StringView user_key) override;
   std::shared_ptr<Iterator>
-  NewSortedIterator(const pmem::obj::string_view collection) override;
+  NewSortedIterator(const StringView collection) override;
 
   // Unordered Collection
-  virtual Status HGet(pmem::obj::string_view const collection_name,
-                      pmem::obj::string_view const key,
+  virtual Status HGet(StringView const collection_name, StringView const key,
                       std::string *value) override;
-  virtual Status HSet(pmem::obj::string_view const collection_name,
-                      pmem::obj::string_view const key,
-                      pmem::obj::string_view const value) override;
-  virtual Status HDelete(pmem::obj::string_view const collection_name,
-                         pmem::obj::string_view const key) override;
+  virtual Status HSet(StringView const collection_name, StringView const key,
+                      StringView const value) override;
+  virtual Status HDelete(StringView const collection_name,
+                         StringView const key) override;
   std::shared_ptr<Iterator>
-  NewUnorderedIterator(pmem::obj::string_view const collection_name) override;
+  NewUnorderedIterator(StringView const collection_name) override;
 
   void ReleaseWriteThread() override { write_thread.Release(); }
 
@@ -94,27 +89,25 @@ private:
     std::unordered_map<uint64_t, int> visited_skiplist_ids;
   };
 
-  bool CheckKeySize(const pmem::obj::string_view &key) {
-    return key.size() <= UINT16_MAX;
-  }
+  bool CheckKeySize(const StringView &key) { return key.size() <= UINT16_MAX; }
 
-  bool CheckValueSize(const pmem::obj::string_view &value) {
+  bool CheckValueSize(const StringView &value) {
     return value.size() <= UINT32_MAX;
   }
 
   Status Init(const std::string &name, const Configs &configs);
 
-  Status HashGetImpl(const pmem::obj::string_view &key, std::string *value,
+  Status HashGetImpl(const StringView &key, std::string *value,
                      uint16_t type_mask);
 
   inline Status MaybeInitWriteThread();
 
-  Status SearchOrInitPersistentList(const pmem::obj::string_view &collection,
+  Status SearchOrInitPersistentList(const StringView &collection,
                                     PersistentList **list, bool init,
                                     uint16_t header_type);
 
-  Status SearchOrInitSkiplist(const pmem::obj::string_view &collection,
-                              Skiplist **skiplist, bool init) {
+  Status SearchOrInitSkiplist(const StringView &collection, Skiplist **skiplist,
+                              bool init) {
     if (!CheckKeySize(collection)) {
       return Status::InvalidDataSize;
     }
@@ -124,25 +117,22 @@ private:
 
 private:
   std::shared_ptr<UnorderedCollection>
-  createUnorderedCollection(pmem::obj::string_view const collection_name);
-  UnorderedCollection *
-  findUnorderedCollection(pmem::obj::string_view collection_name);
+  createUnorderedCollection(StringView const collection_name);
+  UnorderedCollection *findUnorderedCollection(StringView collection_name);
 
   Status MaybeInitPendingBatchFile();
 
-  Status StringSetImpl(const pmem::obj::string_view &key,
-                       const pmem::obj::string_view &value);
+  Status StringSetImpl(const StringView &key, const StringView &value);
 
-  Status StringDeleteImpl(const pmem::obj::string_view &key);
+  Status StringDeleteImpl(const StringView &key);
 
   Status StringBatchWriteImpl(const WriteBatch::KV &kv,
                               BatchWriteHint &batch_hint);
 
-  Status SSetImpl(Skiplist *skiplist, const pmem::obj::string_view &user_key,
-                  const pmem::obj::string_view &value);
+  Status SSetImpl(Skiplist *skiplist, const StringView &user_key,
+                  const StringView &value);
 
-  Status SDeleteImpl(Skiplist *skiplist,
-                     const pmem::obj::string_view &user_key);
+  Status SDeleteImpl(Skiplist *skiplist, const StringView &user_key);
 
   Status Recovery();
 

--- a/engine/pmem_allocator/pmem_allocator.cpp
+++ b/engine/pmem_allocator/pmem_allocator.cpp
@@ -17,10 +17,10 @@ PMEMAllocator::PMEMAllocator(char *pmem, uint64_t pmem_size,
     : pmem_(pmem), thread_cache_(num_write_threads), block_size_(block_size),
       segment_size_(num_segment_blocks * block_size), offset_head_(0),
       pmem_size_(pmem_size),
-      max_block_offset_(pmem_size / block_size / num_segment_blocks *
-                        num_segment_blocks),
       free_list_(num_segment_blocks, block_size, num_write_threads,
-                 max_block_offset_, this) {
+                 pmem_size / block_size / num_segment_blocks *
+                     num_segment_blocks /*num blocks*/,
+                 this) {
   init_data_size_2_block_size();
 }
 

--- a/engine/pmem_allocator/pmem_allocator.hpp
+++ b/engine/pmem_allocator/pmem_allocator.hpp
@@ -140,7 +140,6 @@ private:
   std::atomic<uint64_t> offset_head_;
   char *pmem_;
   uint64_t pmem_size_;
-  uint64_t max_block_offset_;
   Freelist free_list_;
   // For quickly get corresponding block size of a requested data size
   std::vector<uint16_t> data_size_2_block_size_;

--- a/engine/pmem_allocator/pmem_allocator.hpp
+++ b/engine/pmem_allocator/pmem_allocator.hpp
@@ -19,7 +19,7 @@
 
 namespace KVDK_NAMESPACE {
 
-constexpr uint64_t kNullPmemOffset = UINT64_MAX;
+constexpr PMemOffsetType kPMemNull = UINT64_MAX;
 constexpr uint64_t kMinPaddingBlocks = 8;
 
 // Manage allocation/de-allocation of PMem space at block unit
@@ -37,7 +37,7 @@ public:
                    uint32_t num_write_threads, bool use_devdax_mode);
 
   // Allocate a PMem space, return offset and actually allocated space in bytes
-  virtual SizedSpaceEntry Allocate(uint64_t size) override;
+  SizedSpaceEntry Allocate(uint64_t size) override;
 
   // Free a PMem space entry. The entry should be allocated by this allocator
   void Free(const SizedSpaceEntry &entry) override;
@@ -60,8 +60,8 @@ public:
     return nullptr;
   }
 
-  template <typename T> inline T *offset2addr_checked(uint64_t block_offset) {
-    return static_cast<T *>(offset2addr_checked(block_offset));
+  template <typename T> inline T *offset2addr_checked(uint64_t offset) {
+    return static_cast<T *>(offset2addr_checked(offset));
   }
 
   template <typename T> inline T *offset2addr(uint64_t block_offset) {
@@ -83,11 +83,11 @@ public:
         return offset;
       }
     }
-    return kNullPmemOffset;
+    return kPMemNull;
   }
 
   inline bool validate_offset(uint64_t offset) {
-    return offset < pmem_size_ && offset != kNullPmemOffset;
+    return offset < pmem_size_ && offset != kPMemNull;
   }
 
   // Populate PMem space so the following access can be faster

--- a/engine/pmem_allocator/pmem_allocator.hpp
+++ b/engine/pmem_allocator/pmem_allocator.hpp
@@ -19,7 +19,7 @@
 
 namespace KVDK_NAMESPACE {
 
-constexpr PMemOffsetType kPMemNull = UINT64_MAX;
+constexpr PMemOffsetType kPmemNullOffset = UINT64_MAX;
 constexpr uint64_t kMinPaddingBlocks = 8;
 
 // Manage allocation/de-allocation of PMem space at block unit
@@ -83,11 +83,11 @@ public:
         return offset;
       }
     }
-    return kPMemNull;
+    return kPmemNullOffset;
   }
 
   inline bool validate_offset(uint64_t offset) {
-    return offset < pmem_size_ && offset != kPMemNull;
+    return offset < pmem_size_ && offset != kPmemNullOffset;
   }
 
   // Populate PMem space so the following access can be faster

--- a/engine/skiplist.cpp
+++ b/engine/skiplist.cpp
@@ -13,15 +13,12 @@
 
 namespace KVDK_NAMESPACE {
 
-pmem::obj::string_view SkiplistNode::UserKey() {
-  return Skiplist::UserKey(this);
-}
+StringView SkiplistNode::UserKey() { return Skiplist::UserKey(this); }
 
 uint64_t SkiplistNode::SkiplistId() { return Skiplist::SkiplistId(this); }
 
-void SkiplistNode::SeekNode(const pmem::obj::string_view &key,
-                            uint8_t start_height, uint8_t end_height,
-                            Splice *result_splice) {
+void SkiplistNode::SeekNode(const StringView &key, uint8_t start_height,
+                            uint8_t end_height, Splice *result_splice) {
   std::unique_ptr<std::vector<SkiplistNode *>> to_delete(nullptr);
   assert(height >= start_height && end_height >= 1);
   SkiplistNode *prev = this;
@@ -210,8 +207,7 @@ Status Skiplist::CheckConnection(int height) {
   return Status::Ok;
 }
 
-bool Skiplist::FindUpdatePos(Splice *splice,
-                             const pmem::obj::string_view &updated_key,
+bool Skiplist::FindUpdatePos(Splice *splice, const StringView &updated_key,
                              const SpinMutex *updating_key_lock,
                              const DLRecord *updated_record,
                              std::unique_lock<SpinMutex> *prev_record_lock) {
@@ -256,8 +252,7 @@ bool Skiplist::FindUpdatePos(Splice *splice,
   }
 }
 
-bool Skiplist::FindInsertPos(Splice *splice,
-                             const pmem::obj::string_view &insert_key,
+bool Skiplist::FindInsertPos(Splice *splice, const StringView &insert_key,
                              const SpinMutex *inserting_key_lock,
                              std::unique_lock<SpinMutex> *prev_record_lock) {
   while (1) {
@@ -322,8 +317,7 @@ bool Skiplist::FindInsertPos(Splice *splice,
   }
 }
 
-bool Skiplist::Insert(const pmem::obj::string_view &key,
-                      const pmem::obj::string_view &value,
+bool Skiplist::Insert(const StringView &key, const StringView &value,
                       const SizedSpaceEntry &space_to_write, uint64_t timestamp,
                       SkiplistNode **dram_node,
                       const SpinMutex *inserting_key_lock) {
@@ -369,8 +363,7 @@ bool Skiplist::Insert(const pmem::obj::string_view &key,
   return true;
 }
 
-bool Skiplist::Update(const pmem::obj::string_view &key,
-                      const pmem::obj::string_view &value,
+bool Skiplist::Update(const StringView &key, const StringView &value,
                       const DLRecord *updated_record,
                       const SizedSpaceEntry &space_to_write, uint64_t timestamp,
                       SkiplistNode *dram_node,
@@ -398,8 +391,8 @@ bool Skiplist::Update(const pmem::obj::string_view &key,
   return true;
 }
 
-bool Skiplist::Delete(const pmem::obj::string_view &key,
-                      DLRecord *deleted_record, SkiplistNode *dram_node,
+bool Skiplist::Delete(const StringView &key, DLRecord *deleted_record,
+                      SkiplistNode *dram_node,
                       const SpinMutex *deleting_key_lock) {
   Splice splice(this);
   std::unique_lock<SpinMutex> prev_record_lock;

--- a/engine/skiplist.cpp
+++ b/engine/skiplist.cpp
@@ -318,8 +318,8 @@ bool Skiplist::FindInsertPos(Splice *splice, const StringView &insert_key,
 }
 
 bool Skiplist::Insert(const StringView &key, const StringView &value,
-                      const SizedSpaceEntry &space_to_write, uint64_t timestamp,
-                      SkiplistNode **dram_node,
+                      const SizedSpaceEntry &space_to_write,
+                      TimeStampType timestamp, SkiplistNode **dram_node,
                       const SpinMutex *inserting_key_lock) {
   Splice splice(this);
   std::unique_lock<SpinMutex> prev_record_lock;
@@ -365,8 +365,8 @@ bool Skiplist::Insert(const StringView &key, const StringView &value,
 
 bool Skiplist::Update(const StringView &key, const StringView &value,
                       const DLRecord *updated_record,
-                      const SizedSpaceEntry &space_to_write, uint64_t timestamp,
-                      SkiplistNode *dram_node,
+                      const SizedSpaceEntry &space_to_write,
+                      TimeStampType timestamp, SkiplistNode *dram_node,
                       const SpinMutex *updating_key_lock) {
   Splice splice(this);
   std::unique_lock<SpinMutex> prev_record_lock;

--- a/engine/skiplist.hpp
+++ b/engine/skiplist.hpp
@@ -190,31 +190,28 @@ public:
 
   SkiplistNode *header() { return header_; }
 
-  std::string InternalKey(const pmem::obj::string_view &key) {
+  std::string InternalKey(const StringView &key) {
     return PersistentList::ListKey(key, id_);
   }
 
-  inline static pmem::obj::string_view
-  UserKey(const pmem::obj::string_view &skiplist_key) {
-    return pmem::obj::string_view(skiplist_key.data() + 8,
-                                  skiplist_key.size() - 8);
+  inline static StringView UserKey(const StringView &skiplist_key) {
+    return StringView(skiplist_key.data() + 8, skiplist_key.size() - 8);
   }
 
-  inline static pmem::obj::string_view UserKey(const SkiplistNode *node) {
+  inline static StringView UserKey(const SkiplistNode *node) {
     assert(node != nullptr);
     if (node->cached_key_size > 0) {
-      return pmem::obj::string_view(node->cached_key, node->cached_key_size);
+      return StringView(node->cached_key, node->cached_key_size);
     }
     return UserKey(node->record->Key());
   }
 
-  inline static pmem::obj::string_view UserKey(const DLRecord *record) {
+  inline static StringView UserKey(const DLRecord *record) {
     assert(record != nullptr);
     return UserKey(record->Key());
   }
 
-  inline static uint64_t
-  SkiplistId(const pmem::obj::string_view &skiplist_key) {
+  inline static uint64_t SkiplistId(const StringView &skiplist_key) {
     uint64_t id;
     memcpy_8(&id, skiplist_key.data());
     return id;
@@ -258,8 +255,7 @@ public:
   // calling this function
   //
   // Return true on success, return false on fail.
-  bool Insert(const pmem::obj::string_view &key,
-              const pmem::obj::string_view &value,
+  bool Insert(const StringView &key, const StringView &value,
               const SizedSpaceEntry &space_to_write, uint64_t timestamp,
               SkiplistNode **dram_node, const SpinMutex *inserting_key_lock);
 
@@ -273,8 +269,7 @@ public:
   // calling this function
   //
   // Return true on success, return false on fail.
-  bool Update(const pmem::obj::string_view &key,
-              const pmem::obj::string_view &value,
+  bool Update(const StringView &key, const StringView &value,
               const DLRecord *updated_record,
               const SizedSpaceEntry &space_to_write, uint64_t timestamp,
               SkiplistNode *dram_node, const SpinMutex *updating_key_lock);
@@ -288,7 +283,7 @@ public:
   // calling this function
   //
   // Return true on success, return false on fail.
-  bool Delete(const pmem::obj::string_view &key, DLRecord *deleted_record,
+  bool Delete(const StringView &key, DLRecord *deleted_record,
               SkiplistNode *dram_node, const SpinMutex *deleting_key_lock);
 
   void ObsoleteNodes(const std::vector<SkiplistNode *> nodes) {
@@ -323,8 +318,7 @@ private:
   // prev DLRecord and manage the lock with "prev_record_lock".
   //
   // The "insert_key" should be already locked before call this function
-  bool FindInsertPos(Splice *splice,
-                     const pmem::obj::string_view &inserting_key,
+  bool FindInsertPos(Splice *splice, const StringView &inserting_key,
                      const SpinMutex *inserting_key_lock,
                      std::unique_lock<SpinMutex> *prev_record_lock);
 
@@ -334,12 +328,12 @@ private:
   // the lock with "prev_record_lock".
   //
   //  The "updated_key" should be already locked before call this function
-  bool FindUpdatePos(Splice *splice, const pmem::obj::string_view &updating_key,
+  bool FindUpdatePos(Splice *splice, const StringView &updating_key,
                      const SpinMutex *updating_key_lock,
                      const DLRecord *updated_record,
                      std::unique_lock<SpinMutex> *prev_record_lock);
 
-  bool FindDeletePos(Splice *splice, const pmem::obj::string_view &deleting_key,
+  bool FindDeletePos(Splice *splice, const StringView &deleting_key,
                      const SpinMutex *deleting_key_lock,
                      const DLRecord *deleted_record,
                      std::unique_lock<SpinMutex> *prev_record_lock) {

--- a/engine/skiplist.hpp
+++ b/engine/skiplist.hpp
@@ -256,7 +256,7 @@ public:
   //
   // Return true on success, return false on fail.
   bool Insert(const StringView &key, const StringView &value,
-              const SizedSpaceEntry &space_to_write, uint64_t timestamp,
+              const SizedSpaceEntry &space_to_write, TimeStampType timestamp,
               SkiplistNode **dram_node, const SpinMutex *inserting_key_lock);
 
   // Update "key" in skiplist
@@ -271,7 +271,7 @@ public:
   // Return true on success, return false on fail.
   bool Update(const StringView &key, const StringView &value,
               const DLRecord *updated_record,
-              const SizedSpaceEntry &space_to_write, uint64_t timestamp,
+              const SizedSpaceEntry &space_to_write, TimeStampType timestamp,
               SkiplistNode *dram_node, const SpinMutex *updating_key_lock);
 
   // Delete "key" from skiplist

--- a/engine/snapshot.hpp
+++ b/engine/snapshot.hpp
@@ -2,6 +2,6 @@
 
 namespace KVDK_NAMESPACE {
 struct Snapshot {
-  uint64_t timestamp;
+  TimeStampType timestamp;
 };
 } // namespace KVDK_NAMESPACE

--- a/engine/structures.hpp
+++ b/engine/structures.hpp
@@ -64,7 +64,7 @@ struct PendingBatch {
     Processing = 1,
   };
 
-  PendingBatch(Stage s, uint32_t nkv, uint64_t ts)
+  PendingBatch(Stage s, uint32_t nkv, TimeStampType ts)
       : stage(s), num_kv(nkv), timestamp(ts) {}
 
   void PersistProcessing(void *target,
@@ -78,7 +78,7 @@ struct PendingBatch {
 
   Stage stage;
   uint32_t num_kv;
-  uint64_t timestamp;
+  TimeStampType timestamp;
 };
 
 class PersistentList {

--- a/engine/structures.hpp
+++ b/engine/structures.hpp
@@ -85,7 +85,7 @@ class PersistentList {
 public:
   virtual uint64_t id() = 0;
 
-  inline static std::string ListKey(const pmem::obj::string_view &user_key,
+  inline static std::string ListKey(const StringView &user_key,
                                     uint64_t list_id) {
     return std::string((char *)&list_id, 8)
         .append(user_key.data(), user_key.size());

--- a/engine/unordered_collection.hpp
+++ b/engine/unordered_collection.hpp
@@ -42,7 +42,7 @@ struct ModifyReturn {
     return *this;
   }
 
-  static constexpr PMemOffsetType FailOffset = kNullPmemOffset;
+  static constexpr PMemOffsetType FailOffset = kPMemNull;
 };
 } // namespace KVDK_NAMESPACE
 

--- a/engine/unordered_collection.hpp
+++ b/engine/unordered_collection.hpp
@@ -42,7 +42,7 @@ struct ModifyReturn {
     return *this;
   }
 
-  static constexpr PMemOffsetType FailOffset = kPMemNull;
+  static constexpr PMemOffsetType FailOffset = kPmemNullOffset;
 };
 } // namespace KVDK_NAMESPACE
 


### PR DESCRIPTION
<!--
Thank you for contributing to KVDK.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Problem Summary:
Using Alias StringView to replace pmem::obj::string_view, TimeStampType to replace uint64_t

### What is changed and how it works?

What's Changed:
Using Alias StringView to replace pmem::obj::string_view, TimeStampType to replace uint64_t

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

Side effects

no
