### PR TITLE
Remove copy/move constructor of SpinMutex, and align thread caches to cache line

### DIFF
--- a/engine/alias.hpp
+++ b/engine/alias.hpp
@@ -1,6 +1,6 @@
 #include <cinttypes>
 
-#include "../libpmemobj++/string_view.hpp"
+#include "libpmem.h"
 
 namespace KVDK_NAMESPACE {
 using StringView = pmem::obj::string_view;

--- a/engine/dram_allocator.hpp
+++ b/engine/dram_allocator.hpp
@@ -36,11 +36,15 @@ public:
   }
 
 private:
-  struct ThreadCache {
+  struct alignas(64) ThreadCache {
     alignas(64) char *chunk_addr = nullptr;
     uint64_t usable_bytes = 0;
     std::vector<void *> allocated_chunks;
+
+    char padding[64 - sizeof(allocated_chunks) - sizeof(usable_bytes) -
+                 sizeof(chunk_addr)];
   };
+  static_assert(sizeof(ThreadCache) == 64);
 
   const uint32_t chunk_size_ = (1 << 20);
   std::vector<ThreadCache> thread_cache_;

--- a/engine/dram_allocator.hpp
+++ b/engine/dram_allocator.hpp
@@ -42,6 +42,10 @@ private:
     uint64_t usable_bytes = 0;
     std::vector<void *> allocated_chunks;
 
+    ThreadCache() = default;
+    ThreadCache(const ThreadCache &) = delete;
+    ThreadCache(ThreadCache &&) = delete;
+
     char padding[64 - sizeof(allocated_chunks) - sizeof(usable_bytes) -
                  sizeof(chunk_addr)];
   };

