### PR TITLE
Implement sorted iterator on snapshot

### DIFF
--- a/benchmark/bench.cpp
+++ b/benchmark/bench.cpp
@@ -280,6 +280,7 @@ void DBScan(int tid) {
       } else {
         throw std::runtime_error{"Error creating SortedIterator"};
       }
+      engine->ReleaseSortedIterator(iter);
       break;
     }
     case DataType::Hashes: {

--- a/doc/user_doc.md
+++ b/doc/user_doc.md
@@ -321,6 +321,7 @@ int main()
     }
 
     printf("Successfully iterated through a sorted named collections.\n");
+    engine->ReleaseSortedIterator(iter);
   }
 
   ... Do something else with KVDK instance ...

--- a/engine/c.cc
+++ b/engine/c.cc
@@ -325,6 +325,7 @@ void KVDKDestroyIterator(KVDKEngine *engine, KVDKIterator *iterator) {
     break;
   }
   case HASH: {
+    break;
   }
 
   default:

--- a/engine/kv_engine.hpp
+++ b/engine/kv_engine.hpp
@@ -74,8 +74,9 @@ public:
               const StringView value) override;
   Status SDelete(const StringView collection,
                  const StringView user_key) override;
-  std::shared_ptr<Iterator>
-  NewSortedIterator(const StringView collection) override;
+  Iterator *NewSortedIterator(const StringView collection,
+                              Snapshot *snapshot) override;
+  void ReleaseSortedIterator(Iterator *sorted_iterator) override;
 
   // Unordered Collection
   virtual Status HGet(StringView const collection_name, StringView const key,

--- a/engine/skiplist.cpp
+++ b/engine/skiplist.cpp
@@ -490,6 +490,15 @@ void SortedIterator::Seek(const std::string &key) {
 void SortedIterator::SeekToFirst() {
   uint64_t first = skiplist_->header()->record->next;
   current_ = pmem_allocator_->offset2addr<DLRecord>(first);
+  while (Valid()) {
+    DLRecord *valid_version_record = findValidVersion(current_);
+    if (valid_version_record == nullptr) {
+      current_ = pmem_allocator_->offset2addr_checked<DLRecord>(current_->next);
+    } else {
+      current_ = valid_version_record;
+      break;
+    }
+  }
   while (current_->entry.meta.type == SortedDeleteRecord) {
     current_ = pmem_allocator_->offset2addr<DLRecord>(current_->next);
   }
@@ -498,6 +507,15 @@ void SortedIterator::SeekToFirst() {
 void SortedIterator::SeekToLast() {
   uint64_t last = skiplist_->header()->record->prev;
   current_ = pmem_allocator_->offset2addr<DLRecord>(last);
+  while (Valid()) {
+    DLRecord *valid_version_record = findValidVersion(current_);
+    if (valid_version_record == nullptr) {
+      current_ = pmem_allocator_->offset2addr_checked<DLRecord>(current_->prev);
+    } else {
+      current_ = valid_version_record;
+      break;
+    }
+  }
   while (current_->entry.meta.type == SortedDeleteRecord) {
     current_ = pmem_allocator_->offset2addr<DLRecord>(current_->prev);
   }

--- a/engine/skiplist.cpp
+++ b/engine/skiplist.cpp
@@ -343,9 +343,8 @@ bool Skiplist::Update(const StringView &key, const StringView &value,
   Splice splice(this);
   std::unique_lock<SpinMutex> prev_record_lock;
 
-  if (!SearchAndLockRecordPos(&splice, updating_record, updating_record_lock,
-                              &prev_record_lock, pmem_allocator_.get(),
-                              hash_table_.get())) {
+  if (!searchAndLockUpdatePos(&splice, updating_record, updating_record_lock,
+                              &prev_record_lock)) {
     return false;
   }
 
@@ -376,9 +375,8 @@ bool Skiplist::Delete(const StringView &key, DLRecord *deleting_record,
   Splice splice(this);
   std::unique_lock<SpinMutex> prev_record_lock;
 
-  if (!SearchAndLockRecordPos(&splice, deleting_record, deleting_record_lock,
-                              &prev_record_lock, pmem_allocator_.get(),
-                              hash_table_.get())) {
+  if (!searchAndLockDeletePos(&splice, deleting_record, deleting_record_lock,
+                              &prev_record_lock)) {
     return false;
   }
 

--- a/engine/skiplist.cpp
+++ b/engine/skiplist.cpp
@@ -342,8 +342,10 @@ bool Skiplist::Update(const StringView &key, const StringView &value,
                       const SpaceEntry &space_to_write) {
   Splice splice(this);
   std::unique_lock<SpinMutex> prev_record_lock;
-  if (!searchAndLockUpdatePos(&splice, updating_record, updating_record_lock,
-                              &prev_record_lock)) {
+
+  if (!SearchAndLockRecordPos(&splice, updating_record, updating_record_lock,
+                              &prev_record_lock, pmem_allocator_.get(),
+                              hash_table_.get())) {
     return false;
   }
 
@@ -373,8 +375,10 @@ bool Skiplist::Delete(const StringView &key, DLRecord *deleting_record,
                       const SpaceEntry &space_to_write) {
   Splice splice(this);
   std::unique_lock<SpinMutex> prev_record_lock;
-  if (!searchAndLockDeletePos(&splice, deleting_record, deleting_record_lock,
-                              &prev_record_lock)) {
+
+  if (!SearchAndLockRecordPos(&splice, deleting_record, deleting_record_lock,
+                              &prev_record_lock, pmem_allocator_.get(),
+                              hash_table_.get())) {
     return false;
   }
 
@@ -468,25 +472,36 @@ void SortedIterator::Seek(const std::string &key) {
   assert(skiplist_);
   Splice splice(skiplist_);
   skiplist_->Seek(key, &splice);
-  current = splice.next_pmem_record;
-  while (current->entry.meta.type == SortedDeleteRecord) {
-    current = pmem_allocator_->offset2addr<DLRecord>(current->next);
+  current_ = splice.next_pmem_record;
+  while (Valid()) {
+    // we only need to find valid version in seek, as the linkage in valid
+    // version record must be valid
+    DLRecord *valid_version_record = findValidVersion(current_);
+    if (valid_version_record == nullptr) {
+      current_ = pmem_allocator_->offset2addr_checked<DLRecord>(current_->next);
+    } else {
+      current_ = valid_version_record;
+      break;
+    }
+  }
+  while (current_->entry.meta.type == SortedDeleteRecord) {
+    current_ = pmem_allocator_->offset2addr<DLRecord>(current_->next);
   }
 }
 
 void SortedIterator::SeekToFirst() {
   uint64_t first = skiplist_->header()->record->next;
-  current = pmem_allocator_->offset2addr<DLRecord>(first);
-  while (current->entry.meta.type == SortedDeleteRecord) {
-    current = pmem_allocator_->offset2addr<DLRecord>(current->next);
+  current_ = pmem_allocator_->offset2addr<DLRecord>(first);
+  while (current_->entry.meta.type == SortedDeleteRecord) {
+    current_ = pmem_allocator_->offset2addr<DLRecord>(current_->next);
   }
 }
 
 void SortedIterator::SeekToLast() {
   uint64_t last = skiplist_->header()->record->prev;
-  current = pmem_allocator_->offset2addr<DLRecord>(last);
-  while (current->entry.meta.type == SortedDeleteRecord) {
-    current = pmem_allocator_->offset2addr<DLRecord>(current->prev);
+  current_ = pmem_allocator_->offset2addr<DLRecord>(last);
+  while (current_->entry.meta.type == SortedDeleteRecord) {
+    current_ = pmem_allocator_->offset2addr<DLRecord>(current_->prev);
   }
 }
 
@@ -495,8 +510,8 @@ void SortedIterator::Next() {
     return;
   }
   do {
-    current = pmem_allocator_->offset2addr<DLRecord>(current->next);
-  } while (current->entry.meta.type == SortedDeleteRecord);
+    current_ = pmem_allocator_->offset2addr<DLRecord>(current_->next);
+  } while (current_->entry.meta.type == SortedDeleteRecord);
 }
 
 void SortedIterator::Prev() {
@@ -504,20 +519,36 @@ void SortedIterator::Prev() {
     return;
   }
   do {
-    current = (pmem_allocator_->offset2addr<DLRecord>(current->prev));
-  } while (current->entry.meta.type == SortedDeleteRecord);
+    current_ = (pmem_allocator_->offset2addr<DLRecord>(current_->prev));
+  } while (current_->entry.meta.type == SortedDeleteRecord);
 }
 
 std::string SortedIterator::Key() {
   if (!Valid())
     return "";
-  return string_view_2_string(Skiplist::UserKey(current));
+  return string_view_2_string(Skiplist::UserKey(current_));
 }
 
 std::string SortedIterator::Value() {
   if (!Valid())
     return "";
-  return string_view_2_string(current->Value());
+  return string_view_2_string(current_->Value());
+}
+
+DLRecord *SortedIterator::findValidVersion(DLRecord *pmem_record) {
+  DLRecord *curr = pmem_record;
+  TimeStampType ts = snapshot_->GetTimestamp();
+  while (curr != nullptr && curr->entry.meta.timestamp > ts) {
+    curr = pmem_allocator_->offset2addr<DLRecord>(curr->older_version_offset);
+    kvdk_assert(curr == nullptr || curr->Validate(),
+                "Broken checkpoint: invalid older version sorted record");
+    kvdk_assert(curr == nullptr ||
+                    equal_string_view(curr->Key(), pmem_record->Key()),
+                "Broken checkpoint: key of older version sorted data is "
+                "not same as new "
+                "version");
+  }
+  return curr;
 }
 
 DLRecord *SortedCollectionRebuilder::FindValidVersion(

--- a/engine/skiplist.hpp
+++ b/engine/skiplist.hpp
@@ -368,6 +368,28 @@ private:
                               const SpinMutex *inserting_key_lock,
                               std::unique_lock<SpinMutex> *prev_record_lock);
 
+  // Search and lock skiplist position to update"key".
+  //
+  // Store prev/next PMem DLRecord in "splice", lock prev DLRecord and manage
+  // the lock with "prev_record_lock".
+  //
+  //  The "updated_key" should be already locked before call this function
+  bool searchAndLockUpdatePos(Splice *splice, const DLRecord *updating_record,
+                              const SpinMutex *updating_record_lock,
+                              std::unique_lock<SpinMutex> *prev_record_lock) {
+    return SearchAndLockRecordPos(splice, updating_record, updating_record_lock,
+                                  prev_record_lock, pmem_allocator_.get(),
+                                  hash_table_.get());
+  }
+
+  bool searchAndLockDeletePos(Splice *splice, const DLRecord *deleting_record,
+                              const SpinMutex *deleting_record_lock,
+                              std::unique_lock<SpinMutex> *prev_record_lock) {
+    return SearchAndLockRecordPos(splice, deleting_record, deleting_record_lock,
+                                  prev_record_lock, pmem_allocator_.get(),
+                                  hash_table_.get());
+  }
+
   bool ValidateDLRecord(const DLRecord *record) {
     DLRecord *prev = pmem_allocator_->offset2addr<DLRecord>(record->prev);
     return prev != nullptr &&

--- a/examples/graph_sim/src/kv_engines/kvdk.cpp
+++ b/examples/graph_sim/src/kv_engines/kvdk.cpp
@@ -83,8 +83,9 @@ private:
 
 KVEngine::Iterator *PMemKVDK::NewIterator() {
   if (!collection_.empty()) {
+    // TODO fix snapshot
     auto it = db_->NewSortedIterator(collection_);
-    return new PMemKVDKIterator(it.get());
+    return new PMemKVDKIterator(it);
   }
   return nullptr;
 }

--- a/examples/tutorial/c_api_tutorial.c
+++ b/examples/tutorial/c_api_tutorial.c
@@ -319,8 +319,8 @@ void HashesCollectionExample(KVDKEngine *kvdk_engine) {
                      "key8", strlen("key8"));
   assert(s == Ok);
   // create sorted iterator
-  KVDKIterator *kvdk_iter = KVDKCreateSortedIterator(
-      kvdk_engine, hash_collection, strlen(hash_collection), NULL);
+  KVDKIterator *kvdk_iter = KVDKCreateUnorderedIterator(
+      kvdk_engine, hash_collection, strlen(hash_collection));
   int cnt = 0;
   for (KVDKIterSeekToFirst(kvdk_iter); KVDKIterValid(kvdk_iter);
        KVDKIterNext(kvdk_iter)) {

--- a/examples/tutorial/c_api_tutorial.c
+++ b/examples/tutorial/c_api_tutorial.c
@@ -144,8 +144,8 @@ void SortedCollectinIterExample(KVDKEngine *kvdk_engine) {
     assert(s == Ok);
   }
   // create sorted iterator
-  KVDKIterator *kvdk_iter = KVDKCreateIterator(
-      kvdk_engine, sorted_collection, strlen(sorted_collection), SORTED);
+  KVDKIterator *kvdk_iter = KVDKCreateSortedIterator(
+      kvdk_engine, sorted_collection, strlen(sorted_collection), NULL);
   KVDKIterSeekToFirst(kvdk_iter);
   // Iterate through range ["key1", "key8").
   const char *beg = "key1";
@@ -195,8 +195,8 @@ void SortedCollectinIterExample(KVDKEngine *kvdk_engine) {
   }
   assert(i == 0);
   printf("Successfully iterated through a sorted named collections.\n");
+  KVDKDestroyIterator(kvdk_engine, kvdk_iter);
   KVDKDestorySortedCollection(collecton_ptr);
-  KVDKIterDestory(kvdk_iter);
 }
 
 int score_cmp(const char *a, size_t a_len, const char *b, size_t b_len) {
@@ -238,8 +238,8 @@ void CompFuncForSortedCollectionExample(KVDKEngine *kvdk_engine) {
                       array[i].value, strlen(array[i].value));
     assert(s == Ok);
   }
-  KVDKIterator *iter =
-      KVDKCreateIterator(kvdk_engine, collection, strlen(collection), SORTED);
+  KVDKIterator *iter = KVDKCreateSortedIterator(kvdk_engine, collection,
+                                                strlen(collection), NULL);
 
   assert(iter != NULL);
 
@@ -260,6 +260,7 @@ void CompFuncForSortedCollectionExample(KVDKEngine *kvdk_engine) {
     }
     ++i;
   }
+  KVDKDestroyIterator(kvdk_engine, iter);
   printf("Successfully collections sorted by number.\n");
   KVDKDestorySortedCollection(collecton_ptr);
 }
@@ -318,8 +319,8 @@ void HashesCollectionExample(KVDKEngine *kvdk_engine) {
                      "key8", strlen("key8"));
   assert(s == Ok);
   // create sorted iterator
-  KVDKIterator *kvdk_iter = KVDKCreateIterator(kvdk_engine, hash_collection,
-                                               strlen(hash_collection), HASH);
+  KVDKIterator *kvdk_iter = KVDKCreateSortedIterator(
+      kvdk_engine, hash_collection, strlen(hash_collection), NULL);
   int cnt = 0;
   for (KVDKIterSeekToFirst(kvdk_iter); KVDKIterValid(kvdk_iter);
        KVDKIterNext(kvdk_iter)) {
@@ -334,7 +335,7 @@ void HashesCollectionExample(KVDKEngine *kvdk_engine) {
   }
   printf("Successfully performed Get Set Delete Iterate on HashList.\n");
   assert(cnt == 9);
-  KVDKIterDestory(kvdk_iter);
+  KVDKDestroyIterator(kvdk_engine, kvdk_iter);
 }
 
 void ListsCollectionExample(KVDKEngine *kvdk_engine) {

--- a/examples/tutorial/cpp_api_tutorial.cpp
+++ b/examples/tutorial/cpp_api_tutorial.cpp
@@ -14,6 +14,7 @@
 #define DEBUG // For assert
 
 using StringView = pmem::obj::string_view;
+using kvdk::Snapshot;
 
 // The KVDK instance is mounted as a directory
 // /mnt/pmem0/tutorial_kvdk_example.
@@ -201,6 +202,7 @@ static void test_iterator() {
   }
 
   printf("Successfully iterated through a sorted named collections.\n");
+  engine->ReleaseSortedIterator(iter);
   return;
 }
 
@@ -296,6 +298,7 @@ static void test_customer_sorted_func() {
     ++i;
   }
   printf("Successfully collections sorted by number.\n");
+  engine->ReleaseSortedIterator(iter);
 }
 
 int main() {

--- a/include/kvdk/engine.h
+++ b/include/kvdk/engine.h
@@ -145,9 +145,13 @@ extern KVDK_LIBRARY_API KVDKStatus KVDKRPop(KVDKEngine *engine,
                                             size_t *key_len);
 
 extern KVDK_LIBRARY_API KVDKIterator *
-KVDKCreateIterator(KVDKEngine *engine, const char *collection,
-                   size_t collection_len, KVDKIterType iter_type);
-extern KVDK_LIBRARY_API void KVDKIterDestory(KVDKIterator *iter);
+KVDKCreateUnorderedIterator(KVDKEngine *engine, const char *collection,
+                            size_t collection_len);
+extern KVDK_LIBRARY_API KVDKIterator *
+KVDKCreateSortedIterator(KVDKEngine *engine, const char *collection,
+                         size_t collection_len, KVDKSnapshot *snapshot);
+extern KVDK_LIBRARY_API void KVDKDestroyIterator(KVDKEngine *engine,
+                                                 KVDKIterator *iterator);
 extern KVDK_LIBRARY_API void KVDKIterSeekToFirst(KVDKIterator *iter);
 extern KVDK_LIBRARY_API void KVDKIterSeekToLast(KVDKIterator *iter);
 extern KVDK_LIBRARY_API void KVDKIterSeek(KVDKIterator *iter, const char *str,

--- a/include/kvdk/engine.hpp
+++ b/include/kvdk/engine.hpp
@@ -96,7 +96,10 @@ public:
   // this snapshot is released. You can recover KVDK instance to the checkpoint
   // version during recovery, then the checkpoint will be removed.
   //
-  // Notice: you can maintain multiple snapshot but only the last checkpoint.
+  // Notice:
+  // 1. You can maintain multiple snapshot but only the last checkpoint.
+  // 2. Please release the snapshot as soon as it is not needed, as it will
+  // forbid newer data being freed
   virtual Snapshot *GetSnapshot(bool make_checkpoint) = 0;
 
   // Make a backup on "snapshot" to "backup_path"
@@ -107,9 +110,19 @@ public:
   virtual void ReleaseSnapshot(const Snapshot *) = 0;
 
   // Create a KV iterator on sorted collection "collection", which is able to
-  // sequentially iterate all KVs in the "collection".
-  virtual std::shared_ptr<Iterator>
-  NewSortedIterator(const StringView collection) = 0;
+  // sequentially iterate all KVs in the "collection" at "snapshot" version, if
+  // snapshot is nullptr, then a internal snapshot will be created at current
+  // version and the iterator will be created on it
+  //
+  // Notice:
+  // 1. Iterator will be invalid after the passed snapshot is released
+  // 2. Please release the iterator as soon as it is not needed, as the holding
+  // snapshot will forbid newer data being freed
+  virtual Iterator *NewSortedIterator(const StringView collection,
+                                      Snapshot *snapshot = nullptr) = 0;
+
+  // Release a sorted iterator
+  virtual void ReleaseSortedIterator(Iterator *) = 0;
 
   virtual std::shared_ptr<Iterator>
   NewUnorderedIterator(StringView const collection_name) = 0;

--- a/tests/stress_test.cpp
+++ b/tests/stress_test.cpp
@@ -148,7 +148,8 @@ private:
 public:
   ShadowKVEngine() = delete;
   ShadowKVEngine(kvdk::Engine *&e, CollectionNameType cn, size_t nt)
-      : engine{e}, collection_name{cn}, engine_operator{engine, collection_name},
+      : engine{e}, collection_name{cn}, engine_operator{engine,
+                                                        collection_name},
         n_thread{nt}, possible_state{}, task_queues(n_thread) {}
 
   // Execute task_queues in ShadowKVEngine
@@ -158,7 +159,7 @@ public:
   void UpdatePossibleStates() {
     std::cout << "[Testing] Updating Engine State" << std::endl;
 
-    // Some keys are overwritten by operations in operateKVEngine(), 
+    // Some keys are overwritten by operations in operateKVEngine(),
     // states and values before calling operateKVEngine() are
     // no longer possible.
     {
@@ -220,8 +221,7 @@ public:
 
   // Check KVEngine by iterating through it.
   // Iterated KVs are looked up in possible_state.
-  void CheckIterator(std::shared_ptr<kvdk::Iterator> iterator,
-                     IteratingDirection direction) {
+  void CheckIterator(kvdk::Iterator *iterator, IteratingDirection direction) {
 
     PossibleStates possible_state_copy{possible_state};
 
@@ -561,10 +561,10 @@ protected:
               << std::endl;
     shadow_hashes_engines[collection_name]->CheckGetter();
     shadow_hashes_engines[collection_name]->CheckIterator(
-        engine->NewUnorderedIterator(collection_name),
+        engine->NewUnorderedIterator(collection_name).get(),
         kvdk_testing::IteratingDirection::Forward);
     shadow_hashes_engines[collection_name]->CheckIterator(
-        engine->NewUnorderedIterator(collection_name),
+        engine->NewUnorderedIterator(collection_name).get(),
         kvdk_testing::IteratingDirection::Backward);
   }
 
@@ -572,12 +572,12 @@ protected:
     std::cout << "[Testing] Checking Sorted Collection: " << collection_name
               << std::endl;
     shadow_sorted_engines[collection_name]->CheckGetter();
+    auto iter = engine->NewSortedIterator(collection_name);
     shadow_sorted_engines[collection_name]->CheckIterator(
-        engine->NewSortedIterator(collection_name),
-        kvdk_testing::IteratingDirection::Forward);
+        iter, kvdk_testing::IteratingDirection::Forward);
     shadow_sorted_engines[collection_name]->CheckIterator(
-        engine->NewSortedIterator(collection_name),
-        kvdk_testing::IteratingDirection::Backward);
+        iter, kvdk_testing::IteratingDirection::Backward);
+    engine->ReleaseSortedIterator(iter);
   }
 
   void CheckStrings() {


### PR DESCRIPTION
Signed-off-by: Jiayu Wu <jiayu.wu@intel.com>

<!--
Thank you for contributing to KVDK.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Problem Summary:

Current iterator implementation is lockless and version unconscious, may access a record that already been freed

### What is changed and how it works?

What's Changed:

1. Bind every sorted iterator with a snapshot by pass a snapshot parameter in iterator creation function, if the snapshot is not passed, then create a internal one
2.  The iterator only iter through records on the specified snapshot, so accessed records are all valid guarded by mvcc machenism

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Stress test

Side effects

- Create a snapshot can be slower for create snapshot
- Holding snapshot will forbid newer data being freed, so the iterator need to be released as soon as it's not needed
