### PR TITLE
Aliasing, and change some string_view to string

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,18 +73,21 @@ configure_file(kvdk.pc.in kvdk.pc @ONLY)
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/kvdk.pc
 	DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
 
-set_target_properties(
-engine PROPERTIES PUBLIC_HEADER 
-"\
-include/kvdk/configs.hpp;\
-include/kvdk/engine.h;\
-include/kvdk/engine.hpp;\
-include/kvdk/iterator.hpp;\
-include/kvdk/namespace.hpp;\
-include/kvdk/status.h;\
-include/kvdk/status.hpp;\
-include/kvdk/write_batch.hpp")
+set(KVDK_PUBLIC_HEADERS
+    ${PROJECT_SOURCE_DIR}/include/kvdk/collection.hpp
+    ${PROJECT_SOURCE_DIR}/include/kvdk/comparator.hpp
+    ${PROJECT_SOURCE_DIR}/include/kvdk/configs.hpp
+    ${PROJECT_SOURCE_DIR}/include/kvdk/engine.h
+    ${PROJECT_SOURCE_DIR}/include/kvdk/engine.hpp
+    ${PROJECT_SOURCE_DIR}/include/kvdk/iterator.hpp
+    ${PROJECT_SOURCE_DIR}/include/kvdk/namespace.hpp
+    ${PROJECT_SOURCE_DIR}/include/kvdk/status.h
+    ${PROJECT_SOURCE_DIR}/include/kvdk/status.hpp
+    ${PROJECT_SOURCE_DIR}/include/kvdk/write_batch.hpp
+    ${PROJECT_SOURCE_DIR}/extern/libpmemobj++/string_view.hpp
+)
 
