### PR TITLE
Fix batch write return value while pmem overflow

### DIFF
--- a/engine/kv_engine.cpp
+++ b/engine/kv_engine.cpp
@@ -82,7 +82,8 @@ void KVEngine::FreeSkiplistDramNodes() {
 void KVEngine::ReportPMemUsage() {
   auto total = pmem_allocator_->PMemUsageInBytes();
   GlobalLogger.Info("PMem Usage: %ld B, %ld KB, %ld MB, %ld GB\n", total,
-                    (total / (1ULL << 10)), (total / (1ULL << 20)), (total / (1ULL << 30)));
+                    (total / (1ULL << 10)), (total / (1ULL << 20)),
+                    (total / (1ULL << 30)));
 }
 
 void KVEngine::BackgroundWork() {
@@ -1129,7 +1130,7 @@ Status KVEngine::BatchWrite(const WriteBatch &write_batch) {
         for (size_t j = 0; j < i; j++) {
           pmem_allocator_->Free(batch_hints[j].allocated_space);
         }
-        return s;
+        return Status::PmemOverflow;
       }
       space_entry_offsets.emplace_back(batch_hints[i].allocated_space.offset);
     } else {


### PR DESCRIPTION
Signed-off-by: Jiayu Wu <jiayu.wu@intel.com>

<!--
Thank you for contributing to KVDK.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Issue Number: close #xxx <!-- REMOVE this line if no issue to close -->

Problem Summary:

BatchWrite return Ok while PMem overflow in current implementation

### What is changed and how it works?

return PMemOverflow instead

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
