### PR TITLE
Purge updated pmem record before free, and reorg hash entry index

### DIFF
--- a/engine/data_record.hpp
+++ b/engine/data_record.hpp
@@ -15,6 +15,8 @@ namespace KVDK_NAMESPACE {
 enum RecordType : uint16_t {
   Empty = 0,
   StringDataRecord = (1 << 0),
+  // Notice: StringDeleteReocrd is unused now, but will be used while
+  // implementing mvcc, so we do not remove it now
   StringDeleteRecord = (1 << 1),
 
   SortedDataRecord = (1 << 2),

--- a/engine/hash_table.cpp
+++ b/engine/hash_table.cpp
@@ -183,11 +183,7 @@ Status HashTable::SearchForWrite(const KeyHashHint &hint, const StringView &key,
   if (found) {
     (*entry_ptr)->header.status = HashEntryStatus::Updating;
   } else {
-    if ((*entry_ptr) == reusable_entry) {
-      if ((*entry_ptr)->header.status == HashEntryStatus::CleanReusable) {
-        (*entry_ptr)->header.status = HashEntryStatus::Updating;
-      }
-    } else {
+    if ((*entry_ptr) != reusable_entry) {
       (*entry_ptr)->header.status = HashEntryStatus::Initializing;
     }
   }

--- a/engine/hash_table.cpp
+++ b/engine/hash_table.cpp
@@ -249,10 +249,7 @@ void HashTable::Insert(const KeyHashHint &hint, HashEntry *entry_ptr,
   assert(write_thread.id >= 0);
 
   HashEntry new_hash_entry(hint.key_hash_value >> 32, type, index,
-                           (type == StringDeleteRecord)
-                               ? HashEntryStatus::DirtyReusable
-                               : HashEntryStatus::Normal,
-                           offset_type);
+                           HashEntryStatus::Normal, offset_type);
 
   bool new_entry = entry_ptr->header.status == HashEntryStatus::Initializing;
   memcpy_16(entry_ptr, &new_hash_entry);

--- a/engine/hash_table.cpp
+++ b/engine/hash_table.cpp
@@ -156,10 +156,6 @@ Status HashTable::SearchForWrite(const KeyHashHint &hint, const StringView &key,
       // reach end of buckets, reuse entry or allocate a new bucket
       if (i > 0 && i % num_entries_per_bucket_ == 0) {
         if (reusable_entry != nullptr) {
-          if (data_entry_meta && !reusable_entry->Empty()) {
-            memcpy(data_entry_meta, reusable_entry->index.string_record,
-                   sizeof(DataEntry));
-          }
           *entry_ptr = reusable_entry;
         } else {
           auto space = dram_allocator_.Allocate(hash_bucket_size_);

--- a/engine/hash_table.cpp
+++ b/engine/hash_table.cpp
@@ -47,34 +47,35 @@ bool HashTable::MatchHashEntry(const StringView &key, uint32_t hash_k_prefix,
 
     switch (hash_entry->header.offset_type) {
     case HashOffsetType::StringRecord: {
-      pmem_record = pmem_allocator_->offset2addr(hash_entry->offset);
-      data_entry_key = static_cast<StringRecord *>(pmem_record)->Key();
+      pmem_record = hash_entry->index.string_record;
+      data_entry_key = hash_entry->index.string_record->Key();
       break;
     }
     case HashOffsetType::UnorderedCollectionElement:
     case HashOffsetType::DLRecord: {
-      pmem_record = pmem_allocator_->offset2addr(hash_entry->offset);
-      data_entry_key = static_cast<DLRecord *>(pmem_record)->Key();
+      pmem_record = hash_entry->index.dl_record;
+      data_entry_key = hash_entry->index.dl_record->Key();
       break;
     }
     case HashOffsetType::UnorderedCollection: {
-      UnorderedCollection *p_collection = hash_entry->p_unordered_collection;
+      UnorderedCollection *p_collection =
+          hash_entry->index.p_unordered_collection;
       data_entry_key = p_collection->Name();
       break;
     }
     case HashOffsetType::Queue: {
-      Queue *p_collection = hash_entry->queue_ptr;
+      Queue *p_collection = hash_entry->index.queue_ptr;
       data_entry_key = p_collection->Name();
       break;
     }
     case HashOffsetType::SkiplistNode: {
-      SkiplistNode *dram_node = (SkiplistNode *)hash_entry->offset;
+      SkiplistNode *dram_node = hash_entry->index.skiplist_node;
       pmem_record = dram_node->record;
-      data_entry_key = static_cast<DLRecord *>(pmem_record)->Key();
+      data_entry_key = dram_node->record->Key();
       break;
     }
     case HashOffsetType::Skiplist: {
-      Skiplist *skiplist = (Skiplist *)hash_entry->offset;
+      Skiplist *skiplist = hash_entry->index.skiplist;
       pmem_record = skiplist->header()->record;
       data_entry_key = skiplist->Name();
       break;
@@ -156,8 +157,7 @@ Status HashTable::SearchForWrite(const KeyHashHint &hint, const StringView &key,
       if (i > 0 && i % num_entries_per_bucket_ == 0) {
         if (reusable_entry != nullptr) {
           if (data_entry_meta && !reusable_entry->Empty()) {
-            memcpy(data_entry_meta,
-                   pmem_allocator_->offset2addr(reusable_entry->offset),
+            memcpy(data_entry_meta, reusable_entry->index.string_record,
                    sizeof(DataEntry));
           }
           *entry_ptr = reusable_entry;
@@ -245,11 +245,10 @@ Status HashTable::SearchForRead(const KeyHashHint &hint, const StringView &key,
 }
 
 void HashTable::Insert(const KeyHashHint &hint, HashEntry *entry_ptr,
-                       uint16_t type, uint64_t offset,
-                       HashOffsetType offset_type) {
+                       uint16_t type, void *index, HashOffsetType offset_type) {
   assert(write_thread.id >= 0);
 
-  HashEntry new_hash_entry(hint.key_hash_value >> 32, type, offset,
+  HashEntry new_hash_entry(hint.key_hash_value >> 32, type, index,
                            (type == StringDeleteRecord)
                                ? HashEntryStatus::DirtyReusable
                                : HashEntryStatus::Normal,

--- a/engine/hash_table.hpp
+++ b/engine/hash_table.hpp
@@ -27,14 +27,6 @@ enum class HashEntryStatus : uint8_t {
   // A entry being updated by the same key, or a CleanReusable hash entry being
   // updated by a new key
   Updating = 1 << 2,
-  // A Normal hash entry of a delete record that is reusing by a new key, it's
-  // unknown if there are older version data of the same key existing so we can
-  // not free corresponding PMem data record
-  DirtyReusable = 1 << 3,
-  // A hash entry of a delete record which has no older version data of the same
-  // key exsiting on PMem, so the delete record can be safely freed after the
-  // hash entry updated by a new key
-  CleanReusable = 1 << 4,
   // A empty hash entry that points to nothing
   Empty = 1 << 5
 };
@@ -105,11 +97,7 @@ public:
     dst->index = src->index;
   }
 
-  bool Reusable() {
-    return (uint8_t)header.status & ((uint8_t)HashEntryStatus::CleanReusable |
-                                     (uint8_t)HashEntryStatus::DirtyReusable |
-                                     (uint8_t)HashEntryStatus::Empty);
-  }
+  bool Reusable() { return header.status == HashEntryStatus::Empty; }
 
   bool Empty() { return header.status == HashEntryStatus::Empty; }
 

--- a/engine/hash_table.hpp
+++ b/engine/hash_table.hpp
@@ -28,7 +28,7 @@ enum class HashEntryStatus : uint8_t {
   // updated by a new key
   Updating = 1 << 2,
   // A empty hash entry that points to nothing
-  Empty = 1 << 5
+  Empty = 1 << 3
 };
 
 enum class HashOffsetType : uint8_t {

--- a/engine/kv_engine.cpp
+++ b/engine/kv_engine.cpp
@@ -1151,6 +1151,8 @@ Status KVEngine::BatchWrite(const WriteBatch &write_batch) {
   // Free updated kvs / unused space
   for (size_t i = 0; i < write_batch.Size(); i++) {
     if (batch_hints[i].free_after_finish.size > 0) {
+      // TODO: we should purge all updated kvs before release locks, and after
+      // persist finish stage
       pmem_allocator_->Free(batch_hints[i].free_after_finish);
     }
   }

--- a/engine/kv_engine.hpp
+++ b/engine/kv_engine.hpp
@@ -101,7 +101,6 @@ private:
     TimeStampType timestamp{0};
     SizedSpaceEntry allocated_space{};
     SizedSpaceEntry free_after_finish{};
-    bool delay_free{false};
   };
 
   struct ThreadLocalRes {

--- a/engine/kv_engine.hpp
+++ b/engine/kv_engine.hpp
@@ -100,7 +100,8 @@ private:
   struct BatchWriteHint {
     TimeStampType timestamp{0};
     SizedSpaceEntry allocated_space{};
-    SizedSpaceEntry free_after_finish{};
+    HashTable::KeyHashHint hash_hint{};
+    void *pmem_record_to_free = nullptr;
   };
 
   struct ThreadLocalRes {

--- a/engine/kv_engine.hpp
+++ b/engine/kv_engine.hpp
@@ -261,12 +261,12 @@ private:
     }
   }
 
-  inline void purgeAndFree(DLRecord *record_pmmptr) {
-    record_pmmptr->Destroy();
-    pmem_allocator_->Free(
-        SizedSpaceEntry(pmem_allocator_->addr2offset_checked(record_pmmptr),
-                        record_pmmptr->entry.header.record_size,
-                        record_pmmptr->entry.meta.timestamp));
+  inline void purgeAndFree(void *pmem_record) {
+    DataEntry *data_entry = static_cast<DataEntry *>(pmem_record);
+    data_entry->Destroy();
+    pmem_allocator_->Free(SizedSpaceEntry(
+        pmem_allocator_->addr2offset_checked(pmem_record),
+        data_entry->header.record_size, data_entry->meta.timestamp));
   }
 
   std::vector<ThreadLocalRes> thread_res_;

--- a/engine/pmem_allocator/pmem_allocator.cpp
+++ b/engine/pmem_allocator/pmem_allocator.cpp
@@ -31,13 +31,6 @@ void PMEMAllocator::Free(const SizedSpaceEntry &entry) {
   }
 }
 
-void PMEMAllocator::DelayFree(const SizedSpaceEntry &entry) {
-  if (entry.size > 0) {
-    assert(entry.size % block_size_ == 0);
-    free_list_.DelayPush(entry);
-  }
-}
-
 void PMEMAllocator::PopulateSpace() {
   GlobalLogger.Info("Populating PMem space ...\n");
   std::vector<std::thread> ths;

--- a/engine/pmem_allocator/pmem_allocator.hpp
+++ b/engine/pmem_allocator/pmem_allocator.hpp
@@ -42,11 +42,6 @@ public:
   // Free a PMem space entry. The entry should be allocated by this allocator
   void Free(const SizedSpaceEntry &entry) override;
 
-  // These entries hold a delete record of some key, it can be safely freed only
-  // if no free space entry of smaller timestamp existing in the free list, so
-  // just record these entries. The entry should be allocated by this allocator.
-  void DelayFree(const SizedSpaceEntry &entry);
-
   // translate block_offset of allocated space to address
   inline void *offset2addr_checked(uint64_t offset) {
     assert(validate_offset(offset) && "Trying to access invalid offset");

--- a/engine/skiplist.cpp
+++ b/engine/skiplist.cpp
@@ -123,7 +123,7 @@ Status Skiplist::Rebuild() {
       return s;
     }
     if (hash_entry.header.offset_type == HashOffsetType::SkiplistNode) {
-      SkiplistNode *dram_node = (SkiplistNode *)hash_entry.offset;
+      SkiplistNode *dram_node = hash_entry.index.skiplist_node;
       int height = dram_node->Height();
       for (int i = 1; i <= height; i++) {
         splice.prevs[i]->RelaxedSetNext(i, dram_node);
@@ -194,7 +194,7 @@ Status Skiplist::CheckConnection(int height) {
     assert(s == Status::Ok && "search node fail!");
 
     if (hash_entry.header.offset_type == HashOffsetType::SkiplistNode) {
-      SkiplistNode *dram_node = (SkiplistNode *)hash_entry.offset;
+      SkiplistNode *dram_node = hash_entry.index.skiplist_node;
       if (next_node == nullptr) {
         if (dram_node->Height() >= height) {
           GlobalLogger.Error(
@@ -570,10 +570,10 @@ void SortedCollectionRebuilder::LinkedNode(uint64_t thread_id, int height,
               engine->pmem_allocator_->offset2addr<DLRecord>(next_offset);
 
           if (hash_entry.header.offset_type == HashOffsetType::Skiplist) {
-            next_node = ((Skiplist *)hash_entry.offset)->header();
+            next_node = hash_entry.index.skiplist->header();
           } else if (hash_entry.header.offset_type ==
                      HashOffsetType::SkiplistNode) {
-            next_node = (SkiplistNode *)hash_entry.offset;
+            next_node = hash_entry.index.skiplist_node;
           } else {
             continue;
           }
@@ -645,7 +645,7 @@ Status SortedCollectionRebuilder::DealWithFirstHeight(uint64_t thread_id,
              hash_entry.header.offset_type == HashOffsetType::DLRecord &&
                  "next entry should be skiplistnode type or data_entry type!");
       if (hash_entry.header.offset_type == HashOffsetType::SkiplistNode) {
-        next_node = (SkiplistNode *)hash_entry.offset;
+        next_node = hash_entry.index.skiplist_node;
       }
       // excepte data_entry node (height = 0)
       if (next_node) {
@@ -730,9 +730,9 @@ void SortedCollectionRebuilder::UpdateEntriesOffset(const KVEngine *engine) {
       continue;
     }
     if (hash_entry.header.offset_type == HashOffsetType::Skiplist) {
-      node = ((Skiplist *)hash_entry.offset)->header();
+      node = hash_entry.index.skiplist->header();
     } else if (hash_entry.header.offset_type == HashOffsetType::SkiplistNode) {
-      node = (SkiplistNode *)hash_entry.offset;
+      node = hash_entry.index.skiplist_node;
     }
     assert(node && "should be not empty!");
 

--- a/engine/unordered_collection.hpp
+++ b/engine/unordered_collection.hpp
@@ -217,8 +217,8 @@ public:
   UnorderedIterator(std::shared_ptr<UnorderedCollection> sp_coll);
 
   /// UnorderedIterator currently does not support Seek to a key
-  [[gnu::deprecated]] virtual void Seek([
-      [gnu::unused]] std::string const &key) final override {
+  [[gnu::deprecated]] virtual void
+  Seek([[gnu::unused]] std::string const &key) final override {
     throw std::runtime_error{"UnorderedIterator does not support Seek()!"};
   }
 

--- a/engine/utils.hpp
+++ b/engine/utils.hpp
@@ -223,7 +223,7 @@ public:
 template <typename T, typename Alloc = AlignedAllocator<T>> class Array {
 public:
   template <typename... Args>
-  explicit Array(uint64_t size, Args &&... args) : size_(size) {
+  explicit Array(uint64_t size, Args &&...args) : size_(size) {
     data_ = alloc_.allocate(size_);
     for (uint64_t i = 0; i < size; i++) {
       new (data_ + i) T{std::forward<Args>(args)...};

--- a/scripts/benchmark_impl.py
+++ b/scripts/benchmark_impl.py
@@ -119,14 +119,8 @@ def run_benchmark(
     # create report dir
     timestamp = datetime.datetime.now().strftime("%Y%m%d-%H%M")
     git_hash = git.Repo(search_parent_directories=True).head.object.hexsha
-    report_path = "./results-threads-{}-vs-{}-vs_dist-{}-collections-{}-commit-{}/{}-{}/".format(
-        n_thread,
-        value_size,
-        value_size_distribution,
-        num_collection,
-        git_hash,
-        data_type,
-        timestamp)
+    report_path = "./results-{}/commit-{}/threads-{}-vs-{}-vs_dist-{}-collections-{}/{}/".format(
+        timestamp, git_hash, n_thread, value_size, value_size_distribution, num_collection, data_type)
     os.system("mkdir -p {}".format(report_path))
 
     # run benchmarks

--- a/scripts/benchmark_impl.py
+++ b/scripts/benchmark_impl.py
@@ -119,8 +119,8 @@ def run_benchmark(
     # create report dir
     timestamp = datetime.datetime.now().strftime("%Y%m%d-%H%M")
     git_hash = git.Repo(search_parent_directories=True).head.object.hexsha
-    report_path = "./results-{}/commit-{}/threads-{}-vs-{}-vs_dist-{}-collections-{}/{}/".format(
-        timestamp, git_hash, n_thread, value_size, value_size_distribution, num_collection, data_type)
+    report_path = "./results-{}/commit-{}/threads-{}-vs-{}-vs_dist-{}-collections-{}/{}-{}/".format(
+        str(timestamp)[0:8], git_hash, n_thread, value_size, value_size_distribution, num_collection, data_type, timestamp)
     os.system("mkdir -p {}".format(report_path))
 
     # run benchmarks


### PR DESCRIPTION
<!--
Thank you for contributing to KVDK.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Issue Number: close #xxx <!-- REMOVE this line if no issue to close -->

Problem Summary:

- Existing impl free delete record with DelayFree mechanism, which makes confuse and potential space leakage
- Address stored in hash entry is cast to pointers from uint64_t, which is error prone and not clear

### What is changed and how it works?

What's Changed:

- Purge updated pmem record as Padding type before free, so we can remove DelayFree mechanism. StringDeleteRecord is removed as we don't need it
- remove uint64_t offset from hash entry, and store pointers directly

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Stress test

Side effects

- Performance regression
    - update performance of all types decreased ~10%
    - Space utilization for string should be improved as we don't need to write StringDeleteRecord anymore
