### PR TITLE
Faster populate

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@ if(DEBUG_CHECK)
     add_compile_definitions(DEBUG_CHECK)
 endif()
 
-set(KVDK_COMPILE_SHARED_FLAGS "-mavx -mavx2")
+set(KVDK_COMPILE_SHARED_FLAGS "-mavx -mavx2 -mavx512f")
 
 if (CMAKE_BUILD_TYPE STREQUAL "Release")
     set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} ${KVDK_COMPILE_SHARED_FLAGS}")


### PR DESCRIPTION
Signed-off-by: ZiyanShi <ziyan.shi@intel.com>

<!--
Thank you for contributing to KVDK.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What is changed and how it works?

What's Changed:

Use NT-Store to directly write zeros to newly allocated PMem space by mmap.

Tests <!-- At least one of them must be included. -->

- Unit test

Side effects

Performance change from main falls in 1% range.
Reduce populating time by about 30%.