### PR TITLE
Repair issue #165: get_timestamp() bug

### DIFF
--- a/engine/kv_engine.cpp
+++ b/engine/kv_engine.cpp
@@ -1314,7 +1314,7 @@ Status KVEngine::StringSetImpl(const StringView &key, const StringView &value) {
     void *block_base = pmem_allocator_->offset2addr(sized_space_entry.offset);
 
     uint64_t new_ts = get_timestamp();
-    assert(!found || new_ts > data_entry.meta.timestamp);
+    kvdk_assert(!found || new_ts > data_entry.meta.timestamp, "old record has newer timestamp!");
 
     StringRecord::PersistStringRecord(block_base, sized_space_entry.size,
                                       new_ts, StringDataRecord, key, value);

--- a/engine/kv_engine.cpp
+++ b/engine/kv_engine.cpp
@@ -753,8 +753,7 @@ Status KVEngine::Recovery() {
   if (s != Status::Ok) {
     return s;
   }
-  GlobalLogger.Info("RestorePendingBatch done: iterated %lu records\n",
-                    restored_.load());
+  GlobalLogger.Info("RestorePendingBatch done.\n");
 
   std::vector<std::future<Status>> fs;
   for (uint32_t i = 0; i < configs_.max_write_threads; i++) {
@@ -772,6 +771,12 @@ Status KVEngine::Recovery() {
   GlobalLogger.Info("RestoreData done: iterated %lu records\n",
                     restored_.load());
 
+  for (auto &ts : thread_res_) {
+    if (ts.newest_restored_ts > newest_version_on_startup_) {
+      newest_version_on_startup_ = ts.newest_restored_ts;
+    }
+  }
+
   // restore skiplist by two optimization strategy
   s = sorted_rebuilder_.Rebuild(this);
   if (s != Status::Ok) {
@@ -779,14 +784,6 @@ Status KVEngine::Recovery() {
   }
 
   GlobalLogger.Info("Rebuild skiplist done\n");
-
-  if (restored_.load() == 0) {
-    for (auto &ts : thread_res_) {
-      if (ts.newest_restored_ts > newest_version_on_startup_) {
-        newest_version_on_startup_ = ts.newest_restored_ts;
-      }
-    }
-  }
 
   return Status::Ok;
 }
@@ -1314,7 +1311,9 @@ Status KVEngine::StringSetImpl(const StringView &key, const StringView &value) {
     void *block_base = pmem_allocator_->offset2addr(sized_space_entry.offset);
 
     uint64_t new_ts = get_timestamp();
-    kvdk_assert(!found || new_ts > data_entry.meta.timestamp, "old record has newer timestamp!");
+
+    kvdk_assert(!found || new_ts > data_entry.meta.timestamp,
+                "old record has newer timestamp!");
 
     StringRecord::PersistStringRecord(block_base, sized_space_entry.size,
                                       new_ts, StringDataRecord, key, value);

--- a/engine/kv_engine.hpp
+++ b/engine/kv_engine.hpp
@@ -109,9 +109,9 @@ private:
   struct ThreadLocalRes {
     ThreadLocalRes() = default;
 
-    uint64_t newest_restored_ts = 0;
+    std::uint64_t newest_restored_ts = 0;
     PendingBatch *persisted_pending_batch = nullptr;
-    std::unordered_map<uint64_t, int> visited_skiplist_ids;
+    std::unordered_map<std::uint64_t, int> visited_skiplist_ids;
   };
 
   bool CheckKeySize(const StringView &key) { return key.size() <= UINT16_MAX; }


### PR DESCRIPTION
<!--
Thank you for contributing to KVDK.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

get_timestamp() returns error value

Problem Summary:

startup_timestamp was not updated properly, this patch fixes that.

Tests <!-- At least one of them must be included. -->

- Unit test
