### PR TITLE
Refactoring benchmark

### DIFF
--- a/benchmark/bench.cpp
+++ b/benchmark/bench.cpp
@@ -433,7 +433,7 @@ void ProcessBenchmarkConfigs() {
   case DataType::Queue: {
     if (FLAGS_scan) {
       throw std::invalid_argument{
-          R"(Scan is not supported for "String" and "Que" type data.)"};
+          R"(Scan is not supported for "String" and "Queue" type data.)"};
     }
   }
   default: {

--- a/benchmark/bench.cpp
+++ b/benchmark/bench.cpp
@@ -539,7 +539,7 @@ int main(int argc, char **argv) {
   }
 
   size_t const field_width = 15;
-  std::cout << "------- ops in seconds -----------\n"
+  std::cout << "----------------------------------------------------------\n"
             << std::setw(field_width) << "Time(ms)" << std::setw(field_width)
             << "Read Ops" << std::setw(field_width) << "Write Ops"
             << std::setw(field_width) << "Not Found" << std::setw(field_width)
@@ -608,7 +608,7 @@ int main(int argc, char **argv) {
         write_cnt[last_effective_idx] - write_cnt[warmup_time];
   }
 
-  std::cout << "------------ statistics ------------\n"
+  std::cout << "----------------------------------------------------------\n"
             << "Average Read Ops:\t" << total_effective_read / time_elapsed
             << ". "
             << "Average Write Ops:\t" << total_effective_write / time_elapsed

--- a/benchmark/generator.hpp
+++ b/benchmark/generator.hpp
@@ -13,18 +13,16 @@
 #include <x86intrin.h>
 
 #include "utils/rand64.hpp"
-#include "utils/zipf.hpp"
 #include "utils/range_iterator.hpp"
+#include "utils/zipf.hpp"
 
-struct PaddedEngine
-{
+struct PaddedEngine {
   extd::xorshift_engine gen;
   char padding[64];
 };
 
-struct PaddedRangeIterators
-{
+struct PaddedRangeIterators {
   extd::range_iterator<std::uint64_t> gen;
-  PaddedRangeIterators(std::uint64_t lo, std::uint64_t hi) : gen{lo, hi}{}
+  PaddedRangeIterators(std::uint64_t lo, std::uint64_t hi) : gen{lo, hi} {}
   char padding[64];
 };

--- a/benchmark/generator.hpp
+++ b/benchmark/generator.hpp
@@ -14,141 +14,17 @@
 
 #include "utils/rand64.hpp"
 #include "utils/zipf.hpp"
+#include "utils/range_iterator.hpp"
 
-inline uint64_t fast_random_64() {
-  thread_local unsigned long long state = 0;
-  static std::atomic_uint64_t seed_gen{1};
-  if (state == 0) {
-    state = seed_gen.fetch_add(1);
-  }
-  uint64_t x = state; /* The state must be seeded with a nonzero value. */
-  x ^= x >> 12;       // a
-  x ^= x << 25;       // b
-  x ^= x >> 27;       // c
-  state = x;
-  return x * 0x2545F4914F6CDD1D;
-}
-
-inline double fast_random_double() {
-  return (double)fast_random_64() / UINT64_MAX;
-}
-
-class Generator {
-public:
-  virtual uint64_t Next() = 0;
-};
-
-class ConstantGenerator : public Generator {
-public:
-  ConstantGenerator(uint64_t num) : num_(num) {}
-
-  uint64_t Next() override { return num_; }
-
-private:
-  uint64_t num_;
-};
-
-class UniformGenerator : public Generator {
-public:
-  UniformGenerator(uint64_t max_num, int scale = 64)
-      : base_(max_num / scale), scale_(scale), gen_cnt_(0) {
-    for (uint64_t i = 0; i < base_.size(); i++) {
-      base_[i] = i + 1;
-    }
-    std::shuffle(base_.begin(), base_.end(), std::mt19937_64());
-  }
-
-  virtual uint64_t Next() override {
-    auto next = gen_cnt_.fetch_add(1, std::memory_order_relaxed);
-    auto index = next % base_.size();
-    auto cur_scale = (next / base_.size()) % scale_;
-    return base_[index] + base_.size() * cur_scale;
-  }
-
-private:
-  std::vector<uint64_t> base_;
-  uint64_t scale_;
-  std::atomic<uint64_t> gen_cnt_;
-};
-
-class RangeIterator {
-public:
-  // Yield Number in range [lower, upper), by step.
-  RangeIterator(std::uint64_t lower, std::uint64_t upper,
-                std::uint64_t step = 1)
-      : lower_{lower}, upper_{upper}, step_{step}, curr_{lower_} {}
-
-  uint64_t Yield() {
-    std::uint64_t old = curr_;
-    curr_ += step_;
-    if (curr_ < upper_) {
-      return old;
-    } else {
-      // Sleep 100ms, slow down generation
-      std::this_thread::sleep_for(std::chrono::duration<int, std::milli>(100));
-      return curr_;
-    }
-  }
-
-private:
-  std::uint64_t lower_;
-  std::uint64_t upper_;
-  std::uint64_t step_;
-  std::uint64_t curr_;
+struct PaddedEngine
+{
+  extd::xorshift_engine gen;
   char padding[64];
 };
 
-class MultiThreadingRangeIterator : public Generator {
-public:
-  MultiThreadingRangeIterator(size_t n_thread, std::uint64_t lower,
-                              std::uint64_t upper, std::uint64_t step = 1)
-      : ranges_{}, id_pool_{0} {
-    size_t n = (upper - lower) / n_thread;
-    for (size_t i = 0; i < n_thread; i++) {
-      size_t lo = lower + i * n;
-      size_t hi = (i < n_thread - 1) ? lo + n : upper;
-      ranges_.emplace_back(RangeIterator{lo, hi, step});
-    }
-  }
-
-  virtual std::uint64_t Next() override {
-    thread_local std::uint64_t id = id_pool_.fetch_add(1);
-    assert(id < ranges_.size());
-    return ranges_[id].Yield();
-  }
-
-private:
-  std::vector<RangeIterator> ranges_;
-  std::atomic_uint64_t id_pool_;
-};
-
-class RandomGenerator : public Generator {
-public:
-  RandomGenerator(uint64_t max) : max_(max) {}
-
-  uint64_t Next() override { return fast_random_64() % max_ + 1; }
-
-private:
-  uint64_t max_;
-};
-
-class ZipfianGenerator : public Generator {
-public:
-  ZipfianGenerator(size_t n_thread, uint64_t max, double s = 0.99)
-      : zipf_dist{max, s}, engines(n_thread), id_pool_{0} {}
-
-  uint64_t Next() override {
-    thread_local std::uint64_t id = id_pool_.fetch_add(1);
-    return zipf_dist(engines[id].engine);
-  }
-
-private:
-  extd::zipfian_distribution<std::uint64_t> const zipf_dist;
-  struct PaddedEngine {
-    extd::xorshift_engine engine;
-    char padding[64];
-  };
-
-  std::vector<PaddedEngine> engines;
-  std::atomic_uint64_t id_pool_;
+struct PaddedRangeIterators
+{
+  extd::range_iterator<std::uint64_t> gen;
+  PaddedRangeIterators(std::uint64_t lo, std::uint64_t hi) : gen{lo, hi}{}
+  char padding[64];
 };

--- a/benchmark/utils/range_iterator.hpp
+++ b/benchmark/utils/range_iterator.hpp
@@ -1,26 +1,26 @@
 #ifndef EXTD_RANGE_ITERATOR_HPP
 #define EXTD_RANGE_ITERATOR_HPP
 
-#include <cstdint>
 #include <cassert>
+#include <cstdint>
 
 #include <type_traits>
 
-namespace extd
-{
-template<typename IntType, typename std::enable_if<std::is_integral<IntType>::value, bool>::type = true>
+namespace extd {
+template <typename IntType,
+          typename std::enable_if<std::is_integral<IntType>::value,
+                                  bool>::type = true>
 // Yield Number in range [lower, upper), by step.
 class range_iterator {
 public:
   range_iterator(IntType lo, IntType hi, IntType s = 1)
       : lower{lo}, upper{hi}, step{s}, curr{lower} {}
 
-  IntType operator()() 
-  {
+  IntType operator()() {
     IntType old = curr;
     curr += step;
     assert(old < upper);
-    return old;    
+    return old;
   }
 
 private:
@@ -30,6 +30,6 @@ private:
   IntType curr;
 };
 
-}
+} // namespace extd
 
 #endif // EXTD_RANGE_ITERATOR_HPP

--- a/benchmark/utils/range_iterator.hpp
+++ b/benchmark/utils/range_iterator.hpp
@@ -1,0 +1,35 @@
+#ifndef EXTD_RANGE_ITERATOR_HPP
+#define EXTD_RANGE_ITERATOR_HPP
+
+#include <cstdint>
+#include <cassert>
+
+#include <type_traits>
+
+namespace extd
+{
+template<typename IntType, typename std::enable_if<std::is_integral<IntType>::value, bool>::type = true>
+// Yield Number in range [lower, upper), by step.
+class range_iterator {
+public:
+  range_iterator(IntType lo, IntType hi, IntType s = 1)
+      : lower{lo}, upper{hi}, step{s}, curr{s} {}
+
+  IntType operator()() 
+  {
+    IntType old = curr;
+    curr += step;
+    assert(curr < upper);
+    return old;    
+  }
+
+private:
+  IntType lower;
+  IntType upper;
+  IntType step;
+  IntType curr;
+};
+
+}
+
+#endif // EXTD_RANGE_ITERATOR_HPP

--- a/benchmark/utils/range_iterator.hpp
+++ b/benchmark/utils/range_iterator.hpp
@@ -13,20 +13,20 @@ template<typename IntType, typename std::enable_if<std::is_integral<IntType>::va
 class range_iterator {
 public:
   range_iterator(IntType lo, IntType hi, IntType s = 1)
-      : lower{lo}, upper{hi}, step{s}, curr{s} {}
+      : lower{lo}, upper{hi}, step{s}, curr{lower} {}
 
   IntType operator()() 
   {
     IntType old = curr;
     curr += step;
-    assert(curr < upper);
+    assert(old < upper);
     return old;    
   }
 
 private:
-  IntType lower;
-  IntType upper;
-  IntType step;
+  IntType const lower;
+  IntType const upper;
+  IntType const step;
   IntType curr;
 };
 

--- a/scripts/benchmark_impl.py
+++ b/scripts/benchmark_impl.py
@@ -17,10 +17,9 @@ def __fill(exec, shared_para, data_type, report_path):
     os.system(cmd)
 
 
-def read_random(exec, shared_para, data_type, report_path):
+def read_random(exec, shared_para, data_type, report_path, num_operations):
     new_para = shared_para + \
-        " -fill=0 -type={} -read_ratio=1".format(
-            data_type)
+        " -fill=0 -type={} -read_ratio=1 -num_operations={}".format(data_type, num_operations)
     report = report_path + "read_random"
     print("Read random {}".format(data_type))
     cmd = "{0} {1} > {2}".format(exec, new_para, report)
@@ -28,10 +27,9 @@ def read_random(exec, shared_para, data_type, report_path):
     os.system(cmd)
 
 
-def insert_random(exec, shared_para, data_type, report_path):
+def insert_random(exec, shared_para, data_type, report_path, num_operations):
     new_para = shared_para + \
-        " -fill=0 -type={} -read_ratio=0 -existing_keys_ratio=0".format(
-            data_type)
+        " -fill=0 -type={} -read_ratio=0 -existing_keys_ratio=0 -num_operations={}".format(data_type, num_operations)
     report = report_path + "insert_random"
     print("Insert random {}".format(data_type))
     cmd = "{0} {1} > {2}".format(exec, new_para, report)
@@ -39,12 +37,12 @@ def insert_random(exec, shared_para, data_type, report_path):
     os.system(cmd)
 
 
-def batch_insert_random(exec, shared_para, data_type, report_path):
+def batch_insert_random(exec, shared_para, data_type, report_path, num_operations):
     if data_type != "string":
         return
     new_para = shared_para + \
-        " -fill=0 -type={} -read_ratio=0 -batch_size=100 -existing_keys_ratio=0".format(
-            data_type)
+        " -fill=0 -type={} -read_ratio=0 -batch_size=100"\
+        " -existing_keys_ratio=0 -num_operations={}".format(data_type, num_operations)
     report = report_path + "batch_insert_random"
     print("Batch insert random {}".format(data_type))
     cmd = "{0} {1} > {2}".format(exec, new_para, report)
@@ -52,10 +50,9 @@ def batch_insert_random(exec, shared_para, data_type, report_path):
     os.system(cmd)
 
 
-def update_random(exec, shared_para, data_type, report_path):
+def update_random(exec, shared_para, data_type, report_path, num_operations):
     new_para = shared_para + \
-        " -fill=0 -type={} -read_ratio=0".format(
-            data_type)
+        " -fill=0 -type={} -read_ratio=0 -num_operations={}".format(data_type, num_operations)
     report = report_path + "update_random"
     print("Update random {}".format(data_type))
     cmd = "{0} {1} > {2}".format(exec, new_para, report)
@@ -63,10 +60,9 @@ def update_random(exec, shared_para, data_type, report_path):
     os.system(cmd)
 
 
-def read_write_random(exec, shared_para, data_type, report_path):
+def read_write_random(exec, shared_para, data_type, report_path, num_operations):
     new_para = shared_para + \
-        " -fill=0 -type={} -read_ratio=0.9".format(
-            data_type)
+        " -fill=0 -type={} -read_ratio=0.9 -num_operations={}".format(data_type, num_operations)
     report = report_path + "read_write_random"
     print("Read write random {}".format(data_type))
     cmd = "{0} {1} > {2}".format(exec, new_para, report)
@@ -74,11 +70,11 @@ def read_write_random(exec, shared_para, data_type, report_path):
     os.system(cmd)
 
 
-def range_scan(exec, shared_para, data_type, report_path):
+def range_scan(exec, shared_para, data_type, report_path, num_operations):
     if data_type == "string" or data_type == "queue":
         return
     new_para = shared_para + \
-        " -fill=0 -type={} -read_ratio=1 -scan=1".format(data_type)
+        " -fill=0 -type={} -read_ratio=1 -scan=1 -num_operations={}".format(data_type, num_operations)
     report = report_path + "range_scan"
     print("Range scan {}".format(data_type))
     cmd = "{0} {1} > {2}".format(exec, new_para, report)
@@ -155,8 +151,7 @@ def run_benchmark(
         "-timeout={7} "\
         "-value_size={8} "\
         "-value_size_distribution={9} "\
-        "-key_distribution={10} "\
-        "-num_operations={11}".format(
+        "-key_distribution={10} ".format(
         pmem_path, 
         pmem_size, 
         populate_on_fill, 
@@ -172,6 +167,7 @@ def run_benchmark(
     # we always fill data before run benchmarks
     __fill(exec, shared_para, data_type, report_path)
     for benchmark in benchmarks:
+        num_operations = num_operations if (benchmark == insert_random or benchmark == batch_insert_random) else 1024 * 1024 * 1024 * 10
         benchmark(exec, shared_para, data_type, report_path)
 
     os.system("rm -rf {0}".format(pmem_path))

--- a/scripts/benchmark_impl.py
+++ b/scripts/benchmark_impl.py
@@ -38,7 +38,7 @@ def insert_random(exec, shared_para, data_type, report_path, num_operations):
 
 
 def batch_insert_random(exec, shared_para, data_type, report_path, num_operations):
-    if data_type != "string" or data_type != "blackhole":
+    if data_type != "string" and data_type != "blackhole":
         return
     new_para = shared_para + \
         " -fill=0 -type={} -read_ratio=0 -batch_size=100"\

--- a/scripts/benchmark_impl.py
+++ b/scripts/benchmark_impl.py
@@ -165,7 +165,11 @@ def run_benchmark(
     # we always fill data before run benchmarks
     __fill(exec, shared_para, data_type, report_path)
     for benchmark in benchmarks:
-        num_operations = num_kv if (benchmark == insert_random or benchmark == batch_insert_random) else 1024 * 1024 * 1024 * 10
+        num_operations = num_kv 
+        num_operations = 1024 * 1024 * 1024 * 10 if (benchmark == read_random) else num_operations
+        num_operations = 1024 * 1024 * 1024 * 10 if (benchmark == update_random) else num_operations
+        num_operations = 1024 * 1024 * 1024 * 10 if (benchmark == range_scan) else num_operations
+        num_operations = num_operations * 5 if (benchmark == read_write_random) else num_operations
         benchmark(exec, shared_para, data_type, report_path, num_operations)
 
     os.system("rm -rf {0}".format(pmem_path))

--- a/scripts/benchmark_impl.py
+++ b/scripts/benchmark_impl.py
@@ -38,7 +38,7 @@ def insert_random(exec, shared_para, data_type, report_path, num_operations):
 
 
 def batch_insert_random(exec, shared_para, data_type, report_path, num_operations):
-    if data_type != "string":
+    if data_type != "string" or data_type != "blackhole":
         return
     new_para = shared_para + \
         " -fill=0 -type={} -read_ratio=0 -batch_size=100"\

--- a/scripts/benchmark_impl.py
+++ b/scripts/benchmark_impl.py
@@ -125,7 +125,7 @@ def run_benchmark(
     # create report dir
     timestamp = datetime.datetime.now().strftime("%Y%m%d-%H%M")
     git_hash = git.Repo(search_parent_directories=True).head.object.hexsha
-    report_path = "./results/{0}-key_dist-{1}-vsize-{2}-vsize_dist-threads-{3}-threads-{4}-collections-{5}-commit-{6}-time-{7}/".format(
+    report_path = "./results/{0}-key_dist-{1}-vsize-{2}-vsize_dist-{3}-threads-{4}-collections-{5}-commit-{6}-time-{7}/".format(
         data_type,
         key_distribution,
         value_size,

--- a/scripts/benchmark_impl.py
+++ b/scripts/benchmark_impl.py
@@ -121,7 +121,6 @@ def run_benchmark(
 
     # 1/4 for fill, 1/4 for insert, 1/4 for batch_write
     num_kv = pmem_size // 4 // avg_kv_size
-    num_operations = 1024 * 1024 * 1024 * 4
 
     # create report dir
     timestamp = datetime.datetime.now().strftime("%Y%m%d-%H%M")
@@ -162,12 +161,11 @@ def run_benchmark(
         timeout, 
         value_size, 
         value_size_distribution,
-        key_distribution,
-        num_operations)
+        key_distribution)
     # we always fill data before run benchmarks
     __fill(exec, shared_para, data_type, report_path)
     for benchmark in benchmarks:
-        num_operations = num_operations if (benchmark == insert_random or benchmark == batch_insert_random) else 1024 * 1024 * 1024 * 10
-        benchmark(exec, shared_para, data_type, report_path)
+        num_operations = num_kv if (benchmark == insert_random or benchmark == batch_insert_random) else 1024 * 1024 * 1024 * 10
+        benchmark(exec, shared_para, data_type, report_path, num_operations)
 
     os.system("rm -rf {0}".format(pmem_path))

--- a/scripts/benchmark_impl.py
+++ b/scripts/benchmark_impl.py
@@ -125,14 +125,14 @@ def run_benchmark(
     # create report dir
     timestamp = datetime.datetime.now().strftime("%Y%m%d-%H%M")
     git_hash = git.Repo(search_parent_directories=True).head.object.hexsha
-    report_path = "./results/{0}-key_dist-{1}-vsize-{2}-vsize_dist-{3}-threads-{4}-collections-{5}-commit-{6}-time-{7}/".format(
+    report_path = "./results/commit-{0}/data_type-{1}-key_dist-{2}/vsize-{3}-vsize_dist-{4}-threads-{5}-collections-{6}-time-{7}/".format(
+        git_hash[0:8], 
         data_type,
         key_distribution,
         value_size,
         value_size_distribution, 
         n_thread, 
         num_collection, 
-        git_hash[0:8], 
         timestamp)
     os.system("mkdir -p {}".format(report_path))
 

--- a/scripts/run_benchmark.py
+++ b/scripts/run_benchmark.py
@@ -18,12 +18,12 @@ pmem_size = 384 * 1024 * 1024 * 1024  # we need enough space to test insert
 num_collection = 16
 
 benchmarks = [
-    benchmark_impl.insert_random,
     benchmark_impl.batch_insert_random, 
-    benchmark_impl.update_random, 
+    benchmark_impl.insert_random,
     benchmark_impl.range_scan, 
     benchmark_impl.read_random, 
-    benchmark_impl.read_write_random]
+    benchmark_impl.read_write_random,
+    benchmark_impl.update_random]
 
 data_types = []
 

--- a/scripts/run_benchmark.py
+++ b/scripts/run_benchmark.py
@@ -10,13 +10,11 @@ exec = "numactl --cpunodebind={0} --membind={0} {1}".format(numanode, bin)
 num_thread = 64
 value_size = 120
 # constant: value size always be "value_size",
-# random: value size randomly distributed in [1, value_size]
+# random: value size uniformly distributed in [1, value_size]
 value_size_distributions = ['constant']
-key_distributions = ['random', 'zipf']
-test_duration = 10                         # For operations other than fill
-populate_on_fill = 1                    # For fill only
+timeout = 30                          # For operations other than fill
+populate_on_fill = 1                  # For fill only
 pmem_size = 384 * 1024 * 1024 * 1024  # we need enough space to test insert
-fill_data_size = 96 * 1024 * 1024 * 1024
 num_collection = 16
 
 benchmarks = [
@@ -30,9 +28,10 @@ benchmarks = [
 data_types = []
 
 if __name__ == "__main__":
-    usage = 'usage: run_benchmark.py [data type]\n\
-        data type can be "string", "sorted", "hash", "queue", or "all" to bench them all'
-    if len(sys.argv) != 2:
+    usage = 'usage: run_benchmark.py [data type] [key distribution]\n\
+        data type can be "string", "sorted", "hash", "queue", or "all"\n\
+        key distribution can be "random" or "zipf" or "all".'
+    if len(sys.argv) != 3:
         print(usage)
         exit(1)
     if sys.argv[1] == 'string':
@@ -50,6 +49,16 @@ if __name__ == "__main__":
     else:
         print(usage)
         exit(1)
+    if sys.argv[2] == 'random':
+        key_distributions = ['random']
+    elif sys.argv[2] == 'zipf':
+        key_distributions = ['zipf']
+    elif sys.argv[2] == 'all':
+        key_distributions = ['random','zipf']
+    else:
+        print(usage)
+        exit(1)
+    
     for [data_type, vsz_dist, k_dist] in itertools.product(data_types, value_size_distributions, key_distributions):
-        benchmark_impl.run_benchmark(data_type, exec, pmem_path, pmem_size, populate_on_fill, fill_data_size,
-                                     num_thread, num_collection, test_duration, k_dist, value_size, vsz_dist, benchmarks)
+        benchmark_impl.run_benchmark(data_type, exec, pmem_path, pmem_size, populate_on_fill,
+                                     num_thread, num_collection, timeout, k_dist, value_size, vsz_dist, benchmarks)

--- a/scripts/run_benchmark.py
+++ b/scripts/run_benchmark.py
@@ -18,11 +18,11 @@ pmem_size = 384 * 1024 * 1024 * 1024  # we need enough space to test insert
 num_collection = 16
 
 benchmarks = [
-    benchmark_impl.read_random, 
-    benchmark_impl.range_scan, 
     benchmark_impl.insert_random,
     benchmark_impl.batch_insert_random, 
     benchmark_impl.update_random, 
+    benchmark_impl.range_scan, 
+    benchmark_impl.read_random, 
     benchmark_impl.read_write_random]
 
 data_types = []


### PR DESCRIPTION
### What problem does this PR solve?

Refactor benchmark.
Average ops will now only counts in operations 2 seconds after launching threads, 
and the counter will stops when 1 thread has joined.
This gives a more accurate performance measurement.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

Side effects

Batch Write mysteriously improve by 20%. The reason is unknown.
Other performance improvement or regression falls in 1% change from main branch.