### PR TITLE
Add functionality to pmem::obj::string_view and use C++11 standard

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,7 +108,7 @@ endif ()
 option(BUILD_TUTORIAL "Build the tutorial" ON)
 add_subdirectory(examples/tutorial)
 
-option(BUILD_GRAPH_SIMULATOR "Build the graph simulator" OFF)
+option(BUILD_GRAPH_SIMULATOR "Build the graph simulator" ON)
 add_subdirectory(examples/graph_sim)
 
 add_custom_target(checkers ALL)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ set(KVDK_ROOT_DIR ${CMAKE_CURRENT_SOURCE_DIR})
 include(${KVDK_ROOT_DIR}/cmake/functions.cmake)
 include(GNUInstallDirs)
 
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 11)
 option(DEBUG_CHECK "check connection" OFF)
 if(DEBUG_CHECK)
     add_compile_definitions(DEBUG_CHECK)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,8 +108,8 @@ endif ()
 option(BUILD_TUTORIAL "Build the tutorial" ON)
 add_subdirectory(examples/tutorial)
 
-option(BUILD_GRAPH_SIMULATOR "Build the graph simulator" ON)
-# add_subdirectory(examples/graph_sim)
+option(BUILD_GRAPH_SIMULATOR "Build the graph simulator" OFF)
+add_subdirectory(examples/graph_sim)
 
 add_custom_target(checkers ALL)
 add_custom_target(cppstyle)

--- a/engine/dram_allocator.hpp
+++ b/engine/dram_allocator.hpp
@@ -27,6 +27,8 @@ public:
   }
   inline uint64_t addr2offset(void *addr) { return (uint64_t)addr; }
   ChunkBasedAllocator(uint32_t write_threads) : thread_cache_(write_threads) {}
