### PR TITLE
Pmem usage quick fix

### DIFF
--- a/engine/kv_engine.cpp
+++ b/engine/kv_engine.cpp
@@ -81,7 +81,7 @@ void KVEngine::FreeSkiplistDramNodes() {
 
 void KVEngine::ReportPMemUsage() {
   auto total = pmem_allocator_->PMemUsageInBytes();
-  GlobalLogger.Info("PMem Usage: %ll B, %ll KB, %ll MB, %ll GB\n", total,
+  GlobalLogger.Info("PMem Usage: %ld B, %ld KB, %ld MB, %ld GB\n", total,
                     (total / (1ULL << 10)), (total / (1ULL << 20)), (total / (1ULL << 30)));
 }
 

--- a/engine/kv_engine.cpp
+++ b/engine/kv_engine.cpp
@@ -80,9 +80,9 @@ void KVEngine::FreeSkiplistDramNodes() {
 }
 
 void KVEngine::ReportPMemUsage() {
-  size_t total = pmem_allocator_->PMemUsageInBytes();
-  GlobalLogger.Info("PMem Usage: %llu B, %llu KB, %llu MB, %llu GB\n", total,
-                    (total >> 10), (total >> 20), (total >> 30));
+  auto total = pmem_allocator_->PMemUsageInBytes();
+  GlobalLogger.Info("PMem Usage: %ll B, %ll KB, %ll MB, %ll GB\n", total,
+                    (total / (1ULL << 10)), (total / (1ULL << 20)), (total / (1ULL << 30)));
 }
 
 void KVEngine::BackgroundWork() {

--- a/engine/pmem_allocator/pmem_allocator.cpp
+++ b/engine/pmem_allocator/pmem_allocator.cpp
@@ -32,8 +32,8 @@ void PMEMAllocator::Free(const SpaceEntry &entry) {
   }
 }
 
-size_t PMEMAllocator::PMemUsageInBytes() {
-  size_t total = 0;
+std::int64_t PMEMAllocator::PMemUsageInBytes() {
+  std::int64_t total = 0;
   for (auto const &ptcache : palloc_thread_cache_) {
     total += ptcache.allocated_sz;
   }

--- a/engine/pmem_allocator/pmem_allocator.cpp
+++ b/engine/pmem_allocator/pmem_allocator.cpp
@@ -162,7 +162,6 @@ bool PMEMAllocator::AllocateSegmentSpace(SpaceEntry *segment_entry) {
     *segment_entry = SpaceEntry{offset_head_, segment_size_};
     persistSpaceEntry(offset_head_, segment_size_);
     offset_head_ += segment_size_;
-    LogAllocation(write_thread.id, segment_size_);
     return true;
   }
   return false;
@@ -266,7 +265,6 @@ SpaceEntry PMEMAllocator::Allocate(uint64_t size) {
       GlobalLogger.Error("PMem OVERFLOW!\n");
       return space_entry;
     }
-    LogDeallocation(write_thread.id, palloc_thread_cache.segment_entry.size);
   }
   space_entry = palloc_thread_cache.segment_entry;
   space_entry.size = aligned_size;

--- a/engine/pmem_allocator/pmem_allocator.cpp
+++ b/engine/pmem_allocator/pmem_allocator.cpp
@@ -140,17 +140,11 @@ bool PMEMAllocator::FreeAndFetchSegment(SpaceEntry *segment_space_entry) {
   if (segment_space_entry->size == segment_size_) {
     persistSpaceEntry(segment_space_entry->offset, segment_size_);
     palloc_thread_cache_[write_thread.id].segment_entry = *segment_space_entry;
+    LogDeallocation(write_thread.id, segment_size_);
     return false;
   }
 
-  std::lock_guard<SpinMutex> lg(offset_head_lock_);
-  if (offset_head_ <= pmem_size_ - segment_size_) {
-    Free(*segment_space_entry);
-    *segment_space_entry = SpaceEntry{offset_head_, segment_size_};
-    offset_head_ += segment_size_;
-    return true;
-  }
-  return false;
+  return AllocateSegmentSpace(segment_space_entry);
 }
 
 bool PMEMAllocator::AllocateSegmentSpace(SpaceEntry *segment_entry) {
@@ -160,6 +154,7 @@ bool PMEMAllocator::AllocateSegmentSpace(SpaceEntry *segment_entry) {
     *segment_entry = SpaceEntry{offset_head_, segment_size_};
     persistSpaceEntry(offset_head_, segment_size_);
     offset_head_ += segment_size_;
+    LogAllocation(write_thread.id, segment_size_);
     return true;
   }
   return false;

--- a/engine/pmem_allocator/pmem_allocator.hpp
+++ b/engine/pmem_allocator/pmem_allocator.hpp
@@ -102,7 +102,7 @@ public:
   void LogDeallocation(size_t tid, size_t sz) {
     palloc_thread_cache_[tid].allocated_sz -= sz;
   }
-  size_t PMemUsageInBytes();
+  std::int64_t PMemUsageInBytes();
 
 private:
   friend Freelist;
@@ -117,7 +117,7 @@ private:
     // Space fetched from head of PMem segments, the size is aligned to
     // block_size_
     SpaceEntry segment_entry;
-    size_t allocated_sz{};
+    std::int64_t allocated_sz{};
   };
 
   bool AllocateSegmentSpace(SpaceEntry *segment_entry);


### PR DESCRIPTION
<!--
Thank you for contributing to KVDK.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

Repair pmem usage statistics.
In recovery, pmem allocator allocates by FreeAndFetchSegment and then Free some space.
We need to count this in.

Tests <!-- At least one of them must be included. -->

- Unit test
