### PR TITLE
Pmem usage bugfix

### DIFF
--- a/engine/dlinked_list.hpp
+++ b/engine/dlinked_list.hpp
@@ -24,8 +24,8 @@
 #include "hash_table.hpp"
 #include "macros.hpp"
 #include "structures.hpp"
-#include "utils/utils.hpp"
 #include "utils/sync_point.hpp"
+#include "utils/utils.hpp"
 
 namespace KVDK_NAMESPACE {
 /// DLinkedList is a helper class to access PMem

--- a/engine/pmem_allocator/pmem_allocator.cpp
+++ b/engine/pmem_allocator/pmem_allocator.cpp
@@ -164,7 +164,6 @@ bool PMEMAllocator::FreeAndFetchSegment(SpaceEntry *segment_space_entry) {
 bool PMEMAllocator::allocateSegmentSpace(SpaceEntry *segment_entry) {
   std::lock_guard<SpinMutex> lg(offset_head_lock_);
   if (offset_head_ <= pmem_size_ - segment_size_) {
-    Free(*segment_entry);
     *segment_entry = SpaceEntry{offset_head_, segment_size_};
     persistSpaceEntry(offset_head_, segment_size_);
     offset_head_ += segment_size_;
@@ -254,6 +253,8 @@ SpaceEntry PMEMAllocator::Allocate(uint64_t size) {
         return space_entry;
       }
       if (palloc_thread_cache.free_entry.size > 0) {
+        // Not a true free
+        LogAllocation(write_thread.id, palloc_thread_cache.free_entry.size);
         Free(palloc_thread_cache.free_entry);
         palloc_thread_cache.free_entry.size = 0;
       }
@@ -265,6 +266,8 @@ SpaceEntry PMEMAllocator::Allocate(uint64_t size) {
       break;
     }
 
+    LogAllocation(write_thread.id, palloc_thread_cache.segment_entry.size);
+    Free(palloc_thread_cache.segment_entry);
     // allocate a new segment, add remainning space of the old one
     // to the free list
     if (!allocateSegmentSpace(&palloc_thread_cache.segment_entry)) {


### PR DESCRIPTION
<!--
Thank you for contributing to KVDK.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Fix KVDK report wrong PMem usage because PMemAllocator calls Free internally.
Refactor Background work so that Background work will not start immediately after engine start up.

Tests <!-- At least one of them must be included. -->

- Unit test
