### PR TITLE
Remove timestamp from free space entry

### DIFF
--- a/engine/allocator.hpp
+++ b/engine/allocator.hpp
@@ -8,18 +8,17 @@
 #include "structures.hpp"
 
 namespace KVDK_NAMESPACE {
-struct SizedSpaceEntry {
-  SizedSpaceEntry() = default;
+struct SpaceEntry {
+  SpaceEntry() = default;
 
-  SizedSpaceEntry(uint64_t _offset, uint64_t _size)
-      : offset(_offset), size(_size) {}
-  PMemOffsetType offset;
+  SpaceEntry(uint64_t _offset, uint64_t _size) : offset(_offset), size(_size) {}
+  uint64_t offset;
   uint64_t size = 0;
 };
 
 class Allocator {
 public:
-  virtual SizedSpaceEntry Allocate(uint64_t size) = 0;
-  virtual void Free(const SizedSpaceEntry &entry) = 0;
+  virtual SpaceEntry Allocate(uint64_t size) = 0;
+  virtual void Free(const SpaceEntry &entry) = 0;
 };
 } // namespace KVDK_NAMESPACE

--- a/engine/allocator.hpp
+++ b/engine/allocator.hpp
@@ -8,27 +8,13 @@
 #include "structures.hpp"
 
 namespace KVDK_NAMESPACE {
-// Free pmem blocks
-struct SpaceEntry {
-  uint64_t offset = 0;
-  // Allocator specific information
-  // For example, in PMEMAllocator, it indicates timestamp of data stored in
-  // the space entry, or 0 if it's a padding entry or a freed delete record
-  uint64_t info = 0;
-
-  SpaceEntry() = default;
-  explicit SpaceEntry(uint64_t bo, uint64_t i) : offset(bo), info(i) {}
-};
-
 struct SizedSpaceEntry {
   SizedSpaceEntry() = default;
 
-  SizedSpaceEntry(uint64_t _offset, uint64_t _size, uint64_t _info)
-      : space_entry(_offset, _info), size(_size) {}
-  SpaceEntry space_entry;
+  SizedSpaceEntry(uint64_t _offset, uint64_t _size)
+      : offset(_offset), size(_size) {}
+  PMemOffsetType offset;
   uint64_t size = 0;
-  SizedSpaceEntry(const SpaceEntry &_entry, uint64_t _size)
-      : space_entry(_entry), size(_size) {}
 };
 
 class Allocator {

--- a/engine/dlinked_list.hpp
+++ b/engine/dlinked_list.hpp
@@ -169,8 +169,8 @@ public:
         throw std::bad_alloc{};
       }
 
-      PMemOffsetType head_offset = head_space_entry.space_entry.offset;
-      PMemOffsetType tail_offset = tail_space_entry.space_entry.offset;
+      PMemOffsetType head_offset = head_space_entry.offset;
+      PMemOffsetType tail_offset = tail_space_entry.offset;
 
       // Persist tail first then head
       // If only tail is persisted then it can be deallocated by caller at
@@ -324,8 +324,7 @@ private:
     record_pmmptr->Destroy();
     pmem_allocator_ptr_->Free(
         SizedSpaceEntry(pmem_allocator_ptr_->addr2offset_checked(record_pmmptr),
-                        record_pmmptr->entry.header.record_size,
-                        record_pmmptr->entry.meta.timestamp));
+                        record_pmmptr->entry.header.record_size));
   }
 
   /// Emplace between iter_prev and iter_next, linkage not checked
@@ -350,7 +349,7 @@ private:
     if (space.size == 0) {
       throw std::bad_alloc{};
     }
