### PR TITLE
Fix recovery while max write threads changed

### DIFF
--- a/engine/kv_engine.cpp
+++ b/engine/kv_engine.cpp
@@ -315,7 +315,6 @@ Status KVEngine::RestoreData() {
       thread_res_[write_thread.id].newest_restored_ts = ts_recovering;
     }
 
-    Status s(Status::Ok);
     switch (data_entry_cached.meta.type) {
     case RecordType::SortedDataRecord: {
       s = RestoreSkiplistRecord(static_cast<DLRecord *>(recovering_pmem_record),

--- a/engine/kv_engine.hpp
+++ b/engine/kv_engine.hpp
@@ -186,7 +186,7 @@ private:
 
   Status Recovery();
 
-  Status RestoreData(uint64_t thread_id);
+  Status RestoreData();
 
   Status RestoreSkiplistHead(DLRecord *pmem_record,
                              const DataEntry &cached_entry);

--- a/engine/pmem_allocator/free_list.cpp
+++ b/engine/pmem_allocator/free_list.cpp
@@ -143,9 +143,8 @@ void Freelist::MergeAndCheckTSInPool() {
         if (merged_blocks > 0) {
           // Persist merged free entry on PMem
           if (merged_blocks > b_size) {
-            DataHeader header(0, merged_blocks * block_size_);
-            pmem_memcpy_persist(pmem_allocator_->offset2addr(offset), &header,
-                                sizeof(DataHeader));
+            pmem_allocator_->persistSpaceEntry(offset,
+                                               merged_blocks * block_size_);
           }
 
           // large space entries

--- a/engine/pmem_allocator/free_list.hpp
+++ b/engine/pmem_allocator/free_list.hpp
@@ -66,8 +66,9 @@ private:
 // free space entries (the third level).
 //
 // For a specific block size, a write thread will move a entry list from the
-// pool to its thread cache while no usable free space in the cache, or move a
-// entry list to the pool while too many entries cached.
+// pool to its thread cache while no usable free space in the cache, and the
+// background thread will move cached entry list to the pool for merge and
+// balance resource
 //
 // Organization of the three level vectors:
 //

--- a/engine/pmem_allocator/pmem_allocator.hpp
+++ b/engine/pmem_allocator/pmem_allocator.hpp
@@ -89,8 +89,8 @@ public:
   // Warning! this will zero the entire PMem space
   void PopulateSpace();
 
-  // Free space_entry and fetch a new segment in space_entry, unless
-  // segment_space_entry is a full segment
+  // Free segment_space_entry and fetch an allocated segment to
+  // segment_space_entry, until reach the end of allocated space
   bool FreeAndFetchSegment(SpaceEntry *segment_space_entry);
 
   // Regularly execute by background thread of KVDK
@@ -105,6 +105,8 @@ public:
   size_t PMemUsageInBytes();
 
 private:
+  friend Freelist;
+
   PMEMAllocator(char *pmem, uint64_t pmem_size, uint64_t num_segment_blocks,
                 uint32_t block_size, uint32_t num_write_threads);
   // Write threads cache a dedicated PMem segment and a free space to
@@ -122,6 +124,9 @@ private:
 
   static bool CheckDevDaxAndGetSize(const char *path, uint64_t *size);
 
+  // Mark and persist a space entry on PMem
+  void persistSpaceEntry(PMemOffsetType offset, uint64_t size);
+
   void init_data_size_2_block_size() {
     data_size_2_block_size_.resize(4096);
     for (size_t i = 0; i < data_size_2_block_size_.size(); i++) {
@@ -137,11 +142,13 @@ private:
     return data_size / block_size_ + (data_size % block_size_ == 0 ? 0 : 1);
   }
 
+  // Protect PMem offset head
+  SpinMutex offset_head_lock_;
+  uint64_t offset_head_;
   std::vector<PAllocThreadCache, AlignedAllocator<PAllocThreadCache>>
       palloc_thread_cache_;
   const uint32_t block_size_;
   const uint64_t segment_size_;
-  std::atomic<uint64_t> offset_head_;
   char *pmem_;
   uint64_t pmem_size_;
   Freelist free_list_;

--- a/engine/thread_manager.cpp
+++ b/engine/thread_manager.cpp
@@ -45,6 +45,7 @@ void ThreadManager::Release(const Thread &t) {
   if (t.id < 0) {
     return;
   }
+  assert(t.id < max_threads_);
   std::lock_guard<SpinMutex> lg(spin_);
   usable_id_.insert(t.id);
 }

--- a/engine/thread_manager.cpp
+++ b/engine/thread_manager.cpp
@@ -42,6 +42,9 @@ Status ThreadManager::MaybeInitThread(Thread &t) {
 }
 
 void ThreadManager::Release(const Thread &t) {
+  if (t.id < 0) {
+    return;
+  }
   std::lock_guard<SpinMutex> lg(spin_);
   usable_id_.insert(t.id);
 }


### PR DESCRIPTION
Signed-off-by: Jiayu Wu <jiayu.wu@intel.com>

<!--
Thank you for contributing to KVDK.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Problem Summary:

In current impl, data recovery will stop if the recovery thread meet an empty segment. If there are more write threads in last execution (say, 32) than recovery threads in this execution (say, 1), and some write threads not write any data to allocated segment yet before closing the instance, then data on other segments may lost during recovery.

### What is changed and how it works?

Mark the segment as allocated before allocation by persist segment size on PMem, so the recovery thread won't be early stopped.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

Side effects

- No regression