+  ChunkBasedAllocator(ChunkBasedAllocator const &) = delete;
+  ChunkBasedAllocator(ChunkBasedAllocator &&) = delete;
   ~ChunkBasedAllocator() {
     for (uint64_t i = 0; i < thread_cache_.size(); i++) {
       auto &tc = thread_cache_[i];

--- a/engine/hash_table.hpp
+++ b/engine/hash_table.hpp
@@ -178,8 +178,7 @@ private:
             uint32_t write_threads)
       : hash_bucket_num_(hash_bucket_num),
         num_buckets_per_slot_(num_buckets_per_slot),
-        hash_bucket_size_(hash_bucket_size),
-        dram_allocator_(ChunkBasedAllocator(write_threads)),
+        hash_bucket_size_(hash_bucket_size), dram_allocator_(write_threads),
         pmem_allocator_(pmem_allocator),
         num_entries_per_bucket_((hash_bucket_size_ - 8 /* next pointer */) /
                                 sizeof(HashEntry)),

--- a/engine/kv_engine.cpp
+++ b/engine/kv_engine.cpp
@@ -1892,13 +1892,13 @@ Status KVEngine::RestoreQueueRecords(DLRecord *pmp_record) {
     return Status::Ok;
   }
   case RecordType::QueueHeadRecord: {
-    kvdk_assert(pmp_record->prev == kNullPmemOffset &&
+    kvdk_assert(pmp_record->prev == kPmemNullOffset &&
                     checkDLRecordLinkageRight(pmp_record),
                 "Bad linkage found when RestoreDlistRecords. Broken head.");
     return Status::Ok;
   }
   case RecordType::QueueTailRecord: {
-    kvdk_assert(pmp_record->next == kNullPmemOffset &&
+    kvdk_assert(pmp_record->next == kPmemNullOffset &&
                     checkDLRecordLinkageLeft(pmp_record),
                 "Bad linkage found when RestoreDlistRecords. Broken tail.");
     return Status::Ok;

--- a/engine/kv_engine.cpp
+++ b/engine/kv_engine.cpp
@@ -1742,7 +1742,7 @@ std::unique_ptr<Queue> KVEngine::createQueue(StringView const collection_name) {
   std::uint64_t ts = get_timestamp();
   uint64_t id = list_id_.fetch_add(1);
   std::string name(collection_name.data(), collection_name.size());
-  return std::make_unique<Queue>(pmem_allocator_.get(), name, id, ts);
+  return std::unique_ptr<Queue>(new Queue{pmem_allocator_.get(), name, id, ts});
 }
 
 Queue *KVEngine::findQueue(StringView const collection_name) {
@@ -1871,7 +1871,7 @@ Status KVEngine::RestoreQueueRecords(DLRecord *pmp_record) {
     std::lock_guard<std::mutex> lg{list_mu_};
     {
       queue_uptr_vec_.emplace_back(
-          std::make_unique<Queue>(pmem_allocator_.get(), pmp_record));
+          new Queue{pmem_allocator_.get(), pmp_record});
       queue_ptr = queue_uptr_vec_.back().get();
     }
 

--- a/engine/queue.hpp
+++ b/engine/queue.hpp
@@ -103,7 +103,7 @@ private:
   inline static std::string makeInternalKey(CollectionIDType id,
                                             StringView key) {
     std::string internal_key{id2View(id)};
-    internal_key += key;
+    internal_key += std::string{key};
     return internal_key;
   }
 

--- a/engine/unordered_collection.cpp
+++ b/engine/unordered_collection.cpp
@@ -1,12 +1,12 @@
 #include "unordered_collection.hpp"
 
 namespace KVDK_NAMESPACE {
-UnorderedCollection::UnorderedCollection(HashTable *hash_table_p,
+UnorderedCollection::UnorderedCollection(HashTable *hash_table_ptr,
                                          PMEMAllocator *pmem_allocator_p,
                                          std::string const name,
                                          CollectionIDType id,
                                          TimeStampType timestamp)
-    : hash_table_ptr_{hash_table_p}, collection_record_ptr_{nullptr},
+    : hash_table_ptr_{hash_table_ptr}, collection_record_ptr_{nullptr},
       dlinked_list_{pmem_allocator_p, timestamp, id2View(id), StringView{""}},
       collection_name_{name}, collection_id_{id}, timestamp_{timestamp} {
   {
@@ -30,10 +30,10 @@ UnorderedCollection::UnorderedCollection(HashTable *hash_table_p,
   }
 }
 
-UnorderedCollection::UnorderedCollection(HashTable *hash_table_p,
+UnorderedCollection::UnorderedCollection(HashTable *hash_table_ptr,
                                          PMEMAllocator *pmem_allocator_p,
                                          DLRecord *pmp_dlist_record)
-    : hash_table_ptr_{hash_table_p}, collection_record_ptr_{pmp_dlist_record},
+    : hash_table_ptr_{hash_table_ptr}, collection_record_ptr_{pmp_dlist_record},
       dlinked_list_{
           pmem_allocator_p,
           pmem_allocator_p->offset2addr_checked<DLRecord>(
@@ -118,8 +118,9 @@ ModifyReturn UnorderedCollection::Replace(DLRecord *pos,
   ++next;
 
   LockPair lock_prev_and_next;
-  if (!lockPositions(prev, next, lock, lock_prev_and_next))
+  if (!lockPositions(prev, next, lock, lock_prev_and_next)) {
     return ModifyReturn{};
+  }
 
   iterator curr =
       dlinked_list_.Replace(old, timestamp, makeInternalKey(key), value);
@@ -138,8 +139,9 @@ ModifyReturn UnorderedCollection::Erase(DLRecord *pos, LockType const &lock) {
   ++next;
 
   LockPair lock_prev_and_next;
-  if (!lockPositions(prev, next, lock, lock_prev_and_next))
+  if (!lockPositions(prev, next, lock, lock_prev_and_next)) {
     return ModifyReturn{};
+  }
 
   dlinked_list_.Erase(old);
 

--- a/engine/unordered_collection.hpp
+++ b/engine/unordered_collection.hpp
@@ -268,8 +268,8 @@ public:
   UnorderedIterator(std::shared_ptr<UnorderedCollection> sp_coll);
 
   /// UnorderedIterator currently does not support Seek to a key
-  [[gnu::deprecated]]
-  virtual void Seek([[gnu::unused]] std::string const &key) final override {
+  [[gnu::deprecated]] virtual void Seek([
+      [gnu::unused]] std::string const &key) final override {
     throw std::runtime_error{"UnorderedIterator does not support Seek()!"};
   }
 

--- a/engine/unordered_collection.hpp
+++ b/engine/unordered_collection.hpp
@@ -9,6 +9,8 @@
 
 #include <algorithm>
 
+#include "../extern/libpmemobj++/string_view.hpp"
+
 #include "kvdk/engine.hpp"
 #include "kvdk/iterator.hpp"
 
@@ -124,7 +126,6 @@ public:
   friend std::ostream &operator<<(std::ostream &out,
                                   UnorderedCollection const &col) {
     auto iter = col.collection_record_ptr_;
-    auto internal_key = iter->Key();
     out << "Name: " << col.Name() << "\t"
         << "ID: " << to_hex(col.ID()) << "\n";
     out << "Type: " << to_hex(iter->entry.meta.type) << "\t"
@@ -267,7 +268,8 @@ public:
   UnorderedIterator(std::shared_ptr<UnorderedCollection> sp_coll);
 
   /// UnorderedIterator currently does not support Seek to a key
-  virtual void Seek(std::string const &key) final override {
+  [[gnu::deprecated]]
+  virtual void Seek([[gnu::unused]] std::string const &key) final override {
     throw std::runtime_error{"UnorderedIterator does not support Seek()!"};
   }
 

--- a/engine/unordered_collection.hpp
+++ b/engine/unordered_collection.hpp
@@ -193,7 +193,7 @@ private:
   inline static std::string makeInternalKey(CollectionIDType id,
                                             StringView key) {
     std::string internal_key{id2View(id)};
-    internal_key += key;
+    internal_key += std::string{key};
     return internal_key;
   }
 

--- a/examples/graph_sim/bench/graph_bench.cpp
+++ b/examples/graph_sim/bench/graph_bench.cpp
@@ -5,13 +5,15 @@
 #include <gflags/gflags.h>
 #include <sys/time.h>
 
-#include <atomic>
 #include <cstdint>
+#include <cinttypes>
+
+#include <atomic>
 #include <random>
 #include <string>
 #include <thread>
+#include <unordered_map>
 #include <vector>
-#include <cinttypes>
 
 #include "graph_impl.hpp"
 #include "options.hpp"

--- a/examples/graph_sim/src/graph_algorithm/top_n.hpp
+++ b/examples/graph_sim/src/graph_algorithm/top_n.hpp
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <algorithm>
 #include <functional>
 #include <queue>
 #include <vector>

--- a/examples/graph_sim/src/kv_engines/KVEngine.hpp
+++ b/examples/graph_sim/src/kv_engines/KVEngine.hpp
@@ -6,10 +6,12 @@
 
 #include <cstdint>
 #include <cstdio>
-#include <kvdk/engine.hpp>
+
 #include <map>
 #include <string>
 #include <vector>
+
+#include <kvdk/engine.hpp>
 
 #if defined(BUILD_ROCKSDB)
 #include <rocksdb/db.h>
@@ -143,7 +145,7 @@ class MemoryEngine : public KVEngine {
 
  private:
   std::string path_;
-  std::map<std::string, std::string, std::less<>> memory_db_;
+  std::map<std::string, std::string> memory_db_;
 };
 
 // Construct the engine's map with their engine name.

--- a/examples/tutorial/cpp_api_tutorial.cpp
+++ b/examples/tutorial/cpp_api_tutorial.cpp
@@ -243,7 +243,7 @@ int main() {
   std::string engine_path{pmem_path};
 
   // Purge old KVDK instance
-  int sink = system(std::string{"rm -rf " + engine_path + "\n"}.c_str());
+  [[gnu::unused]] int sink = system(std::string{"rm -rf " + engine_path + "\n"}.c_str());
 
   status = kvdk::Engine::Open(engine_path, &engine, engine_configs, stdout);
   assert(status == kvdk::Status::Ok);

--- a/examples/tutorial/cpp_api_tutorial.cpp
+++ b/examples/tutorial/cpp_api_tutorial.cpp
@@ -243,7 +243,8 @@ int main() {
   std::string engine_path{pmem_path};
 
   // Purge old KVDK instance
-  [[gnu::unused]] int sink = system(std::string{"rm -rf " + engine_path + "\n"}.c_str());
+  [[gnu::unused]] int sink =
+      system(std::string{"rm -rf " + engine_path + "\n"}.c_str());
 
   status = kvdk::Engine::Open(engine_path, &engine, engine_configs, stdout);
   assert(status == kvdk::Status::Ok);

--- a/extern/libpmemobj++/string_view.hpp
+++ b/extern/libpmemobj++/string_view.hpp
@@ -1413,13 +1413,12 @@ std::ostream& operator<<(std::ostream& out, basic_string_view<CharT, Traits> con
 } /* namespace pmem */
 
 #if !USE_STL_STRING_VIEW
-// Really shouldn't do this.
-/// TODO: modify user code instead of open namespace std
+#include<bits/functional_hash.h>
 template<>
 struct std::hash<pmem::obj::string_view>
 {
 	size_t operator()(pmem::obj::string_view const& sv) const noexcept
-	{ return std::hash<std::string>{}(std::string{sv}); }
+	{ return std::_Hash_impl::hash(sv.data(), sv.size()); }
 };
 #endif /* !USE_STL_STRING_VIEW */
 

--- a/extern/libpmemobj++/string_view.hpp
+++ b/extern/libpmemobj++/string_view.hpp
@@ -15,7 +15,10 @@
 #include <string>
 #include <utility>
 
-#if __cpp_lib_string_view
+#define USE_STL_STRING_VIEW_IF_POSSIBLE false
+#define USE_STL_STRING_VIEW (__cpp_lib_string_view && USE_STL_STRING_VIEW_IF_POSSIBLE)
+
+#if USE_STL_STRING_VIEW
 #include <string_view>
 #endif
 
@@ -25,7 +28,7 @@ namespace pmem
 namespace obj
 {
 
-#if __cpp_lib_string_view
+#if USE_STL_STRING_VIEW
 
 template <typename CharT, typename Traits = std::char_traits<CharT>>
 using basic_string_view = std::basic_string_view<CharT, Traits>;
@@ -67,6 +70,8 @@ public:
 	constexpr basic_string_view(const CharT *data, size_type size);
 	constexpr basic_string_view(const std::basic_string<CharT, Traits> &s);
 	constexpr basic_string_view(const CharT *data);
+	
+	explicit operator std::basic_string<CharT, Traits>() const;
 
 	/** Constructor initialized with the basic_string_view *rhs*.
 	 *
@@ -213,6 +218,12 @@ constexpr inline basic_string_view<CharT, Traits>::basic_string_view(
 	const CharT *data)
     : data_(data), size_(Traits::length(data))
 {
+}
+
+template <class CharT, class Traits>
+inline basic_string_view<CharT, Traits>::operator std::basic_string<CharT, Traits>() const
+{
+	return std::basic_string<CharT, Traits>{data_, size_};
 }
 
 /**
@@ -1388,9 +1399,28 @@ operator>=(
 {
 	return lhs.compare(rhs) >= 0;
 }
+
+template <class CharT, class Traits>
+std::ostream& operator<<(std::ostream& out, basic_string_view<CharT, Traits> const& sv)
+{
+	out << std::basic_string<CharT, Traits>{sv};
+	return out;
+}
+
 #endif
 
 } /* namespace obj */
 } /* namespace pmem */
+
+#if !USE_STL_STRING_VIEW
+// Really shouldn't do this.
+/// TODO: modify user code instead of open namespace std
+template<>
+struct std::hash<pmem::obj::string_view>
+{
+	size_t operator()(pmem::obj::string_view const& sv) const noexcept
+	{ return std::hash<std::string>{}(std::string{sv}); }
+};
+#endif /* !USE_STL_STRING_VIEW */
 
 #endif /* LIBPMEMOBJ_CPP_STRING_VIEW */

--- a/tests/stress_test.cpp
+++ b/tests/stress_test.cpp
@@ -77,7 +77,8 @@ static void HashesIterateThrough(
       std::cout << "[Testing] Iterating backward through Hashes." << std::endl;
     }
 
-    ProgressBar progress_iterating{std::cout, "", n_total_possible_kv_pairs, report_progress};
+    ProgressBar progress_iterating{std::cout, "", n_total_possible_kv_pairs,
+                                   report_progress};
     while (u_iter->Valid()) {
       std::string value_got;
       auto key = u_iter->Key();

--- a/tests/stress_test.cpp
+++ b/tests/stress_test.cpp
@@ -101,9 +101,12 @@ static void HashesIterateThrough(
       }
 
       if (i == 0) // i == 0 for forward
+      {
         u_iter->Next();
-      else // i == 1 for backward
+      } else // i == 1 for backward
+      {
         u_iter->Prev();
+      }
     }
     // Remaining kv-pairs in possible_kv_pairs are deleted kv-pairs
     // Here we use a dirty trick to check for their deletion.
@@ -220,10 +223,10 @@ static void SortedSetsIterateThrough(
 namespace kvdk_testing {
 namespace // nested anonymous namespace to hide implementation
 {
-static void
-allXSet(std::function<kvdk::Status(StringView, StringView, StringView)> setter,
-        std::string collection_name, std::vector<StringView> const &keys,
-        std::vector<StringView> const &values, bool report_progress) {
+void allXSet(
+    std::function<kvdk::Status(StringView, StringView, StringView)> setter,
+    std::string collection_name, std::vector<StringView> const &keys,
+    std::vector<StringView> const &values, bool report_progress) {
   ASSERT_EQ(keys.size(), values.size())
       << "Must have same amount of keys and values to form kv-pairs!";
   kvdk::Status status;
@@ -236,13 +239,14 @@ allXSet(std::function<kvdk::Status(StringView, StringView, StringView)> setter,
           << "Fail to Set a key " << keys[j] << " in collection "
           << collection_name;
 
-      if ((j + 1) % 100 == 0 || j + 1 == keys.size())
+      if ((j + 1) % 100 == 0 || j + 1 == keys.size()) {
         progress_xsetting.Update(j + 1);
+      }
     }
   }
 }
 
-static void evenXSetOddXDelete(
+void evenXSetOddXDelete(
     std::function<kvdk::Status(StringView, StringView, StringView)> setter,
     std::function<kvdk::Status(StringView, StringView)> getter,
     std::string collection_name, std::vector<StringView> const &keys,
@@ -268,8 +272,9 @@ static void evenXSetOddXDelete(
             << collection_name;
       }
 
-      if ((j + 1) % 100 == 0 || j + 1 == keys.size())
+      if ((j + 1) % 100 == 0 || j + 1 == keys.size()) {
         progress_xupdating.Update(j + 1);
+      }
     }
   }
 }
@@ -399,7 +404,7 @@ protected:
 
     prepareKVPairs();
 
-    status = kvdk::Engine::Open(path_db.data(), &engine, configs, stderr);
+    status = kvdk::Engine::Open(path_db, &engine, configs, stderr);
     ASSERT_EQ(status, kvdk::Status::Ok) << "Fail to open the KVDK instance";
   }
 
@@ -411,7 +416,7 @@ protected:
   void RebootDB() {
     delete engine;
 
-    status = kvdk::Engine::Open(path_db.data(), &engine, configs, stderr);
+    status = kvdk::Engine::Open(path_db, &engine, configs, stderr);
     ASSERT_EQ(status, kvdk::Status::Ok) << "Fail to open the KVDK instance";
   }
 
@@ -426,12 +431,14 @@ protected:
     updateHashesPossibleKVPairs(collection_name, false);
 
     auto ModifyEngine = [&](int tid) {
-      if (tid == 0)
+      if (tid == 0) {
         kvdk_testing::AllHSet(engine, collection_name, grouped_keys[tid],
                               grouped_values[tid], true);
-      else
+
+      } else {
         kvdk_testing::AllHSet(engine, collection_name, grouped_keys[tid],
                               grouped_values[tid], false);
+      }
     };
 
     std::cout << "[Testing] Execute HSet in " << collection_name << "."
@@ -443,14 +450,15 @@ protected:
     updateHashesPossibleKVPairs(collection_name, true);
 
     auto ModifyEngine = [&](int tid) {
-      if (tid == 0)
+      if (tid == 0) {
         kvdk_testing::EvenHSetOddHDelete(engine, collection_name,
                                          grouped_keys[tid], grouped_values[tid],
                                          true);
-      else
+      } else {
         kvdk_testing::EvenHSetOddHDelete(engine, collection_name,
                                          grouped_keys[tid], grouped_values[tid],
                                          false);
+      }
     };
     std::cout << "[Testing] Execute HSet and HDelete in " << collection_name
               << "." << std::endl;
@@ -461,12 +469,13 @@ protected:
     updateSortedSetsPossibleKVPairs(collection_name, false);
 
     auto ModifyEngine = [&](int tid) {
-      if (tid == 0)
+      if (tid == 0) {
         kvdk_testing::AllSSetOnly(engine, collection_name, grouped_keys[tid],
                                   grouped_values[tid], true);
-      else
+      } else {
         kvdk_testing::AllSSetOnly(engine, collection_name, grouped_keys[tid],
                                   grouped_values[tid], false);
+      }
     };
     std::cout << "[Testing] Execute SSet in " << collection_name << "."
               << std::endl;
@@ -477,14 +486,15 @@ protected:
     updateSortedSetsPossibleKVPairs(collection_name, true);
 
     auto ModifyEngine = [&](int tid) {
-      if (tid == 0)
+      if (tid == 0) {
         kvdk_testing::EvenSSetOddSDelete(engine, collection_name,
                                          grouped_keys[tid], grouped_values[tid],
                                          true);
-      else
+      } else {
         kvdk_testing::EvenSSetOddSDelete(engine, collection_name,
                                          grouped_keys[tid], grouped_values[tid],
                                          false);
+      }
     };
     std::cout << "[Testing] Execute SSet and SDelete in " << collection_name
               << "." << std::endl;
@@ -519,11 +529,12 @@ private:
 
   void hashesIterateThrough(uint32_t tid, std::string collection_name,
                             bool report_progress) {
-    if (report_progress)
+    if (report_progress) {
       std::cout << "[Testing] HashesIterateThrough " << collection_name
                 << " with thread " << tid << ". "
                 << "It may take a few seconds to copy possible_kv_pairs."
                 << std::endl;
+    }
 
     // possible_kv_pairs is copied here
     kvdk_testing::HashesIterateThrough(
@@ -533,11 +544,12 @@ private:
 
   void sortedSetsIterateThrough(uint32_t tid, std::string collection_name,
                                 bool report_progress) {
-    if (report_progress)
+    if (report_progress) {
       std::cout << "[Testing] SortedSetsIterateThrough " << collection_name
                 << " with thread " << tid << ". "
                 << "It may take a few seconds to copy possible_kv_pairs."
                 << std::endl;
+    }
 
     // possible_kv_pairs is copied here
     kvdk_testing::SortedSetsIterateThrough(
@@ -569,8 +581,9 @@ private:
       // Erase keys that will be overwritten
       ProgressBar progress_erasing{std::cout, "", grouped_keys.size(), true};
       for (size_t tid = 0; tid < grouped_keys.size(); tid++) {
-        for (size_t i = 0; i < grouped_keys[tid].size(); i++)
+        for (size_t i = 0; i < grouped_keys[tid].size(); i++) {
           possible_kvs.erase(grouped_keys[tid][i]);
+        }
         progress_erasing.Update(tid + 1);
       }
     }
@@ -588,14 +601,16 @@ private:
         // We use kvs to track that and then put those into possible_kvs
         std::unordered_map<StringView, StringView> kvs;
         for (size_t i = 0; i < grouped_keys[tid].size(); i++) {
-          if ((i % 2 == 0) || !odd_indexed_is_deleted)
+          if ((i % 2 == 0) || !odd_indexed_is_deleted) {
             kvs[grouped_keys[tid][i]] = grouped_values[tid][i];
-          else
+          } else {
             kvs.erase(grouped_keys[tid][i]);
+          }
         }
 
-        for (auto iter = kvs.begin(); iter != kvs.end(); ++iter)
+        for (auto iter = kvs.begin(); iter != kvs.end(); ++iter) {
           possible_kvs.emplace(iter->first, iter->second);
+        }
 
         progress_updating.Update(tid + 1);
       }
@@ -620,11 +635,13 @@ private:
       ProgressBar progress_gen_kv{std::cout, "", n_kv_per_thread, true};
       for (size_t i = 0; i < n_kv_per_thread; i++) {
         value_pool.push_back(GetRandomString(sz_value_min, sz_value_max));
-        for (size_t tid = 0; tid < n_thread; tid++)
+        for (size_t tid = 0; tid < n_thread; tid++) {
           key_pool.push_back(GetRandomString(sz_key_min, sz_key_max));
+        }
 
-        if ((i + 1) % 1000 == 0 || (i + 1) == n_kv_per_thread)
+        if ((i + 1) % 1000 == 0 || (i + 1) == n_kv_per_thread) {
           progress_gen_kv.Update(i + 1);
+        }
       }
     }
     std::cout << "[Testing] Generating string_view for keys and values"

--- a/tests/stress_test.cpp
+++ b/tests/stress_test.cpp
@@ -77,7 +77,7 @@ static void HashesIterateThrough(
       std::cout << "[Testing] Iterating backward through Hashes." << std::endl;
     }
 
-    ProgressBar progress_iterating{std::cout, "", n_total_possible_kv_pairs};
+    ProgressBar progress_iterating{std::cout, "", n_total_possible_kv_pairs, report_progress};
     while (u_iter->Valid()) {
       std::string value_got;
       auto key = u_iter->Key();
@@ -505,7 +505,7 @@ protected:
 private:
   void purgeDB() {
     std::string cmd = "rm -rf " + path_db + "\n";
-    int _sink = system(cmd.data());
+    [[gnu::unused]] int _sink = system(cmd.data());
   }
 
   void shuffleKeys(size_t tid) {

--- a/tests/test_util.h
+++ b/tests/test_util.h
@@ -54,7 +54,7 @@ inline std::string GetRandomString(size_t min_len, size_t max_len) {
 }
 
 inline void LaunchNThreads(int n_thread, std::function<void(int tid)> func,
-                           uint32_t id_start = 0) {
+                           int id_start = 0) {
   std::vector<std::thread> ts;
   for (int i = id_start; i < id_start + n_thread; i++) {
     ts.emplace_back(std::thread(func, i));
@@ -122,7 +122,7 @@ private:
     if (!enabled_)
       return;
 
-    assert(0 <= current_progress_ && current_progress_ <= current_progress_);
+    assert(current_progress_ <= current_progress_);
 
     out_stream_ << "\r" << tag_ << std::setw(10) << std::right
                 << current_progress_ << "/" << std::setw(10) << std::left


### PR DESCRIPTION
Signed-off-by: ZiyanShi <ziyan.shi@intel.com>

<!--
Thank you for contributing to KVDK.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Problem Summary:
Use pmem::obj::string_view to remove dependency on C++17.

### What is changed and how it works?

What's Changed:
1. Add explicit conversion operator from `std::basic_string_view` to `std::basic_string`
2. Overload `operator<<`
3. Specialized `std::hash<pmem::obj::string_view>`
4. Avoid usage of std::make_unique
5. Explicitly delete copy constructor and move constructor of ChunkBasedAllocator to avoid misuse.
6. Use C++11 standard.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

Side effects

- Performance regression

No measurement