+set_target_properties(engine PROPERTIES PUBLIC_HEADER "${KVDK_PUBLIC_HEADERS}")
 
 install(TARGETS engine
 		PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/kvdk

--- a/engine/c.cc
+++ b/engine/c.cc
@@ -98,12 +98,11 @@ void KVDKRegisterCompFunc(KVDKEngine *engine, const char *compara_name,
                           int (*compare)(const char *src, size_t src_len,
                                          const char *target,
                                          size_t target_len)) {
-  auto comp_func = [compare](const pmem::obj::string_view &src,
-                             const pmem::obj::string_view &target) -> int {
+  auto comp_func = [compare](const StringView &src,
+                             const StringView &target) -> int {
     return compare(src.data(), src.size(), target.data(), target.size());
   };
-  engine->rep->SetCompareFunc(pmem::obj::string_view(compara_name, compara_len),
-                              comp_func);
+  engine->rep->SetCompareFunc(StringView(compara_name, compara_len), comp_func);
 }
 
 KVDKStatus KVDKCreateSortedCollection(KVDKEngine *engine,
@@ -115,8 +114,8 @@ KVDKStatus KVDKCreateSortedCollection(KVDKEngine *engine,
   Collection *collection_ptr;
 
   KVDKStatus s = engine->rep->CreateSortedCollection(
-      pmem::obj::string_view(collection_name, collection_len), &collection_ptr,
-      pmem::obj::string_view(compara_name, compara_len));
+      StringView(collection_name, collection_len), &collection_ptr,
+      StringView(compara_name, compara_len));
   if (s != KVDKStatus::Ok) {
     sorted_collection = nullptr;
     return s;

--- a/engine/kv_engine.cpp
+++ b/engine/kv_engine.cpp
@@ -191,10 +191,9 @@ Status KVEngine::Init(const std::string &name, const Configs &configs) {
   return s;
 }
 
-Status
-KVEngine::CreateSortedCollection(const StringView collection_name,
-                                 Collection **collection_ptr,
-                                 const pmem::obj::string_view &comp_name) {
+Status KVEngine::CreateSortedCollection(const StringView collection_name,
+                                        Collection **collection_ptr,
+                                        const StringView &comp_name) {
   *collection_ptr = nullptr;
   Status s = MaybeInitWriteThread();
   if (s != Status::Ok) {

--- a/engine/kv_engine.hpp
+++ b/engine/kv_engine.hpp
@@ -127,17 +127,16 @@ private:
 
   inline Status MaybeInitWriteThread();
 
-  void SetCompareFunc(const pmem::obj::string_view &collection_name,
-                      std::function<int(const pmem::obj::string_view &src,
-                                        const pmem::obj::string_view &target)>
-                          comp_func) {
+  void SetCompareFunc(
+      const StringView &collection_name,
+      std::function<int(const StringView &src, const StringView &target)>
+          comp_func) {
     comparator_.SetComparaFunc(collection_name, comp_func);
   }
 
-  Status
-  CreateSortedCollection(const StringView collection_name,
-                         Collection **collection_ptr,
-                         const pmem::obj::string_view &comp_name) override;
+  Status CreateSortedCollection(const StringView collection_name,
+                                Collection **collection_ptr,
+                                const StringView &comp_name) override;
 
 private:
   Status InitCollection(const StringView &collection, Collection **list,

--- a/examples/tutorial/cpp_api_tutorial.cpp
+++ b/examples/tutorial/cpp_api_tutorial.cpp
@@ -13,6 +13,8 @@
 
 #define DEBUG // For assert
 
+using StringView = pmem::obj::string_view;
+
 // The KVDK instance is mounted as a directory
 // /mnt/pmem0/tutorial_kvdk_example.
 // Modify this path if necessary.
@@ -252,8 +254,7 @@ static void test_customer_sorted_func() {
 
   // regitser compare function
   std::string comp_name = "double_comp";
-  auto score_cmp = [](const pmem::obj::string_view &a,
-                      const pmem::obj::string_view &b) -> int {
+  auto score_cmp = [](const StringView &a, const StringView &b) -> int {
     double scorea = std::stod(a.data());
     double scoreb = std::stod(b.data());
     if (scorea == scoreb)

--- a/extern/libpmemobj++/string_view.hpp
+++ b/extern/libpmemobj++/string_view.hpp
@@ -1414,12 +1414,15 @@ std::ostream& operator<<(std::ostream& out, basic_string_view<CharT, Traits> con
 
 #if !USE_STL_STRING_VIEW
 #include<bits/functional_hash.h>
+namespace std
+{
 template<>
-struct std::hash<pmem::obj::string_view>
+struct hash<pmem::obj::string_view>
 {
 	size_t operator()(pmem::obj::string_view const& sv) const noexcept
-	{ return std::_Hash_impl::hash(sv.data(), sv.size()); }
+	{ return _Hash_impl::hash(sv.data(), sv.size()); }
 };
+}
 #endif /* !USE_STL_STRING_VIEW */
 
 #endif /* LIBPMEMOBJ_CPP_STRING_VIEW */

--- a/include/kvdk/collection.hpp
+++ b/include/kvdk/collection.hpp
@@ -10,6 +10,7 @@
 #include "libpmemobj++/string_view.hpp"
 
 namespace KVDK_NAMESPACE {
+using StringView = pmem::obj::string_view;
 
 // A collection of key-value pairs
 class Collection {
@@ -24,13 +25,13 @@ public:
 
   // Return internal representation of "key" in the collection
   // By default, we concat key with the collection id
-  std::string InternalKey(const pmem::obj::string_view &key) {
+  std::string InternalKey(const StringView &key) {
     return makeInternalKey(key, ID());
   }
 
 protected:
-  inline static std::string
-  makeInternalKey(const pmem::obj::string_view &user_key, uint64_t list_id) {
+  inline static std::string makeInternalKey(const StringView &user_key,
+                                            uint64_t list_id) {
     return std::string((char *)&list_id, 8)
         .append(user_key.data(), user_key.size());
   }

--- a/include/kvdk/comparator.hpp
+++ b/include/kvdk/comparator.hpp
@@ -12,21 +12,28 @@
 
 class Comparator {
 public:
-  using compare = std::function<int(const pmem::obj::string_view &src,
-                                    const pmem::obj::string_view &target)>;
-  void SetComparaFunc(const pmem::obj::string_view &compara_name,
-                      compare comp_func) {
-    if (compara_table_.find(compara_name) == compara_table_.end()) {
-      compara_table_.insert({compara_name, comp_func});
+  using StringView = pmem::obj::string_view;
+
+  using compare =
+      std::function<int(const StringView &src, const StringView &target)>;
+  void SetComparaFunc(const StringView &compara_name, compare comp_func) {
+    if (compara_table_.find(
+            std::string{compara_name.data(), compara_name.size()}) ==
+        compara_table_.end()) {
+      compara_table_.emplace(
+          std::string{compara_name.data(), compara_name.size()}, comp_func);
     }
   }
-  compare GetComparaFunc(const pmem::obj::string_view &compara_name) {
-    if (compara_table_.find(compara_name) != compara_table_.end()) {
-      return compara_table_[compara_name];
+  compare GetComparaFunc(const StringView &compara_name) {
+    if (compara_table_.find(
+            std::string{compara_name.data(), compara_name.size()}) !=
+        compara_table_.end()) {
+      return compara_table_[std::string{compara_name.data(),
+                                        compara_name.size()}];
     }
     return nullptr;
   };
 
 private:
-  std::unordered_map<pmem::obj::string_view, compare> compara_table_;
+  std::unordered_map<std::string, compare> compara_table_;
 };

--- a/include/kvdk/engine.hpp
+++ b/include/kvdk/engine.hpp
@@ -24,6 +24,7 @@ namespace KVDK_NAMESPACE {
 // This is the abstraction of a persistent KVDK instance
 class Engine {
 public:
+  using StringView = pmem::obj::string_view;
   // Open a new KVDK instance or restore a existing KVDK instance with the
   // specified "name". The "name" indicates the dir path that persist the
   // instance.
@@ -37,83 +38,74 @@ public:
 
   // Insert a STRING-type KV to set "key" to hold "value", return Ok on
   // successful persistence, return non-Ok on any error.
-  virtual Status Set(const pmem::obj::string_view key,
-                     const pmem::obj::string_view value) = 0;
+  virtual Status Set(const StringView key, const StringView value) = 0;
 
   virtual Status BatchWrite(const WriteBatch &write_batch) = 0;
 
   // Search the STRING-type KV of "key" and store the corresponding value to
   // *value on success. If the "key" does not exist, return NotFound.
-  virtual Status Get(const pmem::obj::string_view key, std::string *value) = 0;
+  virtual Status Get(const StringView key, std::string *value) = 0;
 
   // Remove STRING-type KV of "key".
   // Return Ok on success or the "key" did not exist, return non-Ok on any
   // error.
-  virtual Status Delete(const pmem::obj::string_view key) = 0;
+  virtual Status Delete(const StringView key) = 0;
 
-  virtual Status
-  CreateSortedCollection(const pmem::obj::string_view collection_name,
-                         Collection **sorted_collection,
-                         const pmem::obj::string_view &comp_name = "") = 0;
+  virtual Status CreateSortedCollection(const StringView collection_name,
+                                        Collection **sorted_collection,
+                                        const StringView &comp_name = "") = 0;
 
   // Insert a SORTED-type KV to set "key" of sorted collection "collection"
   // to hold "value", if "collection" not exist, it will be created, return Ok
   // on successful persistence, return non-Ok on any error.
-  virtual Status SSet(const pmem::obj::string_view collection,
-                      const pmem::obj::string_view key,
-                      const pmem::obj::string_view value) = 0;
+  virtual Status SSet(const StringView collection, const StringView key,
+                      const StringView value) = 0;
 
   // Search the SORTED-type KV of "key" in sorted collection "collection"
   // and store the corresponding value to *value on success. If the
   // "collection"/"key" did not exist, return NotFound.
-  virtual Status SGet(const pmem::obj::string_view collection,
-                      const pmem::obj::string_view key, std::string *value) = 0;
+  virtual Status SGet(const StringView collection, const StringView key,
+                      std::string *value) = 0;
 
   // Remove SORTED-type KV of "key" in the sorted collection "collection".
   // Return Ok on success or the "collection"/"key" did not exist, return non-Ok
   // on any error.
-  virtual Status SDelete(const pmem::obj::string_view collection,
-                         const pmem::obj::string_view key) = 0;
+  virtual Status SDelete(const StringView collection, const StringView key) = 0;
 
-  virtual Status HSet(const pmem::obj::string_view collection,
-                      const pmem::obj::string_view key,
-                      const pmem::obj::string_view value) = 0;
+  virtual Status HSet(const StringView collection, const StringView key,
+                      const StringView value) = 0;
 
-  virtual Status HGet(const pmem::obj::string_view collection,
-                      const pmem::obj::string_view key, std::string *value) = 0;
+  virtual Status HGet(const StringView collection, const StringView key,
+                      std::string *value) = 0;
 
-  virtual Status HDelete(const pmem::obj::string_view collection,
-                         const pmem::obj::string_view key) = 0;
+  virtual Status HDelete(const StringView collection, const StringView key) = 0;
 
   // Queue
-  virtual Status LPop(pmem::obj::string_view const collection_name,
-                      std::string *value) = 0;
+  virtual Status LPop(StringView const collection_name, std::string *value) = 0;
 
-  virtual Status RPop(pmem::obj::string_view const collection_name,
-                      std::string *value) = 0;
+  virtual Status RPop(StringView const collection_name, std::string *value) = 0;
 
-  virtual Status LPush(pmem::obj::string_view const collection_name,
-                       pmem::obj::string_view const value) = 0;
+  virtual Status LPush(StringView const collection_name,
+                       StringView const value) = 0;
 
-  virtual Status RPush(pmem::obj::string_view const collection_name,
-                       pmem::obj::string_view const value) = 0;
+  virtual Status RPush(StringView const collection_name,
+                       StringView const value) = 0;
 
   // Create a KV iterator on sorted collection "collection", which is able to
   // sequentially iterate all KVs in the "collection".
   virtual std::shared_ptr<Iterator>
-  NewSortedIterator(const pmem::obj::string_view collection) = 0;
+  NewSortedIterator(const StringView collection) = 0;
 
   virtual std::shared_ptr<Iterator>
-  NewUnorderedIterator(pmem::obj::string_view const collection_name) = 0;
+  NewUnorderedIterator(StringView const collection_name) = 0;
 
   // Release resources occupied by this write thread so new thread can take
   // part. New write requests of this thread need to re-request write resources.
   virtual void ReleaseWriteThread() = 0;
 
-  virtual void
-  SetCompareFunc(const pmem::obj::string_view &collection_name,
-                 std::function<int(const pmem::obj::string_view &src,
-                                   const pmem::obj::string_view &target)>) = 0;
+  virtual void SetCompareFunc(
+      const StringView &collection_name,
+      std::function<int(const StringView &src, const StringView &target)>) = 0;
 
   // Close the instance on exit.
   virtual ~Engine() = 0;

--- a/include/kvdk/status.h
+++ b/include/kvdk/status.h
@@ -21,23 +21,20 @@
 extern "C" {
 #endif
 
-#define FOREACH_ENUM(GEN)                                                      \
-  GEN(Ok)                                                                      \
-  GEN(NotFound)                                                                \
-  GEN(MemoryOverflow)                                                          \
-  GEN(PmemOverflow)                                                            \
-  GEN(NotSupported)                                                            \
-  GEN(MapError)                                                                \
-  GEN(BatchOverflow)                                                           \
-  GEN(TooManyWriteThreads)                                                     \
-  GEN(InvalidDataSize)                                                         \
-  GEN(IOError)                                                                 \
-  GEN(InvalidConfiguration)                                                    \
-  GEN(Abort)
-#define GENERATE_ENUM(ENUM) ENUM,
-#define GENERATE_STRING(STRING) #STRING,
-
-typedef enum { FOREACH_ENUM(GENERATE_ENUM) } KVDKStatus;
+typedef enum {
+  Ok,
+  NotFound,
+  MemoryOverflow,
+  PmemOverflow,
+  NotSupported,
+  MapError,
+  BatchOverflow,
+  TooManyWriteThreads,
+  InvalidDataSize,
+  IOError,
+  InvalidConfiguration,
+  Abort
+} KVDKStatus;
 
 #ifdef __cplusplus
 } /* end extern "C" */

--- a/include/kvdk/status.h
+++ b/include/kvdk/status.h
@@ -21,20 +21,23 @@
 extern "C" {
 #endif
 
-typedef enum {
-  Ok,
-  NotFound,
-  MemoryOverflow,
-  PmemOverflow,
-  NotSupported,
-  MapError,
-  BatchOverflow,
-  TooManyWriteThreads,
-  InvalidDataSize,
-  IOError,
-  InvalidConfiguration,
-  Abort
-} KVDKStatus;
+#define FOREACH_ENUM(GEN)                                                      \
+  GEN(Ok)                                                                      \
+  GEN(NotFound)                                                                \
+  GEN(MemoryOverflow)                                                          \
+  GEN(PmemOverflow)                                                            \
+  GEN(NotSupported)                                                            \
+  GEN(MapError)                                                                \
+  GEN(BatchOverflow)                                                           \
+  GEN(TooManyWriteThreads)                                                     \
+  GEN(InvalidDataSize)                                                         \
+  GEN(IOError)                                                                 \
+  GEN(InvalidConfiguration)                                                    \
+  GEN(Abort)
+#define GENERATE_ENUM(ENUM) ENUM,
+#define GENERATE_STRING(STRING) #STRING,
+
+typedef enum { FOREACH_ENUM(GENERATE_ENUM) } KVDKStatus;
 
 #ifdef __cplusplus
 } /* end extern "C" */

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -1431,8 +1431,8 @@ TEST_F(EngineBasicTest, TestSortedCustomCompareFunction) {
   std::vector<std::string> collections{"collection0", "collection1",
                                        "collection2"};
 
-  auto cmp0 = [](const pmem::obj::string_view &a,
-                 const pmem::obj::string_view &b) -> int {
+  auto cmp0 = [](const StringView &a,
+                 const StringView &b) -> int {
     double scorea = std::stod(a.data());
     double scoreb = std::stod(b.data());
     if (scorea == scoreb)
@@ -1443,8 +1443,8 @@ TEST_F(EngineBasicTest, TestSortedCustomCompareFunction) {
       return -1;
   };
 
-  auto cmp1 = [](const pmem::obj::string_view &a,
-                 const pmem::obj::string_view &b) -> int {
+  auto cmp1 = [](const StringView &a,
+                 const StringView &b) -> int {
     double scorea = std::stod(a.data());
     double scoreb = std::stod(b.data());
     if (scorea == scoreb)


### PR DESCRIPTION
<!--
Thank you for contributing to KVDK.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

pmemkv cannot link to KVDK

What's Changed:

1. Change string_view in comparator to string. User may pass a temporary string as comparator name. Use string_view may arise segfault or undefined behavior.
2. Aliasing pmem::obj::string_view to StringView.
3. Some slight changes to improve readibility.

Tests <!-- At least one of them must be included. -->
- Unit test