-    std::uint64_t offset = space.space_entry.offset;
+    std::uint64_t offset = space.offset;
     void *pmp = pmem_allocator_ptr_->offset2addr_checked(offset);
 
     DLRecord *record = DLRecord::PersistDLRecord(

--- a/engine/dlinked_list.hpp
+++ b/engine/dlinked_list.hpp
@@ -323,8 +323,8 @@ private:
   void purgeAndFree(DLRecord *record_pmmptr) {
     record_pmmptr->Destroy();
     pmem_allocator_ptr_->Free(
-        SizedSpaceEntry(pmem_allocator_ptr_->addr2offset_checked(record_pmmptr),
-                        record_pmmptr->entry.header.record_size));
+        SpaceEntry(pmem_allocator_ptr_->addr2offset_checked(record_pmmptr),
+                   record_pmmptr->entry.header.record_size));
   }
 
   /// Emplace between iter_prev and iter_next, linkage not checked

--- a/engine/dram_allocator.cpp
+++ b/engine/dram_allocator.cpp
@@ -8,12 +8,12 @@
 
 namespace KVDK_NAMESPACE {
 
-void ChunkBasedAllocator::Free(const SizedSpaceEntry &entry) {
+void ChunkBasedAllocator::Free(const SpaceEntry &entry) {
   // Not supported yet
 }
 
-SizedSpaceEntry ChunkBasedAllocator::Allocate(uint64_t size) {
-  SizedSpaceEntry entry;
+SpaceEntry ChunkBasedAllocator::Allocate(uint64_t size) {
+  SpaceEntry entry;
   if (size > chunk_size_) {
     void *addr = malloc(size);
     if (addr != nullptr) {

--- a/engine/dram_allocator.cpp
+++ b/engine/dram_allocator.cpp
@@ -18,7 +18,7 @@ SizedSpaceEntry ChunkBasedAllocator::Allocate(uint64_t size) {
     void *addr = malloc(size);
     if (addr != nullptr) {
       entry.size = chunk_size_;
-      entry.space_entry.offset = addr2offset(addr);
+      entry.offset = addr2offset(addr);
       thread_cache_[write_thread.id].allocated_chunks.push_back(addr);
     }
     return entry;
@@ -35,8 +35,7 @@ SizedSpaceEntry ChunkBasedAllocator::Allocate(uint64_t size) {
   }
 
   entry.size = size;
-  entry.space_entry.offset =
-      addr2offset(thread_cache_[write_thread.id].chunk_addr);
+  entry.offset = addr2offset(thread_cache_[write_thread.id].chunk_addr);
   thread_cache_[write_thread.id].chunk_addr += size;
   thread_cache_[write_thread.id].usable_bytes -= size;
   return entry;

--- a/engine/dram_allocator.hpp
+++ b/engine/dram_allocator.hpp
@@ -19,8 +19,8 @@ namespace KVDK_NAMESPACE {
 // TODO: optimize, implement free
 class ChunkBasedAllocator : Allocator {
 public:
-  SizedSpaceEntry Allocate(uint64_t size) override;
-  void Free(const SizedSpaceEntry &entry) override;
+  SpaceEntry Allocate(uint64_t size) override;
+  void Free(const SpaceEntry &entry) override;
   inline void *offset2addr(uint64_t offset) { return (void *)offset; }
   template <typename T> inline T *offset2addr(uint64_t offset) {
     return static_cast<T *>(offset);

--- a/engine/hash_table.cpp
+++ b/engine/hash_table.cpp
@@ -25,8 +25,8 @@ HashTable::NewHashTable(uint64_t hash_bucket_num, uint32_t hash_bucket_size,
       delete table;
       table = nullptr;
     } else {
-      table->main_buckets_ = table->dram_allocator_.offset2addr(
-          main_buckets_space.space_entry.offset);
+      table->main_buckets_ =
+          table->dram_allocator_.offset2addr(main_buckets_space.offset);
     }
   }
   return table;
@@ -163,8 +163,7 @@ Status HashTable::SearchForWrite(const KeyHashHint &hint, const StringView &key,
             GlobalLogger.Error("Memory overflow!\n");
             return Status::MemoryOverflow;
           }
-          void *next_off =
-              dram_allocator_.offset2addr(space.space_entry.offset);
+          void *next_off = dram_allocator_.offset2addr(space.offset);
           memset(next_off, 0, space.size);
           memcpy_8(bucket_ptr + hash_bucket_size_ - 8, &next_off);
           *entry_ptr = (HashEntry *)next_off;

--- a/engine/kv_engine.cpp
+++ b/engine/kv_engine.cpp
@@ -208,7 +208,7 @@ Status KVEngine::MaybeInitWriteThread() {
 Status KVEngine::RestoreData(uint64_t thread_id) {
   write_thread.id = thread_id;
 
-  SizedSpaceEntry segment_recovering;
+  SpaceEntry segment_recovering;
   DataEntry data_entry_cached;
   bool fetch = false;
   uint64_t cnt = 0;
@@ -275,7 +275,7 @@ Status KVEngine::RestoreData(uint64_t thread_id) {
     // or the space is padding, empty or with corrupted record
     // Free the space and fetch another
     if (data_entry_cached.meta.type == RecordType::Padding) {
-      pmem_allocator_->Free(SizedSpaceEntry(
+      pmem_allocator_->Free(SpaceEntry(
           pmem_allocator_->addr2offset_checked(recovering_pmem_record),
           data_entry_cached.header.record_size));
       continue;
@@ -599,7 +599,7 @@ Status KVEngine::InitCollection(const StringView &collection, Collection **list,
 
   uint32_t request_size =
       sizeof(DLRecord) + collection.size() + sizeof(CollectionIDType) /* id */;
-  SizedSpaceEntry sized_space_entry = pmem_allocator_->Allocate(request_size);
+  SpaceEntry sized_space_entry = pmem_allocator_->Allocate(request_size);
   if (sized_space_entry.size == 0) {
     return Status::PmemOverflow;
   }
@@ -887,7 +887,7 @@ Status KVEngine::SSetImpl(Skiplist *skiplist, const StringView &user_key,
   }
 
   auto request_size = value.size() + collection_key.size() + sizeof(DLRecord);
-  SizedSpaceEntry sized_space_entry = pmem_allocator_->Allocate(request_size);
+  SpaceEntry sized_space_entry = pmem_allocator_->Allocate(request_size);
   if (sized_space_entry.size == 0) {
     return Status::PmemOverflow;
   }
@@ -1250,7 +1250,7 @@ Status KVEngine::StringDeleteImpl(const StringView &key) {
   HashEntry *entry_ptr = nullptr;
 
   uint32_t requested_size = key.size() + sizeof(StringRecord);
-  SizedSpaceEntry sized_space_entry;
+  SpaceEntry sized_space_entry;
 
   {
     auto hint = hash_table_->GetHint(key);
@@ -1282,7 +1282,7 @@ Status KVEngine::StringSetImpl(const StringView &key, const StringView &value) {
   uint32_t requested_size = v_size + key.size() + sizeof(StringRecord);
 
   // Space is already allocated for batch writes
-  SizedSpaceEntry sized_space_entry = pmem_allocator_->Allocate(requested_size);
+  SpaceEntry sized_space_entry = pmem_allocator_->Allocate(requested_size);
   if (sized_space_entry.size == 0) {
     return Status::PmemOverflow;
   }

--- a/engine/kv_engine.hpp
+++ b/engine/kv_engine.hpp
@@ -99,7 +99,7 @@ public:
 private:
   struct BatchWriteHint {
     TimeStampType timestamp{0};
-    SizedSpaceEntry allocated_space{};
+    SpaceEntry allocated_space{};
     HashTable::KeyHashHint hash_hint{};
     void *pmem_record_to_free = nullptr;
   };
@@ -281,8 +281,8 @@ private:
     DataEntry *data_entry = static_cast<DataEntry *>(pmem_record);
     data_entry->Destroy();
     pmem_allocator_->Free(
-        SizedSpaceEntry(pmem_allocator_->addr2offset_checked(pmem_record),
-                        data_entry->header.record_size));
+        SpaceEntry(pmem_allocator_->addr2offset_checked(pmem_record),
+                   data_entry->header.record_size));
   }
 
   std::vector<ThreadLocalRes> thread_res_;

--- a/engine/kv_engine.hpp
+++ b/engine/kv_engine.hpp
@@ -280,9 +280,9 @@ private:
   inline void purgeAndFree(void *pmem_record) {
     DataEntry *data_entry = static_cast<DataEntry *>(pmem_record);
     data_entry->Destroy();
-    pmem_allocator_->Free(SizedSpaceEntry(
-        pmem_allocator_->addr2offset_checked(pmem_record),
-        data_entry->header.record_size, data_entry->meta.timestamp));
+    pmem_allocator_->Free(
+        SizedSpaceEntry(pmem_allocator_->addr2offset_checked(pmem_record),
+                        data_entry->header.record_size));
   }
 
   std::vector<ThreadLocalRes> thread_res_;

--- a/engine/pmem_allocator/free_list.cpp
+++ b/engine/pmem_allocator/free_list.cpp
@@ -154,7 +154,7 @@ void Freelist::MergeAndCheckTSInPool() {
             large_entries_.emplace(offset, merged_blocks * block_size_);
             // move merged entries to merging pool to avoid redundant merging
           } else {
-            merged_entry_list[merged_blocks].emplace_back(std::move(offset));
+            merged_entry_list[merged_blocks].emplace_back(offset);
             if (merged_entry_list[merged_blocks].size() >= kMinMovableEntries) {
               merged_pool_.MoveEntryList(merged_entry_list[merged_blocks],
                                          merged_blocks);

--- a/engine/pmem_allocator/free_list.cpp
+++ b/engine/pmem_allocator/free_list.cpp
@@ -177,7 +177,7 @@ void Freelist::MergeAndCheckTSInPool() {
   }
 }
 
-void Freelist::Push(const SizedSpaceEntry &entry) {
+void Freelist::Push(const SpaceEntry &entry) {
   assert(entry.size > 0);
   assert(entry.size % block_size_ == 0);
   assert(entry.offset % block_size_ == 0);
@@ -194,7 +194,7 @@ void Freelist::Push(const SizedSpaceEntry &entry) {
   }
 }
 
-bool Freelist::Get(uint32_t size, SizedSpaceEntry *space_entry) {
+bool Freelist::Get(uint32_t size, SpaceEntry *space_entry) {
   assert(size % block_size_ == 0);
   auto b_size = size / block_size_;
   auto &thread_cache = thread_cache_[write_thread.id];
@@ -277,7 +277,7 @@ void Freelist::MoveCachedListsToPool() {
   }
 }
 
-bool Freelist::MergeGet(uint32_t size, SizedSpaceEntry *space_entry) {
+bool Freelist::MergeGet(uint32_t size, SpaceEntry *space_entry) {
   assert(size % block_size_ == 0);
   auto b_size = size / block_size_;
   auto &cache_list = thread_cache_[write_thread.id].active_entry_offsets;

--- a/engine/pmem_allocator/free_list.hpp
+++ b/engine/pmem_allocator/free_list.hpp
@@ -137,14 +137,14 @@ public:
                  block_size, num_threads, num_blocks, allocator) {}
 
   // Add a space entry
-  void Push(const SizedSpaceEntry &entry);
+  void Push(const SpaceEntry &entry);
 
   // Request a at least "size" free space entry
-  bool Get(uint32_t size, SizedSpaceEntry *space_entry);
+  bool Get(uint32_t size, SpaceEntry *space_entry);
 
   // Try to merge thread-cached free space entries to get a at least "size"
   // entry
-  bool MergeGet(uint32_t size, SizedSpaceEntry *space_entry);
+  bool MergeGet(uint32_t size, SpaceEntry *space_entry);
 
   // Merge adjacent free spaces stored in the entry pool into larger one
   //
@@ -189,8 +189,7 @@ private:
 
   class SpaceCmp {
   public:
-    bool operator()(const SizedSpaceEntry &s1,
-                    const SizedSpaceEntry &s2) const {
+    bool operator()(const SpaceEntry &s1, const SpaceEntry &s2) const {
       return s1.size > s2.size;
     }
   };
@@ -212,7 +211,7 @@ private:
   SpaceEntryPool active_pool_;
   SpaceEntryPool merged_pool_;
   // Store all large free space entries that larger than max_classified_b_size_
-  std::set<SizedSpaceEntry, SpaceCmp> large_entries_;
+  std::set<SpaceEntry, SpaceCmp> large_entries_;
   SpinMutex large_entries_spin_;
   PMEMAllocator *pmem_allocator_;
 };

--- a/engine/pmem_allocator/free_list.hpp
+++ b/engine/pmem_allocator/free_list.hpp
@@ -91,17 +91,17 @@ public:
   SpaceEntryPool(uint32_t max_classified_b_size)
       : pool_(max_classified_b_size), spins_(max_classified_b_size) {}
 
-  // move a entry list of b_size free space entries to pool, "src" will be empty
+  // move a list of b_size free space entries to pool, "src" will be empty
   // after move
-  void MoveEntryList(std::vector<SpaceEntry> &src, uint32_t b_size) {
+  void MoveEntryList(std::vector<PMemOffsetType> &src, uint32_t b_size) {
     std::lock_guard<SpinMutex> lg(spins_[b_size]);
     assert(b_size < pool_.size());
     pool_[b_size].emplace_back();
     pool_[b_size].back().swap(src);
   }
 
-  // try to fetch b_size free space entries from a entry list of pool to dst
-  bool TryFetchEntryList(std::vector<SpaceEntry> &dst, uint32_t b_size) {
+  // try to fetch a b_size free space entries list from pool to dst
+  bool TryFetchEntryList(std::vector<PMemOffsetType> &dst, uint32_t b_size) {
     if (pool_[b_size].size() != 0) {
       std::lock_guard<SpinMutex> lg(spins_[b_size]);
       if (pool_[b_size].size() != 0) {
@@ -114,7 +114,7 @@ public:
   }
 
 private:
-  std::vector<std::vector<std::vector<SpaceEntry>>> pool_;
+  std::vector<std::vector<std::vector<PMemOffsetType>>> pool_;
   // Entry lists of a same block size share a spin lock
   std::vector<SpinMutex> spins_;
 };
@@ -168,21 +168,22 @@ public:
   void OrganizeFreeSpace();
 
 private:
-  // Each write threads cache some freed space entries in active_entries to
-  // avoid contention. To balance free space entries among threads, if too many
-  // entries cached by a thread, newly freed entries will be stored to
+  // Each write threads cache some freed space entries in active_entry_offsets
+  // to avoid contention. To balance free space entries among threads, if too
+  // many entries cached by a thread, newly freed entries will be stored to
   // backup_entries and move to entry pool which shared by all threads.
   struct alignas(64) ThreadCache {
     ThreadCache(uint32_t max_classified_b_size)
-        : active_entries(max_classified_b_size), spins(max_classified_b_size) {}
+        : active_entry_offsets(max_classified_b_size),
+          spins(max_classified_b_size) {}
 
     ThreadCache() = delete;
     ThreadCache(ThreadCache &&) = delete;
     ThreadCache(const ThreadCache &) = delete;
 
     // Entry size stored in block unit
-    Array<std::vector<SpaceEntry>> active_entries;
-    // Protect active_entries
+    Array<std::vector<PMemOffsetType>> active_entry_offsets;
+    // Protect active_entry_offsets
     Array<SpinMutex> spins;
   };
 

--- a/engine/pmem_allocator/pmem_allocator.cpp
+++ b/engine/pmem_allocator/pmem_allocator.cpp
@@ -158,7 +158,7 @@ bool PMEMAllocator::AllocateSegmentSpace(SizedSpaceEntry *segment_entry) {
           return false;
         }
         Free(*segment_entry);
-        *segment_entry = SizedSpaceEntry{offset, segment_size_, 0};
+        *segment_entry = SizedSpaceEntry{offset, segment_size_};
         return true;
       }
       continue;
@@ -234,8 +234,7 @@ SizedSpaceEntry PMEMAllocator::Allocate(uint64_t size) {
           DataEntry padding(0, static_cast<uint32_t>(extra_space), 0,
                             RecordType::Padding, 0, 0);
           pmem_memcpy_persist(
-              offset2addr(thread_cache.free_entry.space_entry.offset +
-                          aligned_size),
+              offset2addr(thread_cache.free_entry.offset + aligned_size),
               &padding, sizeof(DataEntry));
         } else {
           aligned_size = thread_cache.free_entry.size;
@@ -244,7 +243,7 @@ SizedSpaceEntry PMEMAllocator::Allocate(uint64_t size) {
         space_entry = thread_cache.free_entry;
         space_entry.size = aligned_size;
         thread_cache.free_entry.size -= aligned_size;
-        thread_cache.free_entry.space_entry.offset += aligned_size;
+        thread_cache.free_entry.offset += aligned_size;
         return space_entry;
       }
       if (thread_cache.free_entry.size > 0) {
@@ -268,7 +267,7 @@ SizedSpaceEntry PMEMAllocator::Allocate(uint64_t size) {
   }
   space_entry = thread_cache.segment_entry;
   space_entry.size = aligned_size;
-  thread_cache.segment_entry.space_entry.offset += aligned_size;
+  thread_cache.segment_entry.offset += aligned_size;
   thread_cache.segment_entry.size -= aligned_size;
   return space_entry;
 }

--- a/engine/pmem_allocator/pmem_allocator.cpp
+++ b/engine/pmem_allocator/pmem_allocator.cpp
@@ -24,7 +24,7 @@ PMEMAllocator::PMEMAllocator(char *pmem, uint64_t pmem_size,
   init_data_size_2_block_size();
 }
 
-void PMEMAllocator::Free(const SizedSpaceEntry &entry) {
+void PMEMAllocator::Free(const SpaceEntry &entry) {
   if (entry.size > 0) {
     assert(entry.size % block_size_ == 0);
     free_list_.Push(entry);
@@ -137,7 +137,7 @@ PMEMAllocator *PMEMAllocator::NewPMEMAllocator(const std::string &pmem_file,
   return allocator;
 }
 
-bool PMEMAllocator::FreeAndFetchSegment(SizedSpaceEntry *segment_space_entry) {
+bool PMEMAllocator::FreeAndFetchSegment(SpaceEntry *segment_space_entry) {
   assert(segment_space_entry);
   if (segment_space_entry->size == segment_size_) {
     thread_cache_[write_thread.id].segment_entry = *segment_space_entry;
@@ -147,7 +147,7 @@ bool PMEMAllocator::FreeAndFetchSegment(SizedSpaceEntry *segment_space_entry) {
   return AllocateSegmentSpace(segment_space_entry);
 }
 
-bool PMEMAllocator::AllocateSegmentSpace(SizedSpaceEntry *segment_entry) {
+bool PMEMAllocator::AllocateSegmentSpace(SpaceEntry *segment_entry) {
   uint64_t offset;
   while (1) {
     offset = offset_head_.load(std::memory_order_relaxed);
@@ -158,7 +158,7 @@ bool PMEMAllocator::AllocateSegmentSpace(SizedSpaceEntry *segment_entry) {
           return false;
         }
         Free(*segment_entry);
-        *segment_entry = SizedSpaceEntry{offset, segment_size_};
+        *segment_entry = SpaceEntry{offset, segment_size_};
         return true;
       }
       continue;
@@ -212,8 +212,8 @@ bool PMEMAllocator::CheckDevDaxAndGetSize(const char *path, uint64_t *size) {
   return true;
 }
 
-SizedSpaceEntry PMEMAllocator::Allocate(uint64_t size) {
-  SizedSpaceEntry space_entry;
+SpaceEntry PMEMAllocator::Allocate(uint64_t size) {
+  SpaceEntry space_entry;
   uint32_t b_size = size_2_block_size(size);
   uint32_t aligned_size = b_size * block_size_;
   // Now the requested block size should smaller than segment size

--- a/engine/pmem_allocator/pmem_allocator.hpp
+++ b/engine/pmem_allocator/pmem_allocator.hpp
@@ -37,10 +37,10 @@ public:
                    uint32_t num_write_threads, bool use_devdax_mode);
 
   // Allocate a PMem space, return offset and actually allocated space in bytes
-  SizedSpaceEntry Allocate(uint64_t size) override;
+  SpaceEntry Allocate(uint64_t size) override;
 
   // Free a PMem space entry. The entry should be allocated by this allocator
-  void Free(const SizedSpaceEntry &entry) override;
+  void Free(const SpaceEntry &entry) override;
 
   // translate block_offset of allocated space to address
   inline void *offset2addr_checked(uint64_t offset) {
@@ -91,7 +91,7 @@ public:
 
   // Free space_entry and fetch a new segment in space_entry, unless
   // segment_space_entry is a full segment
-  bool FreeAndFetchSegment(SizedSpaceEntry *segment_space_entry);
+  bool FreeAndFetchSegment(SpaceEntry *segment_space_entry);
 
   // Regularly execute by background thread of KVDK
   void BackgroundWork() { free_list_.OrganizeFreeSpace(); }
@@ -103,13 +103,13 @@ private:
   // avoid contention
   struct alignas(64) ThreadCache {
     // Space got from free list, the size is aligned to block_size_
-    SizedSpaceEntry free_entry;
+    SpaceEntry free_entry;
     // Space fetched from head of PMem segments, the size is aligned to
     // block_size_
-    SizedSpaceEntry segment_entry;
+    SpaceEntry segment_entry;
   };
 
-  bool AllocateSegmentSpace(SizedSpaceEntry *segment_entry);
+  bool AllocateSegmentSpace(SpaceEntry *segment_entry);
 
   static bool CheckDevDaxAndGetSize(const char *path, uint64_t *size);
 

--- a/engine/queue.cpp
+++ b/engine/queue.cpp
@@ -17,7 +17,7 @@ Queue::Queue(PMEMAllocator *pmem_allocator_ptr, std::string const name,
       dlinked_list_.tail_pmmptr_ = nullptr;
       throw std::bad_alloc{};
     }
-    PMemOffsetType offset_list_record = list_record_space.space_entry.offset;
+    PMemOffsetType offset_list_record = list_record_space.offset;
     collection_record_ptr_ = DLRecord::PersistDLRecord(
         dlinked_list_.pmem_allocator_ptr_->offset2addr_checked(
             offset_list_record),

--- a/engine/skiplist.cpp
+++ b/engine/skiplist.cpp
@@ -353,9 +353,9 @@ bool Skiplist::Insert(const StringView &key, const StringView &value,
   uint64_t prev_offset = pmem_allocator_->addr2offset(splice.prev_pmem_record);
   uint64_t next_offset = pmem_allocator_->addr2offset(splice.next_pmem_record);
   DLRecord *new_record = DLRecord::PersistDLRecord(
-      pmem_allocator_->offset2addr(space_to_write.space_entry.offset),
-      space_to_write.size, timestamp, SortedDataRecord, prev_offset,
-      next_offset, internal_key, value);
+      pmem_allocator_->offset2addr(space_to_write.offset), space_to_write.size,
+      timestamp, SortedDataRecord, prev_offset, next_offset, internal_key,
+      value);
 
   // link new record to PMem
   InsertDLRecord(splice.prev_pmem_record, splice.next_pmem_record, new_record);
@@ -401,9 +401,9 @@ bool Skiplist::Update(const StringView &key, const StringView &value,
   uint64_t prev_offset = pmem_allocator_->addr2offset(splice.prev_pmem_record);
   uint64_t next_offset = pmem_allocator_->addr2offset(splice.next_pmem_record);
   DLRecord *new_record = DLRecord::PersistDLRecord(
-      pmem_allocator_->offset2addr(space_to_write.space_entry.offset),
-      space_to_write.size, timestamp, SortedDataRecord, prev_offset,
-      next_offset, internal_key, value);
+      pmem_allocator_->offset2addr(space_to_write.offset), space_to_write.size,
+      timestamp, SortedDataRecord, prev_offset, next_offset, internal_key,
+      value);
 
   // link new record
   InsertDLRecord(splice.prev_pmem_record, splice.next_pmem_record, new_record);

--- a/engine/skiplist.cpp
+++ b/engine/skiplist.cpp
@@ -339,8 +339,8 @@ bool Skiplist::FindInsertPos(Splice *splice, const StringView &insert_key,
 }
 
 bool Skiplist::Insert(const StringView &key, const StringView &value,
-                      const SizedSpaceEntry &space_to_write,
-                      TimeStampType timestamp, SkiplistNode **dram_node,
+                      const SpaceEntry &space_to_write, TimeStampType timestamp,
+                      SkiplistNode **dram_node,
                       const SpinMutex *inserting_key_lock) {
   Splice splice(this);
   std::unique_lock<SpinMutex> prev_record_lock;
@@ -387,8 +387,8 @@ bool Skiplist::Insert(const StringView &key, const StringView &value,
 
 bool Skiplist::Update(const StringView &key, const StringView &value,
                       const DLRecord *updated_record,
-                      const SizedSpaceEntry &space_to_write,
-                      TimeStampType timestamp, SkiplistNode *dram_node,
+                      const SpaceEntry &space_to_write, TimeStampType timestamp,
+                      SkiplistNode *dram_node,
                       const SpinMutex *updating_key_lock) {
   Splice splice(this);
   std::unique_lock<SpinMutex> prev_record_lock;

--- a/engine/skiplist.hpp
+++ b/engine/skiplist.hpp
@@ -248,7 +248,7 @@ public:
   //
   // Return true on success, return false on fail.
   bool Insert(const StringView &key, const StringView &value,
-              const SizedSpaceEntry &space_to_write, TimeStampType timestamp,
+              const SpaceEntry &space_to_write, TimeStampType timestamp,
               SkiplistNode **dram_node, const SpinMutex *inserting_key_lock);
 
   // Update "key" in skiplist
@@ -262,9 +262,9 @@ public:
   //
   // Return true on success, return false on fail.
   bool Update(const StringView &key, const StringView &value,
-              const DLRecord *updated_record,
-              const SizedSpaceEntry &space_to_write, TimeStampType timestamp,
-              SkiplistNode *dram_node, const SpinMutex *updating_key_lock);
+              const DLRecord *updated_record, const SpaceEntry &space_to_write,
+              TimeStampType timestamp, SkiplistNode *dram_node,
+              const SpinMutex *updating_key_lock);
 
   // Delete "key" from skiplist
   //

--- a/engine/unordered_collection.cpp
+++ b/engine/unordered_collection.cpp
@@ -21,7 +21,7 @@ UnorderedCollection::UnorderedCollection(HashTable *hash_table_ptr,
       dlinked_list_.tail_pmmptr_ = nullptr;
       throw std::bad_alloc{};
     }
-    PMemOffsetType offset_list_record = list_record_space.space_entry.offset;
+    PMemOffsetType offset_list_record = list_record_space.offset;
     collection_record_ptr_ = DLRecord::PersistDLRecord(
         dlinked_list_.pmem_allocator_ptr_->offset2addr_checked(
             offset_list_record),


### PR DESCRIPTION
Signed-off-by: Jiayu Wu <jiayu.wu@intel.com>

<!--
Thank you for contributing to KVDK.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Issue Number: close #xxx <!-- REMOVE this line if no issue to close -->

Problem Summary:

As we removed delay free mechanism in #140 , we do not need to store timestamp in space entry now

### What is changed and how it works?

What's Changed:

Removed timestamp from free space entry, and removed SizedSpaceEntry structure

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

Side effects

- Save memory for storing space entries in PMem allocator
