### PR TITLE
Remove alignas(64)

### DIFF
--- a/engine/dram_allocator.hpp
+++ b/engine/dram_allocator.hpp
@@ -39,8 +39,8 @@ public:
   }
 
 private:
-  struct alignas(64) ThreadCache {
-    alignas(64) char *chunk_addr = nullptr;
+  struct ThreadCache {
+    char *chunk_addr = nullptr;
     uint64_t usable_bytes = 0;
     std::vector<void *> allocated_chunks;
 
@@ -48,10 +48,7 @@ private:
     ThreadCache(const ThreadCache &) = delete;
     ThreadCache(ThreadCache &&) = delete;
 
-    char padding[64 - sizeof(allocated_chunks) - sizeof(usable_bytes) -
-                 sizeof(chunk_addr)];
   };
-  static_assert(sizeof(ThreadCache) == 64);
 
   const uint32_t chunk_size_ = (1 << 20);
   Array<ThreadCache> thread_cache_;

--- a/engine/kv_engine.hpp
+++ b/engine/kv_engine.hpp
@@ -107,7 +107,7 @@ private:
   struct ThreadLocalRes {
     ThreadLocalRes() = default;
 
-    alignas(64) uint64_t newest_restored_ts = 0;
+    uint64_t newest_restored_ts = 0;
     PendingBatch *persisted_pending_batch = nullptr;
     std::unordered_map<uint64_t, int> visited_skiplist_ids;
   };

--- a/engine/pmem_allocator/free_list.hpp
+++ b/engine/pmem_allocator/free_list.hpp
@@ -182,7 +182,7 @@ private:
   // avoid contention. To balance free space entries among threads, if too many
   // entries cached by a thread, newly freed entries will be stored to
   // backup_entries and move to entry pool which shared by all threads.
-  struct alignas(64) ThreadCache {
+  struct ThreadCache {
     ThreadCache(uint32_t max_classified_b_size)
         : active_entries(max_classified_b_size),
           spins(max_classified_b_size +
@@ -202,10 +202,7 @@ private:
     Array<SpinMutex> spins;
     // timestamp of entry that recently fetched from active_entries
     uint64_t last_used_entry_ts;
-    char padding[64 - sizeof(active_entries) - sizeof(delay_freed_entries) -
-                 sizeof(spins) - sizeof(last_used_entry_ts)];
   };
-  static_assert(sizeof(ThreadCache) == 64);
 
   class SpaceCmp {
   public:

--- a/engine/pmem_allocator/pmem_allocator.hpp
+++ b/engine/pmem_allocator/pmem_allocator.hpp
@@ -112,9 +112,7 @@ private:
     // Space fetched from head of PMem segments, the size is aligned to
     // block_size_
     SizedSpaceEntry segment_entry;
-    char padding[64 - sizeof(SizedSpaceEntry) * 2];
   };
-  static_assert(sizeof(ThreadCache) == 64);
 
   bool AllocateSegmentSpace(SizedSpaceEntry *segment_entry);
 

--- a/engine/pmem_allocator/pmem_allocator.hpp
+++ b/engine/pmem_allocator/pmem_allocator.hpp
@@ -106,7 +106,7 @@ private:
                 uint32_t block_size, uint32_t num_write_threads);
   // Write threads cache a dedicated PMem segment and a free space to
   // avoid contention
-  struct alignas(64) ThreadCache {
+  struct ThreadCache {
     // Space got from free list, the size is aligned to block_size_
     SizedSpaceEntry free_entry;
     // Space fetched from head of PMem segments, the size is aligned to


### PR DESCRIPTION
Signed-off-by: ZiyanShi <ziyan.shi@intel.com>

<!--
Thank you for contributing to KVDK.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

## What problem does this PR solve?

Release build by g++ 8.4.0 fails unit test with segfault when opening the KVEngine

## What is changed and how it works?

### What's Changed:
Remove alignas(64) specifiers in ThreadCache class.

### How it works:
Default new operator and malloc guarantees 8 bytes or 16 bytes alignment. ThreadCache has alignas(64) specifiers and g++8 generates code uses instruction vmovdqa for std::vector<ThreadCache> constructor when filling newly allocated space with zeros. vmovdqa requires 32 bytes alignment and raises segfault.

## Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

Side effects

- Performance regression
For string, fill operation have 1% performance improvement, read zipf has 1% performance regression and update zipf has 7% performance improvement. Other operations have performance difference less than 1%.
All these differences falls into the range of experimental error.

Sorted, Queue and Hashes not measured.