--- a/engine/dram_allocator.hpp
+++ b/engine/dram_allocator.hpp
@@ -28,7 +28,8 @@ public:
   inline uint64_t addr2offset(void *addr) { return (uint64_t)addr; }
   ChunkBasedAllocator(uint32_t write_threads) : thread_cache_(write_threads) {}
   ~ChunkBasedAllocator() {
-    for (auto &tc : thread_cache_) {
+    for (uint64_t i = 0; i < thread_cache_.size(); i++) {
+      auto &tc = thread_cache_[i];
       for (void *chunk : tc.allocated_chunks) {
         free(chunk);
       }
@@ -47,6 +48,6 @@ private:
   static_assert(sizeof(ThreadCache) == 64);
 
   const uint32_t chunk_size_ = (1 << 20);
-  std::vector<ThreadCache> thread_cache_;
+  Array<ThreadCache> thread_cache_;
 };
 } // namespace KVDK_NAMESPACE

--- a/engine/hash_table.hpp
+++ b/engine/hash_table.hpp
@@ -201,7 +201,7 @@ private:
   const uint32_t num_buckets_per_slot_;
   const uint32_t hash_bucket_size_;
   const uint64_t num_entries_per_bucket_;
-  std::vector<Slot> slots_;
+  FixedVector<Slot> slots_;
   std::shared_ptr<PMEMAllocator> pmem_allocator_;
   ChunkBasedAllocator dram_allocator_;
   void *main_buckets_;

--- a/engine/hash_table.hpp
+++ b/engine/hash_table.hpp
@@ -201,7 +201,7 @@ private:
   const uint32_t num_buckets_per_slot_;
   const uint32_t hash_bucket_size_;
   const uint64_t num_entries_per_bucket_;
-  FixedVector<Slot> slots_;
+  Array<Slot> slots_;
   std::shared_ptr<PMEMAllocator> pmem_allocator_;
   ChunkBasedAllocator dram_allocator_;
   void *main_buckets_;

--- a/engine/pmem_allocator/free_list.cpp
+++ b/engine/pmem_allocator/free_list.cpp
@@ -328,7 +328,8 @@ bool Freelist::Get(uint32_t size, SizedSpaceEntry *space_entry) {
 void Freelist::MoveCachedListsToPool() {
   std::vector<SpaceEntry> moving_list;
   uint64_t min_ts = min_timestamp_of_entries_;
-  for (auto &tc : thread_cache_) {
+  for (uint64_t i = 0; i < thread_cache_.size(); i++) {
+    auto &tc = thread_cache_[i];
     {
       std::lock_guard<SpinMutex> lg(
           tc.spins.back() /* delay freed entries lock*/);

--- a/engine/pmem_allocator/free_list.hpp
+++ b/engine/pmem_allocator/free_list.hpp
@@ -189,8 +189,8 @@ private:
                 1 /* the last lock is for delay freed entries */),
           last_used_entry_ts(0) {}
 
-    ThreadCache() = default;
-
+    ThreadCache() = delete;
+    ThreadCache(ThreadCache &&) = delete;
     ThreadCache(const ThreadCache &) = delete;
 
     // Entry size stored in block unit

--- a/engine/pmem_allocator/free_list.hpp
+++ b/engine/pmem_allocator/free_list.hpp
@@ -189,12 +189,17 @@ private:
                 1 /* the last lock is for delay freed entries */),
           last_used_entry_ts(0) {}
 
+    ThreadCache() = default;
+
+    ThreadCache(const ThreadCache &) = delete;
+
     // Entry size stored in block unit
-    FixedVector<std::vector<SpaceEntry>> active_entries;
+    Array<std::vector<SpaceEntry>> active_entries;
     // These entries can be add to free list only if no entries with smaller
     // timestamp exist.
     std::vector<SizedSpaceEntry> delay_freed_entries;
-    FixedVector<SpinMutex> spins;
+    // Protect active_entries and delay_freed_entries
+    Array<SpinMutex> spins;
     // timestamp of entry that recently fetched from active_entries
     uint64_t last_used_entry_ts;
     char padding[64 - sizeof(active_entries) - sizeof(delay_freed_entries) -
@@ -223,7 +228,7 @@ private:
   const uint32_t block_size_;
   const uint32_t max_classified_b_size_;
   SpaceMap space_map_;
-  std::vector<ThreadCache> thread_cache_;
+  Array<ThreadCache> thread_cache_;
   SpaceEntryPool active_pool_;
   SpaceEntryPool merged_pool_;
   // Store all large free space entries that larger than max_classified_b_size_

--- a/engine/pmem_allocator/free_list.hpp
+++ b/engine/pmem_allocator/free_list.hpp
@@ -190,14 +190,17 @@ private:
           last_used_entry_ts(0) {}
 
     // Entry size stored in block unit
-    std::vector<std::vector<SpaceEntry>> active_entries;
+    FixedVector<std::vector<SpaceEntry>> active_entries;
     // These entries can be add to free list only if no entries with smaller
     // timestamp exist.
     std::vector<SizedSpaceEntry> delay_freed_entries;
-    std::vector<SpinMutex> spins;
+    FixedVector<SpinMutex> spins;
     // timestamp of entry that recently fetched from active_entries
     uint64_t last_used_entry_ts;
+    char padding[64 - sizeof(active_entries) - sizeof(delay_freed_entries) -
+                 sizeof(spins) - sizeof(last_used_entry_ts)];
   };
+  static_assert(sizeof(ThreadCache) == 64);
 
   class SpaceCmp {
   public:

--- a/engine/pmem_allocator/pmem_allocator.hpp
+++ b/engine/pmem_allocator/pmem_allocator.hpp
@@ -106,7 +106,7 @@ private:
                 uint32_t block_size, uint32_t num_write_threads);
   // Write threads cache a dedicated PMem segment and a free space to
   // avoid contention
-  struct ThreadCache {
+  struct alignas(64) ThreadCache {
     // Space got from free list, the size is aligned to block_size_
     SizedSpaceEntry free_entry;
     // Space fetched from head of PMem segments, the size is aligned to
@@ -114,6 +114,7 @@ private:
     SizedSpaceEntry segment_entry;
     char padding[64 - sizeof(SizedSpaceEntry) * 2];
   };
+  static_assert(sizeof(ThreadCache) == 64);
 
   bool AllocateSegmentSpace(SizedSpaceEntry *segment_entry);
 

--- a/engine/utils.hpp
+++ b/engine/utils.hpp
@@ -117,6 +117,41 @@ static inline bool equal_string_view(const StringView &src,
   return false;
 }
 
+template <typename T> class FixedVector {
+public:
+  FixedVector(uint64_t size) : size_(size) { data_ = new T[size]; }
+
+  FixedVector() = delete;
+
+  FixedVector(const FixedVector<T> &v) {
+    size_ = v.size_;
+    data_ = new T[size_];
+    memcpy(data_, v.data_, size_ * sizeof(T));
+  }
+
+  ~FixedVector() {
+    if (data_ != nullptr) {
+      delete[] data_;
+    }
+  }
+
+  T &back() {
+    assert(size_ > 0);
+    return data_[size_ - 1];
+  }
+
+  T &operator[](uint64_t index) {
+    assert(index < size_);
+    return data_[index];
+  }
+
+  uint64_t size() { return size_; }
+
+private:
+  T *data_;
+  uint64_t size_;
+};
+
 class Slice {
 public:
   Slice() : _data(nullptr), _size(0) {}

--- a/engine/utils.hpp
+++ b/engine/utils.hpp
@@ -126,7 +126,9 @@ public:
   FixedVector(const FixedVector<T> &v) {
     size_ = v.size_;
     data_ = new T[size_];
-    memcpy(data_, v.data_, size_ * sizeof(T));
+    for (size_t i = 0; i < size_; i++) {
+      data_[i] = v.data_[i];
+    }
   }
 
   ~FixedVector() {
@@ -236,11 +238,20 @@ public:
 
   //  bool hold() { return owner == write_thread.id; }
 
-  SpinMutex(const SpinMutex &s) : locked(ATOMIC_FLAG_INIT) {}
+  // We implement these construction function for put spin mutex in vector, but
+  // they should never be called
+  SpinMutex(const SpinMutex &s) : locked(ATOMIC_FLAG_INIT) {
+    kvdk_assert(false, "call copy construction on spin mutex");
+  }
 
-  SpinMutex(const SpinMutex &&s) : locked(ATOMIC_FLAG_INIT) {}
-
+  SpinMutex(const SpinMutex &&s) : locked(ATOMIC_FLAG_INIT) {
+    kvdk_assert(false, "call move construction on spin mutex");
+  }
   SpinMutex() : locked(ATOMIC_FLAG_INIT) {}
+  SpinMutex &operator=(const SpinMutex &s) {
+    locked.clear(std::memory_order_release);
+    kvdk_assert(false, "call assignment on spin mutex");
+  }
 };
 
 // Return the number of process unit (PU) that are bound to the kvdk instance


### PR DESCRIPTION
Signed-off-by: Jiayu Wu <jiayu.wu@intel.com>

<!--
Thank you for contributing to KVDK.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Problem Summary:

- SpinMutex has copy and move constructor, which is insecure
- Thread caches are not aligned to cache line size, so they may need to do cache coherency which will decrease performance

### What is changed and how it works?

What's Changed:
- Remove copy/move constructor and assignment of SpinMutex for security
- Implement Array to reduce thread cache size, and store un-copyable elements
- align thread cache size to 64B

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Stress test

Side effects

- 1% ~ 3% improvement on string insert
- no significant difference on other types
