### PR TITLE
Fix skiplist repair during recovery and batch write open file bugs

### DIFF
--- a/engine/kv_engine.cpp
+++ b/engine/kv_engine.cpp
@@ -1181,15 +1181,8 @@ Status KVEngine::BatchWrite(const WriteBatch &write_batch) {
   // Free updated kvs, we should purge all updated kvs before release locks and
   // after persist write stage
   for (size_t i = 0; i < write_batch.Size(); i++) {
-    if (batch_hints[i].hash_entry_ptr &&
-        (batch_hints[i].hash_entry_ptr->header.status ==
-             HashEntryStatus::Updating ||
-         write_batch.kvs[i].type == StringDeleteRecord)) {
-      purgeAndFree(batch_hints[i].hash_entry_ptr->index.string_record);
-      // For delete kvs, we should clear hash entry
-      if (write_batch.kvs[i].type == StringDeleteRecord) {
-        batch_hints[i].hash_entry_ptr->Clear();
-      }
+    if (batch_hints[i].pmem_record_to_free != nullptr) {
+      purgeAndFree(batch_hints[i].pmem_record_to_free);
     }
   }
   return Status::Ok;
@@ -1199,14 +1192,15 @@ Status KVEngine::StringBatchWriteImpl(const WriteBatch::KV &kv,
                                       BatchWriteHint &batch_hint) {
   DataEntry data_entry;
   HashEntry hash_entry;
+  HashEntry *entry_ptr = nullptr;
 
   {
     auto &hash_hint = batch_hint.hash_hint;
     // hash table for the hint should be alread locked, so we do not lock it
     // here
-    Status s = hash_table_->SearchForWrite(hash_hint, kv.key, StringRecordType,
-                                           &batch_hint.hash_entry_ptr,
-                                           &hash_entry, &data_entry);
+    Status s =
+        hash_table_->SearchForWrite(hash_hint, kv.key, StringRecordType,
+                                    &entry_ptr, &hash_entry, &data_entry);
     if (s == Status::MemoryOverflow) {
       return s;
     }
@@ -1214,6 +1208,10 @@ Status KVEngine::StringBatchWriteImpl(const WriteBatch::KV &kv,
 
     // Deleting kv is not existing
     if (kv.type == StringDeleteRecord) {
+      if (found) {
+        batch_hint.pmem_record_to_free = hash_entry.index.string_record;
+        entry_ptr->Clear();
+      }
       return Status::Ok;
     }
 
@@ -1234,8 +1232,13 @@ Status KVEngine::StringBatchWriteImpl(const WriteBatch::KV &kv,
       std::abort();
     }
 
-    hash_table_->Insert(hash_hint, batch_hint.hash_entry_ptr, kv.type,
-                        block_base, HashOffsetType::StringRecord);
+    auto entry_base_status = entry_ptr->header.status;
+    hash_table_->Insert(hash_hint, entry_ptr, kv.type, block_base,
+                        HashOffsetType::StringRecord);
+
+    if (entry_base_status == HashEntryStatus::Updating) {
+      batch_hint.pmem_record_to_free = hash_entry.index.string_record;
+    }
   }
 
   return Status::Ok;

--- a/engine/kv_engine.hpp
+++ b/engine/kv_engine.hpp
@@ -103,7 +103,7 @@ private:
     TimeStampType timestamp{0};
     SpaceEntry allocated_space{};
     HashTable::KeyHashHint hash_hint{};
-    void *pmem_record_to_free = nullptr;
+    HashEntry *hash_entry_ptr = nullptr;
   };
 
   struct ThreadLocalRes {

--- a/engine/kv_engine.hpp
+++ b/engine/kv_engine.hpp
@@ -103,7 +103,7 @@ private:
     TimeStampType timestamp{0};
     SpaceEntry allocated_space{};
     HashTable::KeyHashHint hash_hint{};
-    HashEntry *hash_entry_ptr = nullptr;
+    void *pmem_record_to_free = nullptr;
   };
 
   struct ThreadLocalRes {

--- a/engine/skiplist.cpp
+++ b/engine/skiplist.cpp
@@ -420,11 +420,11 @@ bool Skiplist::Delete(const StringView &key, DLRecord *deleted_record,
   assert(prev->next == deleting_offset);
   assert(next->prev == deleting_offset);
   // For repair in recovery due to crashes during pointers changing, we should
-  // first unlink deleting entry from prev's next
-  prev->next = pmem_allocator_->addr2offset(next);
-  pmem_persist(&prev->next, 8);
+  // first unlink deleting entry from next's prev
   next->prev = pmem_allocator_->addr2offset(prev);
   pmem_persist(&next->prev, 8);
+  prev->next = pmem_allocator_->addr2offset(next);
+  pmem_persist(&prev->next, 8);
   deleted_record->Destroy();
 
   if (dram_node) {

--- a/engine/skiplist.cpp
+++ b/engine/skiplist.cpp
@@ -420,7 +420,8 @@ bool Skiplist::Delete(const StringView &key, DLRecord *deleted_record,
   assert(prev->next == deleting_offset);
   assert(next->prev == deleting_offset);
   // For repair in recovery due to crashes during pointers changing, we should
-  // first unlink deleting entry from next's prev
+  // first unlink deleting entry from next's prev.(It is the reverse process
+  // of insertion)
   next->prev = pmem_allocator_->addr2offset(prev);
   pmem_persist(&next->prev, 8);
   prev->next = pmem_allocator_->addr2offset(next);

--- a/engine/unordered_collection.hpp
+++ b/engine/unordered_collection.hpp
@@ -135,9 +135,9 @@ private:
     SpinMutex *spin1 = getMutex(pos1->Key());
     SpinMutex *spin2 = getMutex(pos2->Key());
 
-    kvdk_assert(lock.owns_lock(), "User supplied lock not acquired!")
+    kvdk_assert(lock.owns_lock(), "User supplied lock not acquired!");
 
-        if (spin1 != spin) {
+    if (spin1 != spin) {
       lock_holder.first = LockType{*spin1, std::defer_lock};
       if (!lock_holder.first.try_lock())
         return false;

--- a/examples/tutorial/cpp_api_tutorial.cpp
+++ b/examples/tutorial/cpp_api_tutorial.cpp
@@ -255,8 +255,10 @@ static void test_customer_sorted_func() {
   // regitser compare function
   std::string comp_name = "double_comp";
   auto score_cmp = [](const StringView &a, const StringView &b) -> int {
-    double scorea = std::stod(a.data());
-    double scoreb = std::stod(b.data());
+    std::string str_a(a.data(), a.size());
+    std::string str_b(b.data(), b.size());
+    double scorea = std::stod(str_a);
+    double scoreb = std::stod(str_b);
     if (scorea == scoreb)
       return 0;
     else if (scorea < scoreb)

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -1431,10 +1431,9 @@ TEST_F(EngineBasicTest, TestSortedCustomCompareFunction) {
   std::vector<std::string> collections{"collection0", "collection1",
                                        "collection2"};
 
-  auto cmp0 = [](const StringView &a,
-                 const StringView &b) -> int {
-    double scorea = std::stod(a.data());
-    double scoreb = std::stod(b.data());
+  auto cmp0 = [](const StringView &a, const StringView &b) -> int {
+    double scorea = std::stod(string_view_2_string(a));
+    double scoreb = std::stod(string_view_2_string(b));
     if (scorea == scoreb)
       return 0;
     else if (scorea < scoreb)
@@ -1443,10 +1442,9 @@ TEST_F(EngineBasicTest, TestSortedCustomCompareFunction) {
       return -1;
   };
 
-  auto cmp1 = [](const StringView &a,
-                 const StringView &b) -> int {
-    double scorea = std::stod(a.data());
-    double scoreb = std::stod(b.data());
+  auto cmp1 = [](const StringView &a, const StringView &b) -> int {
+    double scorea = std::stod(string_view_2_string(a));
+    double scoreb = std::stod(string_view_2_string(b));
     if (scorea == scoreb)
       return 0;
     else if (scorea > scoreb)


### PR DESCRIPTION
Signed-off-by: zhichenj <zhichen.jiang@intel.com>

### What problem does this PR solve?

    1. Fix repair logic bug
        
![corner_case-第 1 页 drawio](https://user-images.githubusercontent.com/7602435/150469365-09b8c3a6-a611-4536-804f-19bc42ad9898.png)

      The new repair logic is below:
![corner_case-第 3 页 drawio](https://user-images.githubusercontent.com/7602435/150477039-c5d7aa84-a58d-4611-9c4b-acac6bd8d1c8.png)
        

    2. Fix skiplist delete logic bug
        
![corner_case-第 2 页 drawio](https://user-images.githubusercontent.com/7602435/150469371-4aa13066-a16f-4827-a673-e02c1ec64c2f.png)

       Fix : Changed "first change prev point, then change next point"  to "first change next point, then change prev point"
              
![image](https://user-images.githubusercontent.com/7602435/150477560-aeceab32-1d4d-4023-943f-87e7842dcf61.png)
        
       Even if different order of recovering record, It can correctly repair.

    3. Fix batchwrite can't open exit file bug

    4. Fix "batchwrite delete, but not clear hash table" bug

    5. Fix  test memory leak bug

- Unit test
- Integration
- No code

Side effects

- Performance regression
    - Consumes more CPU
    - Consumes more MEM
    - Consumes more PMEM
