### PR TITLE
Populate PMem space on allocator init

### DIFF
--- a/engine/kv_engine.cpp
+++ b/engine/kv_engine.cpp
@@ -170,7 +170,7 @@ Status KVEngine::Init(const std::string &name, const Configs &configs) {
   pmem_allocator_.reset(PMEMAllocator::NewPMEMAllocator(
       db_file_, configs_.pmem_file_size, configs_.pmem_segment_blocks,
       configs_.pmem_block_size, configs_.max_write_threads,
-      configs_.use_devdax_mode));
+      configs_.populate_pmem_space, configs_.use_devdax_mode));
   thread_manager_.reset(new (std::nothrow)
                             ThreadManager(configs_.max_write_threads));
   hash_table_.reset(HashTable::NewHashTable(
@@ -780,10 +780,6 @@ Status KVEngine::Recovery() {
   GlobalLogger.Info("Rebuild skiplist done\n");
 
   if (restored_.load() == 0) {
-    if (configs_.populate_pmem_space) {
-      pmem_allocator_->PopulateSpace();
-    }
-  } else {
     for (auto &ts : thread_res_) {
       if (ts.newest_restored_ts > newest_version_on_startup_) {
         newest_version_on_startup_ = ts.newest_restored_ts;

--- a/engine/pmem_allocator/pmem_allocator.hpp
+++ b/engine/pmem_allocator/pmem_allocator.hpp
@@ -34,7 +34,8 @@ public:
   static PMEMAllocator *
   NewPMEMAllocator(const std::string &pmem_file, uint64_t pmem_size,
                    uint64_t num_segment_blocks, uint32_t block_size,
-                   uint32_t num_write_threads, bool use_devdax_mode);
+                   uint32_t num_write_threads, bool populate_space_on_new_file,
+                   bool use_devdax_mode);
 
   // Allocate a PMem space, return offset and actually allocated space in bytes
   SpaceEntry Allocate(uint64_t size) override;
@@ -85,10 +86,6 @@ public:
     return offset < pmem_size_ && offset != kPmemNullOffset;
   }
 
-  // Populate PMem space so the following access can be faster
-  // Warning! this will zero the entire PMem space
-  void PopulateSpace();
-
   // Free segment_space_entry and fetch an allocated segment to
   // segment_space_entry, until reach the end of allocated space
   bool FreeAndFetchSegment(SpaceEntry *segment_space_entry);
@@ -120,9 +117,13 @@ private:
     size_t allocated_sz{};
   };
 
-  bool AllocateSegmentSpace(SpaceEntry *segment_entry);
+  // Populate PMem space so the following access can be faster
+  // Warning! this will zero the entire PMem space
+  void populateSpace();
 
-  static bool CheckDevDaxAndGetSize(const char *path, uint64_t *size);
+  bool allocateSegmentSpace(SpaceEntry *segment_entry);
+
+  static bool checkDevDaxAndGetSize(const char *path, uint64_t *size);
 
   // Mark and persist a space entry on PMem
   void persistSpaceEntry(PMemOffsetType offset, uint64_t size);

--- a/engine/utils.hpp
+++ b/engine/utils.hpp
@@ -14,6 +14,7 @@
 #include <mutex>
 #include <random>
 #include <string>
+#include <unistd.h>
 #include <vector>
 
 #include <sys/stat.h>
@@ -80,6 +81,11 @@ inline void memcpy_1(void *dst, const void *src) {
 
 inline std::string format_dir_path(const std::string &dir) {
   return dir.back() == '/' ? dir : dir + "/";
+}
+
+inline bool file_exist(const std::string &name) {
+  bool exist = access(name.c_str(), 0) == 0;
+  return exist;
 }
 
 inline int create_dir_if_missing(const std::string &name) {


### PR DESCRIPTION
Signed-off-by: Jiayu Wu <jiayu.wu@intel.com>

<!--
Thank you for contributing to KVDK.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Issue Number: close #xxx <!-- REMOVE this line if no issue to close -->

Problem Summary:

Current PMEMAllocator populate space after kvdk recovery, which is error prone and dangerous

### What is changed and how it works?

What's Changed:

Populate PMem space on allocator initiation if PMem file not exist

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
