### PR TITLE
Validate skiplist nodes in seek operations 

### DIFF
--- a/engine/alias.hpp
+++ b/engine/alias.hpp
@@ -6,6 +6,7 @@
 
 #include <cinttypes>
 
+#include "kvdk/namespace.hpp"
 #include "libpmem.h"
 
 namespace KVDK_NAMESPACE {

--- a/engine/skiplist.cpp
+++ b/engine/skiplist.cpp
@@ -158,6 +158,9 @@ void Skiplist::Seek(const StringView &key, Splice *result_splice) {
 
     // pmem record maybe updated during seek, then the next record could be
     // invalid, so we need to catch exceptions here
+    if (next_record == nullptr) {
+      return Seek(key, result_splice);
+    }
     int cmp;
     try {
       cmp = compare_string_view(key, UserKey(next_record));

--- a/engine/skiplist.cpp
+++ b/engine/skiplist.cpp
@@ -17,9 +17,10 @@ StringView SkiplistNode::UserKey() { return Skiplist::UserKey(this); }
 
 uint64_t SkiplistNode::SkiplistId() { return Skiplist::SkiplistId(this); }
 
-void SkiplistNode::SeekNode(const StringView &key, uint8_t start_height,
-                            uint8_t end_height, Splice *result_splice) {
-  std::unique_ptr<std::vector<SkiplistNode *>> to_delete(nullptr);
+void SkiplistNode::SeekNode(const pmem::obj::string_view &key,
+                            uint8_t start_height, uint8_t end_height,
+                            Splice *result_splice) {
+  std::vector<SkiplistNode *> to_delete;
   assert(height >= start_height && end_height >= 1);
   SkiplistNode *prev = this;
   PointerWithTag<SkiplistNode> next;
@@ -57,17 +58,21 @@ void SkiplistNode::SeekNode(const StringView &key, uint8_t start_height,
       if (next_next.GetTag()) {
         if (prev->CASNext(i, next, next_next.RawPointer())) {
           if (--next->valid_links == 0) {
-            if (to_delete == nullptr) {
-              to_delete.reset(new std::vector<SkiplistNode *>());
-            }
-            to_delete->push_back(next.RawPointer());
+            to_delete.push_back(next.RawPointer());
           }
         }
         // if prev is marked deleted before cas, cas will be failed, and prev
         // will be roll back in next round
         continue;
       }
+
+      DLRecord *next_pmem_record = next->record;
       int cmp = compare_string_view(key, next->UserKey());
+      // next record maybe updated before compare string, then the compare
+      // result will be invalid, so we need to do double check
+      if (next->record != next_pmem_record) {
+        continue;
+      }
 
       if (cmp > 0) {
         prev = next.RawPointer();
@@ -78,8 +83,8 @@ void SkiplistNode::SeekNode(const StringView &key, uint8_t start_height,
       }
     }
   }
-  if (to_delete && to_delete->size() > 0) {
-    result_splice->seeking_list->ObsoleteNodes(*to_delete);
+  if (to_delete.size() > 0) {
+    result_splice->seeking_list->ObsoleteNodes(to_delete);
   }
 }
 
@@ -146,6 +151,12 @@ void Skiplist::Seek(const StringView &key, Splice *result_splice) {
     }
 
     int cmp = compare_string_view(key, UserKey(next_record));
+    // next record maybe updated before compare string, then the compare
+    // result will be invalid, so we need to do double check
+    if (!ValidateDLRecord(next_record)) {
+      return Seek(key, result_splice);
+    }
+
     if (cmp > 0) {
       prev_record = next_record;
     } else {

--- a/engine/skiplist.cpp
+++ b/engine/skiplist.cpp
@@ -17,9 +17,8 @@ StringView SkiplistNode::UserKey() { return Skiplist::UserKey(this); }
 
 uint64_t SkiplistNode::SkiplistId() { return Skiplist::SkiplistId(this); }
 
-void SkiplistNode::SeekNode(const pmem::obj::string_view &key,
-                            uint8_t start_height, uint8_t end_height,
-                            Splice *result_splice) {
+void SkiplistNode::SeekNode(const StringView &key, uint8_t start_height,
+                            uint8_t end_height, Splice *result_splice) {
   std::vector<SkiplistNode *> to_delete;
   assert(height >= start_height && end_height >= 1);
   SkiplistNode *prev = this;

--- a/engine/skiplist.cpp
+++ b/engine/skiplist.cpp
@@ -67,14 +67,7 @@ void SkiplistNode::SeekNode(const pmem::obj::string_view &key,
       }
 
       DLRecord *next_pmem_record = next->record;
-      // pmem record maybe updated during seek, then the next record could be
-      // invalid, so we need to catch exceptions here
-      int cmp;
-      try {
-        cmp = compare_string_view(key, next->UserKey());
-      } catch (std::runtime_error &) {
-        continue;
-      }
+      int cmp = compare_string_view(key, next->UserKey());
       // pmem record maybe updated before comparing string, then the compare
       // result will be invalid, so we need to do double check
       if (next->record != next_pmem_record) {
@@ -156,17 +149,10 @@ void Skiplist::Seek(const StringView &key, Splice *result_splice) {
       break;
     }
 
-    // pmem record maybe updated during seek, then the next record could be
-    // invalid, so we need to catch exceptions here
     if (next_record == nullptr) {
       return Seek(key, result_splice);
     }
-    int cmp;
-    try {
-      cmp = compare_string_view(key, UserKey(next_record));
-    } catch (std::runtime_error &e) {
-      return Seek(key, result_splice);
-    }
+    int cmp = compare_string_view(key, UserKey(next_record));
     // pmem record maybe updated before comparing string, then the comparing
     // result will be invalid, so we need to do double check
     if (!ValidateDLRecord(next_record)) {

--- a/engine/skiplist.hpp
+++ b/engine/skiplist.hpp
@@ -341,6 +341,18 @@ private:
                          deleted_record, prev_record_lock);
   }
 
+  bool ValidateDLRecord(const DLRecord *record) {
+    // if record is not a valid dl record, then its prev maybe a invalid
+    // pointer, so we need to catch exception here
+    try {
+      DLRecord *prev = pmem_allocator_->offset2addr<DLRecord>(record->prev);
+      return prev->next == pmem_allocator_->addr2offset(record) &&
+             SkiplistId(record) == id_;
+    } catch (std::runtime_error &e) {
+      return false;
+    }
+  }
+
   SkiplistNode *header_;
   std::string name_;
   uint64_t id_;

--- a/engine/skiplist.hpp
+++ b/engine/skiplist.hpp
@@ -343,7 +343,8 @@ private:
 
   bool ValidateDLRecord(const DLRecord *record) {
     DLRecord *prev = pmem_allocator_->offset2addr<DLRecord>(record->prev);
-    return prev->next == pmem_allocator_->addr2offset(record) &&
+    return prev != nullptr &&
+           prev->next == pmem_allocator_->addr2offset(record) &&
            SkiplistId(record) == id_;
   }
 

--- a/engine/skiplist.hpp
+++ b/engine/skiplist.hpp
@@ -342,15 +342,9 @@ private:
   }
 
   bool ValidateDLRecord(const DLRecord *record) {
-    // if record is not a valid dl record, then its prev maybe a invalid
-    // pointer, so we need to catch exception here
-    try {
-      DLRecord *prev = pmem_allocator_->offset2addr<DLRecord>(record->prev);
-      return prev->next == pmem_allocator_->addr2offset(record) &&
-             SkiplistId(record) == id_;
-    } catch (std::runtime_error &e) {
-      return false;
-    }
+    DLRecord *prev = pmem_allocator_->offset2addr<DLRecord>(record->prev);
+    return prev->next == pmem_allocator_->addr2offset(record) &&
+           SkiplistId(record) == id_;
   }
 
   SkiplistNode *header_;


### PR DESCRIPTION
<!--
Thank you for contributing to KVDK.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Problem Summary:

pmem record of skiplist maybe updated during seek, so we need to validate them

### What is changed and how it works?

What's Changed:

- check validation of skiplist dram/pmem node after comparing keys

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Stress test

Side effects

- Performance regression
    - No significant performance difference, <1% insert performance decrease on skiplist insert
