### PR TITLE
Test: Refactor tests and add pmem allocator test cases

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,15 +101,8 @@ target_include_directories(bench PUBLIC ./include ./extern ./)
 
 option(BUILD_TESTING "Build the tests" ON)
 if (BUILD_TESTING)
-    set(TEST_SOURCES tests/tests.cpp)
-    enable_testing()
-    include(GoogleTest)
-    add_subdirectory(extern/gtest)
-    add_executable(dbtest ${TEST_SOURCES})
-    target_link_libraries(dbtest PUBLIC engine gtest gmock gtest_main)
-    set(TEST_SOURCES2 tests/stress_test.cpp)
-    add_executable(dbstress_test ${TEST_SOURCES2})
-    target_link_libraries(dbstress_test PUBLIC engine gtest gmock gtest_main)
+    add_subdirectory(${CMAKE_SOURCE_DIR}/extern/gtest)
+    add_subdirectory(tests)
 endif ()
 
 

--- a/engine/kv_engine.cpp
+++ b/engine/kv_engine.cpp
@@ -1585,7 +1585,6 @@ Status KVEngine::StringSetImpl(const StringView &key, const StringView &value) {
 }
 
 Status KVEngine::Set(const StringView key, const StringView value) {
-  ReportPMemUsage();
   Status s = MaybeInitAccessThread();
   if (s != Status::Ok) {
     return s;

--- a/engine/kv_engine.cpp
+++ b/engine/kv_engine.cpp
@@ -1585,6 +1585,7 @@ Status KVEngine::StringSetImpl(const StringView &key, const StringView &value) {
 }
 
 Status KVEngine::Set(const StringView key, const StringView value) {
+  ReportPMemUsage();
   Status s = MaybeInitAccessThread();
   if (s != Status::Ok) {
     return s;

--- a/engine/pmem_allocator/free_list.cpp
+++ b/engine/pmem_allocator/free_list.cpp
@@ -120,13 +120,11 @@ uint64_t SpaceMap::TryMerge(uint64_t offset, uint64_t max_merge_length,
 }
 
 void Freelist::OrganizeFreeSpace() {
-  // Notice: we should move cached list to pool after merge entries in the pool,
-  // otherwise we may miss some entries during minimal timestamp checking
-  MergeAndCheckTSInPool();
   MoveCachedListsToPool();
+  MergeSpaceInPool();
 }
 
-void Freelist::MergeAndCheckTSInPool() {
+void Freelist::MergeSpaceInPool() {
   std::vector<PMemOffsetType> merging_list;
   std::vector<std::vector<PMemOffsetType>> merged_entry_list(
       max_classified_b_size_);

--- a/engine/pmem_allocator/free_list.cpp
+++ b/engine/pmem_allocator/free_list.cpp
@@ -130,7 +130,7 @@ void Freelist::MergeSpaceInPool() {
       max_classified_b_size_);
 
   for (uint32_t b_size = 1; b_size < max_classified_b_size_; b_size++) {
-    if (active_pool_.TryFetchEntryList(merging_list, b_size)) {
+    while (active_pool_.TryFetchEntryList(merging_list, b_size)) {
       for (PMemOffsetType &offset : merging_list) {
         assert(offset % block_size_ == 0);
         auto b_offset = offset / block_size_;

--- a/engine/pmem_allocator/free_list.hpp
+++ b/engine/pmem_allocator/free_list.hpp
@@ -158,7 +158,7 @@ public:
   // active_pool_ for next run. Calculate the minimal timestamp of free entries
   // in the pool meantime
   // TODO: set a condition to decide if we need to do merging
-  void MergeAndCheckTSInPool();
+  void MergeSpaceInPool();
 
   // Move cached free space list to space entry pool to balance usable space
   // of access threads

--- a/engine/pmem_allocator/pmem_allocator.cpp
+++ b/engine/pmem_allocator/pmem_allocator.cpp
@@ -45,7 +45,6 @@ std::int64_t PMEMAllocator::PMemUsageInBytes() {
 void PMEMAllocator::populateSpace() {
   GlobalLogger.Info("Populating PMem space ...\n");
   assert((pmem_ - static_cast<char *>(nullptr)) % 64 == 0);
-  assert(pmem_size_ % 64 == 0);
   for (size_t i = 0; i < pmem_size_ / 64; i++) {
     _mm512_stream_si512(reinterpret_cast<__m512i *>(pmem_) + i,
                         _mm512_set1_epi64(0ULL));
@@ -127,7 +126,8 @@ PMEMAllocator *PMEMAllocator::NewPMEMAllocator(
   // No need to worry user modify those parameters so that records may be
   // skipped.
   size_t sz_wasted = pmem_size % (block_size * num_segment_blocks);
-  if (sz_wasted != 0)
+  if (!(pmem_size > block_size * num_segment_blocks * max_access_threads) &&
+      sz_wasted != 0)
     GlobalLogger.Error(
         "Pmem file size not aligned with segment size, %llu space is wasted.\n",
         sz_wasted);

--- a/engine/pmem_allocator/pmem_allocator.cpp
+++ b/engine/pmem_allocator/pmem_allocator.cpp
@@ -126,11 +126,12 @@ PMEMAllocator *PMEMAllocator::NewPMEMAllocator(
   // No need to worry user modify those parameters so that records may be
   // skipped.
   size_t sz_wasted = pmem_size % (block_size * num_segment_blocks);
-  if (!(pmem_size > block_size * num_segment_blocks * max_access_threads) &&
-      sz_wasted != 0)
+  if ((pmem_size > block_size * num_segment_blocks * max_access_threads) ||
+      sz_wasted != 0) {
     GlobalLogger.Error(
         "Pmem file size not aligned with segment size, %llu space is wasted.\n",
         sz_wasted);
+  }
   GlobalLogger.Info("Map pmem space done\n");
 
   if (!pmem_file_exist && populate_space_on_new_file) {

--- a/engine/pmem_allocator/pmem_allocator.hpp
+++ b/engine/pmem_allocator/pmem_allocator.hpp
@@ -98,6 +98,9 @@ public:
   void BatchFree(const std::vector<SpaceEntry> &entries) {
     if (entries.size() > 0) {
       free_list_.BatchPush(entries);
+      for (auto &entry : entries) {
+        LogDeallocation(access_thread.id, entry.size);
+      }
     }
   }
 
@@ -170,6 +173,6 @@ private:
   VersionController *version_controller_;
 
   std::mutex backup_lock;
-  bool backup_processing;
+  bool backup_processing = false;
 };
 } // namespace KVDK_NAMESPACE

--- a/engine/unordered_collection.cpp
+++ b/engine/unordered_collection.cpp
@@ -51,7 +51,13 @@ ModifyReturn UnorderedCollection::Emplace(TimeStampType timestamp,
                                           StringView const key,
                                           StringView const value,
                                           LockType const &lock) {
-  thread_local DLRecord *last_emplacement_pos = nullptr;
+  thread_local PMemOffsetType last_emplacement_offset = kNullPMemOffset;
+  DLRecord *last_emplacement_pos =
+      (last_emplacement_offset == kNullPMemOffset)
+          ? nullptr
+          : static_cast<DLRecord *>(
+                dlinked_list_.pmem_allocator_ptr_->offset2addr_checked(
+                    last_emplacement_offset));
 
   iterator new_record = makeInternalIterator(nullptr);
   LockPair lock_prev_and_next;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -8,6 +8,7 @@ set(TEST_SOURCES2 stress_test.cpp)
 add_executable(dbstress_test ${TEST_SOURCES2})
 target_link_libraries(dbstress_test PUBLIC engine gtest gmock gtest_main)
 
+message(${PROJECT_SOURCE_DIR})
 # For pmem allocator module tests
 set(TEST_PMEM_ALLOC test_pmem_allocator.cpp)
 add_executable(dbtest_pmem_allocator ${TEST_PMEM_ALLOC})

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,19 @@
+# For kvdk api general test
+set(TEST_SOURCES tests.cpp)
+add_executable(dbtest ${TEST_SOURCES})
+target_link_libraries(dbtest PUBLIC engine gtest gmock gtest_main)
+
+# For stress tests
+set(TEST_SOURCES2 stress_test.cpp)
+add_executable(dbstress_test ${TEST_SOURCES2})
+target_link_libraries(dbstress_test PUBLIC engine gtest gmock gtest_main)
+
+# For pmem allocator module tests
+set(TEST_PMEM_ALLOC test_pmem_allocator.cpp)
+add_executable(dbtest_pmem_allocator ${TEST_PMEM_ALLOC})
+target_include_directories(dbtest_pmem_allocator 
+    PRIVATE 
+    ${PROJECT_SOURCE_DIR}/engine 
+    ${PROJECT_SOURCE_DIR}/include
+    )
+target_link_libraries(dbtest_pmem_allocator PUBLIC engine gtest gmock gtest_main)

--- a/tests/test_pmem_allocator.cpp
+++ b/tests/test_pmem_allocator.cpp
@@ -134,7 +134,7 @@ TEST_F(EnginePMemAllocatorTest, TestPMemFragmentation) {
       pmem_alloc->Free(records[id]);
     }
   };
-     pmem_alloc->BackgroundWork();
+  pmem_alloc->BackgroundWork();
   // Test merge free memory
   auto TestPmemFrag = [&](uint64_t id) {
     thread_manager_->MaybeInitThread(access_thread);
@@ -150,7 +150,7 @@ TEST_F(EnginePMemAllocatorTest, TestPMemFragmentation) {
 }
 
 // TODO: Add more cases
-TEST_F(EnginePMemAllocatorTest, TestPMemAlocFreeList) {
+TEST_F(EnginePMemAllocatorTest, TestPMemAllocFreeList) {
   uint32_t num_thread = 1;
   uint64_t num_segment_block = 4 * kMinPaddingBlocks;
   uint64_t block_size = 64;
@@ -186,13 +186,10 @@ TEST_F(EnginePMemAllocatorTest, TestPMemAlocFreeList) {
   records.push_back(pmem_alloc->Allocate(alloc_size[1]));
   ASSERT_EQ(pmem_alloc->PMemUsageInBytes(), pmem_size);
 
-  // free 512 bytes and again free 512 bytes
-  std::vector<SpaceEntry> frees;
-  frees.push_back(records.back());
+  pmem_alloc->Free(records.back());
   records.pop_back();
-  frees.push_back(records.front());
+  pmem_alloc->Free(records.front());
   records.pop_front();
-  pmem_alloc->BatchFree(frees);
 
   // need to merge
   pmem_alloc->BackgroundWork();

--- a/tests/test_pmem_allocator.cpp
+++ b/tests/test_pmem_allocator.cpp
@@ -1,0 +1,152 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright(c) 2021 Intel Corporation
+ */
+
+#include <chrono>
+#include <ctime>
+#include <future>
+#include <queue>
+#include <string>
+#include <sys/time.h>
+#include <thread>
+#include <vector>
+
+#include "../engine/kv_engine.hpp"
+#include "../engine/logger.hpp"
+#include "../engine/thread_manager.hpp"
+
+#include "gtest/gtest.h"
+
+#include "kvdk/engine.hpp"
+#include "pmem_allocator/free_list.hpp"
+#include "pmem_allocator/pmem_allocator.hpp"
+#include "test_util.h"
+
+
+using namespace KVDK_NAMESPACE;
+
+class EnginePMemAllocatorTest : public testing::Test {
+protected:
+  Engine *engine = nullptr;
+  Configs configs;
+  std::shared_ptr<ThreadManager> thread_manager_;
+  std::string pmem_path;
+
+  virtual void SetUp() override {
+    pmem_path = "/mnt/pmem0/kvdk_pmem_allocator";
+    GlobalLogger.Init(stdout, LogLevel::All);
+    char cmd[1024];
+    sprintf(cmd, "rm -rf %s\n", pmem_path.c_str());
+    int res __attribute__((unused)) = system(cmd);
+  }
+
+  virtual void TearDown() { // delete db_path
+    char cmd[1024];
+    sprintf(cmd, "rm -rf %s\n", pmem_path.c_str());
+    int res __attribute__((unused)) = system(cmd);
+  }
+};
+
+TEST_F(EnginePMemAllocatorTest, TestBasicAlloc) {
+  uint64_t pmem_size = 128ULL << 20; // 128MB
+  uint64_t alloc_size = 8;
+
+  // params config
+  std::vector<uint64_t> num_segment_blocks{1024, 2 * 1024, 2 * 1024 * 1024};
+  std::vector<uint32_t> block_sizes{16, 32, 64};
+  std::vector<uint32_t> num_threads = {1, 16};
+
+  for (int i = 0; i < num_segment_blocks.size(); ++i) {
+    for (auto num_thread : num_threads) {
+      thread_manager_.reset(new (std::nothrow) ThreadManager(num_thread));
+
+      // Test function.
+      auto TestPmemAlloc = [&](uint64_t id) {
+        std::vector<SpaceEntry> records;
+        thread_manager_->MaybeInitThread(write_thread);
+        PMEMAllocator *pmem_alloc = PMEMAllocator::NewPMEMAllocator(
+            pmem_path, pmem_size, num_segment_blocks[i], block_sizes[i],
+            num_thread, true, false);
+        ASSERT_NE(pmem_alloc, nullptr);
+
+        uint64_t kvpairs = pmem_size / block_sizes[i];
+        for (uint64_t j = 0; j < kvpairs; ++j) {
+          auto space_entry = pmem_alloc->Allocate(alloc_size);
+          records.push_back(space_entry);
+        }
+
+        auto alloc_bytes = pmem_alloc->PMemUsageInBytes();
+
+        for (uint64_t j = 0; j < records.size(); ++j) {
+          pmem_alloc->Free(records[j]);
+        }
+
+        ASSERT_EQ(pmem_alloc->PMemUsageInBytes(), (std::int64_t)0);
+        records.clear();
+        
+        uint64_t alloc_cnt = 1;
+        // again allocate pmem
+        while (true) {
+          auto space_entry = pmem_alloc->Allocate(alloc_size);
+          if (pmem_alloc->PMemUsageInBytes() == alloc_bytes)
+            break;
+          alloc_cnt++;
+        }
+        ASSERT_EQ(kvpairs,alloc_cnt);
+        delete pmem_alloc;
+      };
+
+      LaunchNThreads(num_thread, TestPmemAlloc);
+    }
+  }
+}
+
+TEST_F(EnginePMemAllocatorTest, TestPMemFragmentation) {
+  uint32_t num_thread = 16;
+  uint64_t pmem_size = 64ULL << 10;
+  uint64_t num_segment_block = 1024;
+  uint64_t block_size = 64;
+  std::vector<uint64_t> alloc_size{8 * 64, 8 * 64, 16 * 64, 32 * 64};
+  thread_manager_.reset(new ThreadManager(num_thread));
+  PMEMAllocator *pmem_alloc =
+      PMEMAllocator::NewPMEMAllocator(pmem_path, pmem_size, num_segment_block,
+                                      block_size, num_thread, true, false);
+  ASSERT_NE(pmem_alloc, nullptr);
+
+  /* Allocated pmem status (block nums):
+   * | 8 | 8 | 16 | 32 | 8 | 8 | 16 | 32 | 8 | 8 | 16 | 32 | 8 | 8 | 16 | 32 |
+   */
+
+  std::vector<SpaceEntry> records(num_thread);
+  thread_manager_->MaybeInitThread(write_thread);
+  for (uint32_t i = 0; i < records.size(); ++i) {
+    SpaceEntry space_entry = pmem_alloc->Allocate(alloc_size[i % 4]);
+    records[i] = space_entry;
+    ASSERT_NE(space_entry.size, 0);
+  }
+
+  pmem_alloc->BackgroundWork();
+  /* Allocated pmem status:
+   * | null | null | null | 32 | null | null | null | 32 | null | null | null
+   * | 32 | null | null | null | 32 |
+   */
+  auto TestPmemFree = [&](uint64_t id) {
+    thread_manager_->MaybeInitThread(write_thread);
+    if ((id + 1) % 4 != 0) {
+      pmem_alloc->Free(records[id]);
+    }
+  };
+
+  // Test merge free memory
+  auto TestPmemFrag = [&](uint64_t id) {
+    thread_manager_->MaybeInitThread(write_thread);
+    if ((id + 1 % 4) == 0) {
+      SpaceEntry space_entry = pmem_alloc->Allocate(alloc_size[id % 4]);
+      ASSERT_NE(space_entry.size, 0);
+    }
+  };
+  LaunchNThreads(num_thread, TestPmemFree);
+  LaunchNThreads(num_thread, TestPmemFrag);
+
+  delete pmem_alloc;
+}

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -21,6 +21,17 @@
 using namespace KVDK_NAMESPACE;
 static const uint64_t str_pool_length = 1024000;
 
+using SetOpsFunc =
+    std::function<Status(const std::string &collection, const std::string &key,
+                         const std::string &value)>;
+using DeleteOpsFunc = std::function<Status(const std::string &collection,
+                                           const std::string &key)>;
+
+using GetOpsFunc = std::function<Status(
+    const std::string &collection, const std::string &key, std::string *value)>;
+
+enum Types { String, Sorted, Hash, Queue };
+
 class EngineBasicTest : public testing::Test {
 protected:
   Engine *engine = nullptr;
@@ -40,12 +51,15 @@ protected:
     // For faster test, no interval so it would not block engine closing
     configs.background_work_interval = 0.1;
     configs.log_level = LogLevel::All;
+    configs.max_access_threads = 1;
     db_path = "/mnt/pmem0/kvdk-test";
     backup_path = "/mnt/pmem0/kvdk-test-backup";
     char cmd[1024];
     sprintf(cmd, "rm -rf %s && rm -rf %s\n", db_path.c_str(),
             backup_path.c_str());
     int res __attribute__((unused)) = system(cmd);
+    config_option = OptionConfig::Default;
+    cnt = 500;
   }
 
   virtual void TearDown() { Destroy(); }
@@ -61,6 +75,187 @@ protected:
             backup_path.c_str());
     int res __attribute__((unused)) = system(cmd);
   }
+
+  bool ChangedConfig() {
+    config_option++;
+    if (config_option >= End) {
+      return false;
+    } else {
+      ReopenEngine();
+      return true;
+    }
+  }
+
+  void ReopenEngine() {
+    delete engine;
+    engine = nullptr;
+    configs = CurrentConfigs();
+    ASSERT_EQ(Engine::Open(db_path.c_str(), &engine, configs, stdout),
+              Status::Ok);
+  }
+
+  // Return the current configuration.
+  Configs CurrentConfigs() {
+    switch (config_option) {
+    case MultiThread:
+      configs.max_access_threads = 16;
+      break;
+    case OptRestore:
+      configs.opt_large_sorted_collection_restore = true;
+      break;
+    default:
+      break;
+    }
+    return configs;
+  }
+
+  // Set/Get/Delete
+  void TestGlobalCollection(const std::string &collection, SetOpsFunc SetFunc,
+                            GetOpsFunc GetFunc, DeleteOpsFunc DeleteFunc,
+                            Types type) {
+    // Maybe having create collection for all collection types.
+    if (type == Types::Sorted) {
+      Collection *collection_ptr;
+      ASSERT_EQ(engine->CreateSortedCollection(collection, &collection_ptr),
+                Status::Ok);
+    }
+    TestEmptyKey(collection, SetFunc, GetFunc, DeleteFunc);
+    LaunchNThreads(configs.max_access_threads,
+                   BasicOperator(collection, SetFunc, GetFunc, DeleteFunc));
+  }
+
+  void TestLocalCollection(const std::string &collection, SetOpsFunc SetFunc,
+                           GetOpsFunc GetFunc, DeleteOpsFunc DeleteFunc) {
+    auto Local_XSetXGetXDelete = [&](uint64_t id) {
+      std::string thread_local_collection = collection + std::to_string(id);
+      Collection *local_collection_ptr;
+      ASSERT_EQ(engine->CreateSortedCollection(thread_local_collection,
+                                               &local_collection_ptr),
+                Status::Ok);
+
+      TestEmptyKey(thread_local_collection, SetFunc, GetFunc, DeleteFunc);
+
+      auto BasicOpFunc =
+          BasicOperator(thread_local_collection, SetFunc, GetFunc, DeleteFunc);
+      BasicOpFunc(id);
+    };
+    LaunchNThreads(configs.max_access_threads, Local_XSetXGetXDelete);
+  }
+
+  void SeekIterator(const std::string &collection, Types type,
+                    bool is_local = false) {
+    if (type != Types::Sorted && type != Types::Hash) {
+      return;
+    }
+
+    auto IteratingThrough = [&](uint32_t id) {
+      std::atomic<int> entries(0);
+      std::string new_collection = collection;
+      if (is_local) {
+        new_collection += std::to_string(id);
+      }
+      auto iter = type == Types::Sorted
+                      ? engine->NewSortedIterator(new_collection)
+                      : engine->NewUnorderedIterator(new_collection);
+
+      ASSERT_TRUE(iter != nullptr);
+      // forward iterator
+      iter->SeekToFirst();
+      if (iter->Valid()) {
+        ++entries;
+        std::string prev = iter->Key();
+        iter->Next();
+        while (iter->Valid()) {
+          ++entries;
+          std::string k = iter->Key();
+          iter->Next();
+          if (type == Types::Sorted) {
+            ASSERT_EQ(true, k.compare(prev) > 0);
+          }
+          prev = k;
+        }
+      }
+      if (is_local) {
+        ASSERT_EQ(cnt, entries);
+      } else {
+        ASSERT_EQ(cnt * configs.max_access_threads, entries);
+      }
+
+      // backward iterator
+      iter->SeekToLast();
+      if (iter->Valid()) {
+        --entries;
+        std::string next = iter->Key();
+        iter->Prev();
+        while (iter->Valid()) {
+          --entries;
+          std::string k = iter->Key();
+          iter->Prev();
+          if (type == Types::Sorted) {
+            ASSERT_EQ(true, k.compare(next) < 0);
+          }
+          next = k;
+        }
+      }
+      ASSERT_EQ(entries, 0);
+    };
+    LaunchNThreads(configs.max_access_threads, IteratingThrough);
+  }
+
+private:
+  void TestEmptyKey(const std::string &collection, SetOpsFunc SetFunc,
+                    GetOpsFunc GetFunc, DeleteOpsFunc DeleteFunc) {
+    std::string key, val, got_val;
+    key = "", val = "val";
+    ASSERT_EQ(SetFunc(collection, key, val), Status::Ok);
+    ASSERT_EQ(GetFunc(collection, key, &got_val), Status::Ok);
+    ASSERT_EQ(val, got_val);
+    ASSERT_EQ(DeleteFunc(collection, key), Status::Ok);
+    ASSERT_EQ(GetFunc(collection, key, &got_val), Status::NotFound);
+    engine->ReleaseAccessThread();
+  }
+
+  std::function<void(uint32_t)> BasicOperator(const std::string &collection,
+                                              SetOpsFunc SetFunc,
+                                              GetOpsFunc GetFunc,
+                                              DeleteOpsFunc DeleteFunc) {
+    return [&](uint32_t id) {
+      std::string val1, val2, got_val1, got_val2;
+      int t_cnt = cnt;
+      while (t_cnt--) {
+        std::string key1(std::string(id + 1, 'a') + std::to_string(t_cnt));
+        std::string key2(std::string(id + 1, 'b') + std::to_string(t_cnt));
+        AssignData(val1, fast_random_64() % 1024);
+        AssignData(val2, fast_random_64() % 1024);
+
+        // Set
+        ASSERT_EQ(SetFunc(collection, key1, val1), Status::Ok);
+        ASSERT_EQ(SetFunc(collection, key2, val2), Status::Ok);
+
+        // Get
+        ASSERT_EQ(GetFunc(collection, key1, &got_val1), Status::Ok);
+        ASSERT_EQ(val1, got_val1);
+        ASSERT_EQ(GetFunc(collection, key2, &got_val2), Status::Ok);
+        ASSERT_EQ(val2, got_val2);
+
+        // Delete
+        ASSERT_EQ(DeleteFunc(collection, key1), Status::Ok);
+        ASSERT_EQ(GetFunc(collection, key1, &got_val1), Status::NotFound);
+
+        // Update
+        AssignData(val2, fast_random_64() % 1024);
+        ASSERT_EQ(SetFunc(collection, key2, val2), Status::Ok);
+        ASSERT_EQ(GetFunc(collection, key2, &got_val2), Status::Ok);
+        ASSERT_EQ(got_val2, val2);
+      }
+    };
+  }
+
+private:
+  // Sequence of option configurations to try
+  enum OptionConfig { Default, MultiThread, OptRestore, End };
+  int config_option;
+  int cnt;
 };
 
 TEST_F(EngineBasicTest, TestThreadManager) {
@@ -235,51 +430,27 @@ TEST_F(EngineBasicTest, TestBasicBackupAndCheckpoint) {
 }
 
 TEST_F(EngineBasicTest, TestBasicStringOperations) {
-  int num_threads = 16;
-  configs.max_access_threads = num_threads;
-  ASSERT_EQ(Engine::Open(db_path.c_str(), &engine, configs, stdout),
-            Status::Ok);
-
-  // Test empty key
-  std::string key{""}, val{"val"}, got_val;
-  ASSERT_EQ(engine->Set(key, val), Status::Ok);
-  ASSERT_EQ(engine->Get(key, &got_val), Status::Ok);
-  ASSERT_EQ(val, got_val);
-  ASSERT_EQ(engine->Delete(key), Status::Ok);
-  ASSERT_EQ(engine->Get(key, &got_val), Status::NotFound);
-  engine->ReleaseAccessThread();
-
-  auto SetGetDelete = [&](uint32_t id) {
-    std::string val1, val2, got_val1, got_val2;
-    int cnt = 100;
-    while (cnt--) {
-      std::string key1(std::string(id + 1, 'a') + std::to_string(cnt));
-      std::string key2(std::string(id + 1, 'b') + std::to_string(cnt));
-      AssignData(val1, fast_random_64() % 1024);
-      AssignData(val2, fast_random_64() % 1024);
-
-      ASSERT_EQ(engine->Set(key1, val1), Status::Ok);
-      ASSERT_EQ(engine->Set(key2, val2), Status::Ok);
-
-      // Get
-      ASSERT_EQ(engine->Get(key1, &got_val1), Status::Ok);
-      ASSERT_EQ(val1, got_val1);
-      ASSERT_EQ(engine->Get(key2, &got_val2), Status::Ok);
-      ASSERT_EQ(val2, got_val2);
-
-      // Delete
-      ASSERT_EQ(engine->Delete(key1), Status::Ok);
-      ASSERT_EQ(engine->Get(key1, &got_val1), Status::NotFound);
-
-      // Update
-      AssignData(val1, fast_random_64() % 1024);
-      ASSERT_EQ(engine->Set(key1, val1), Status::Ok);
-      ASSERT_EQ(engine->Get(key1, &got_val1), Status::Ok);
-      ASSERT_EQ(got_val1, val1);
-    }
+  auto StringSetFunc = [&](const std::string &collection,
+                           const std::string &key,
+                           const std::string &value) -> Status {
+    return engine->Set(key, value);
   };
 
-  LaunchNThreads(num_threads, SetGetDelete);
+  auto StringGetFunc =
+      [&](const std::string &collection, const std::string &key,
+          std::string *value) -> Status { return engine->Get(key, value); };
+
+  auto StringDeleteFunc = [&](const std::string &collection,
+                              const std::string &key) -> Status {
+    return engine->Delete(key);
+  };
+
+  ASSERT_EQ(Engine::Open(db_path.c_str(), &engine, configs, stdout),
+            Status::Ok);
+  do {
+    TestGlobalCollection("global_string", StringSetFunc, StringGetFunc,
+                         StringDeleteFunc, Types::String);
+  } while (ChangedConfig());
   delete engine;
 }
 
@@ -343,299 +514,64 @@ TEST_F(EngineBasicTest, TestBatchWrite) {
   delete engine;
 }
 
-TEST_F(EngineBasicTest, TestFreeList) {
-  // TODO: Add more cases
-  configs.pmem_segment_blocks = 4 * kMinPaddingBlocks;
-  configs.max_access_threads = 1;
-  configs.pmem_block_size = 64;
-  configs.pmem_file_size =
-      configs.pmem_segment_blocks * configs.pmem_block_size;
-  configs.background_work_interval = 0.5;
-
-  ASSERT_EQ(Engine::Open(db_path.c_str(), &engine, configs, stdout),
-            Status::Ok);
-
-  std::string key1("a1");
-  std::string key2("a2");
-  std::string key3("a3");
-  std::string key4("a4");
-  std::string small_value(64 * (kMinPaddingBlocks - 1) + 1, 'a');
-  std::string large_value(64 * (kMinPaddingBlocks * 2 - 1) + 1, 'a');
-  // We have 4 kMinimalPaddingBlockSize size chunk of blocks, this will take
-  // up 2 of them
-
-  ASSERT_EQ(engine->Set(key1, large_value), Status::Ok);
-
-  // update large value, new value will be stored in 3th chunk
-  ASSERT_EQ(engine->Set(key1, small_value), Status::Ok);
-
-  // key2 will be stored in 4th chunk
-  ASSERT_EQ(engine->Set(key2, small_value), Status::Ok);
-
-  // wait for updated space be freed
-  sleep(4 * configs.background_work_interval);
-
-  // new key 1 and new key 2 will be stored in updated 1st and 2nd chunks
-  ASSERT_EQ(engine->Set(key1, small_value), Status::Ok);
-
-  ASSERT_EQ(engine->Set(key2, small_value), Status::Ok);
-
-  // No more space to store large_value
-  ASSERT_EQ(engine->Set(key3, large_value), Status::PmemOverflow);
-
-  // Wait bg thread finish merging space of 3th and 4th chunks
-  sleep(4 * configs.background_work_interval);
-
-  // large key3 will be stored in merged 3th and 4th chunks
-  ASSERT_EQ(engine->Set(key3, large_value), Status::Ok);
-
-  // No more space
-  ASSERT_EQ(engine->Set(key4, small_value), Status::PmemOverflow);
-
-  delete engine;
-  ASSERT_EQ(Engine::Open(db_path.c_str(), &engine, configs, stdout),
-            Status::Ok);
-  // Still no more space after re-open
-  ASSERT_EQ(engine->Set(key4, small_value), Status::PmemOverflow);
-
-  delete engine;
-}
-
 TEST_F(EngineBasicTest, TestLocalSortedCollection) {
-  int num_threads = 16;
-  configs.max_access_threads = num_threads;
+  auto SortedSetFunc = [&](const std::string &collection,
+                           const std::string &key,
+                           const std::string &value) -> Status {
+    return engine->SSet(collection, key, value);
+  };
+
+  auto SortedGetFunc = [&](const std::string &collection,
+                           const std::string &key,
+                           std::string *value) -> Status {
+    return engine->SGet(collection, key, value);
+  };
+
+  auto SortedDeleteFunc = [&](const std::string &collection,
+                              const std::string &key) -> Status {
+    return engine->SDelete(collection, key);
+  };
+
   ASSERT_EQ(Engine::Open(db_path.c_str(), &engine, configs, stdout),
             Status::Ok);
-  std::vector<int> n_local_entries(num_threads, 0);
-
-  auto SSetSGetSDelete = [&](uint32_t id) {
-    std::string thread_local_skiplist("t_skiplist" + std::to_string(id));
-    std::string key1, key2, val1, val2;
-    std::string got_val1, got_val2;
-
-    Collection *thread_collection_ptr;
-    Status s = engine->CreateSortedCollection(thread_local_skiplist,
-                                              &thread_collection_ptr);
-    ASSERT_EQ(s, Status::Ok);
-    AssignData(val1, 10);
-
-    // Test Empty Key
-    {
-      std::string k0{""};
-      ASSERT_EQ(engine->SSet(thread_local_skiplist, k0, val1), Status::Ok);
-      ++n_local_entries[id];
-      ASSERT_EQ(engine->SGet(thread_local_skiplist, k0, &got_val1), Status::Ok);
-      ASSERT_EQ(val1, got_val1);
-      ASSERT_EQ(engine->SDelete(thread_local_skiplist, k0), Status::Ok);
-      --n_local_entries[id];
-      ASSERT_EQ(engine->SGet(thread_local_skiplist, k0, &got_val1),
-                Status::NotFound);
-    }
-
-    key1 = std::to_string(id);
-    key2 = std::to_string(id);
-
-    int cnt = 100;
-    while (cnt--) {
-      key1.append("k1");
-      key2.append("k2");
-
-      // insert
-      AssignData(val1, fast_random_64() % 1024);
-      AssignData(val2, fast_random_64() % 1024);
-      ASSERT_EQ(engine->SSet(thread_local_skiplist, key1, val1), Status::Ok);
-      ++n_local_entries[id];
-      ASSERT_EQ(engine->SSet(thread_local_skiplist, key2, val2), Status::Ok);
-      ++n_local_entries[id];
-      ASSERT_EQ(engine->SGet(thread_local_skiplist, key1, &got_val1),
-                Status::Ok);
-      ASSERT_EQ(engine->SGet(thread_local_skiplist, key2, &got_val2),
-                Status::Ok);
-      ASSERT_EQ(val1, got_val1);
-      ASSERT_EQ(val2, got_val2);
-
-      // update
-      AssignData(val1, fast_random_64() % 1024);
-      ASSERT_EQ(engine->SSet(thread_local_skiplist, key1, val1), Status::Ok);
-      ASSERT_EQ(engine->SGet(thread_local_skiplist, key1, &got_val1),
-                Status::Ok);
-      ASSERT_EQ(got_val1, val1);
-      AssignData(val2, fast_random_64() % 1024);
-      ASSERT_EQ(engine->SSet(thread_local_skiplist, key2, val2), Status::Ok);
-      ASSERT_EQ(engine->SGet(thread_local_skiplist, key2, &got_val2),
-                Status::Ok);
-      ASSERT_EQ(got_val2, val2);
-
-      // delete
-      ASSERT_EQ(engine->SDelete(thread_local_skiplist, key1), Status::Ok);
-      --n_local_entries[id];
-      ASSERT_EQ(engine->SGet(thread_local_skiplist, key1, &got_val1),
-                Status::NotFound);
-    }
-  };
-
-  auto IteratingThrough = [&](uint32_t id) {
-    std::string thread_local_skiplist("t_skiplist" + std::to_string(id));
-    std::vector<int> n_entries_scan(num_threads, 0);
-
-    auto t_iter = engine->NewSortedIterator(thread_local_skiplist);
-    ASSERT_TRUE(t_iter != nullptr);
-    t_iter->SeekToFirst();
-    if (t_iter->Valid()) {
-      ++n_entries_scan[id];
-      std::string prev = t_iter->Key();
-      t_iter->Next();
-      while (t_iter->Valid()) {
-        ++n_entries_scan[id];
-        std::string k = t_iter->Key();
-        t_iter->Next();
-        ASSERT_EQ(true, k.compare(prev) > 0);
-        prev = k;
-      }
-    }
-    ASSERT_EQ(n_local_entries[id], n_entries_scan[id]);
-
-    t_iter->SeekToLast();
-    if (t_iter->Valid()) {
-      --n_entries_scan[id];
-      std::string next = t_iter->Key();
-      t_iter->Prev();
-      while (t_iter->Valid()) {
-        --n_entries_scan[id];
-        std::string k = t_iter->Key();
-        t_iter->Prev();
-        ASSERT_EQ(true, k.compare(next) < 0);
-        next = k;
-      }
-    }
-    ASSERT_EQ(n_entries_scan[id], 0);
-  };
-
-  LaunchNThreads(num_threads, SSetSGetSDelete);
-  LaunchNThreads(num_threads, IteratingThrough);
+  do {
+    TestLocalCollection("thread_skiplist", SortedSetFunc, SortedGetFunc,
+                        SortedDeleteFunc);
+    SeekIterator("thread_skiplist", Types::Sorted, true);
+  } while (ChangedConfig());
 
   delete engine;
 }
 
 TEST_F(EngineBasicTest, TestGlobalSortedCollection) {
-  const std::string global_skiplist = "skiplist";
-  int num_threads = 16;
-  configs.max_access_threads = num_threads;
-  ASSERT_EQ(Engine::Open(db_path.c_str(), &engine, configs, stdout),
-            Status::Ok);
   std::atomic<int> n_global_entries{0};
 
-  Collection *global_collection_ptr;
-  ASSERT_EQ(
-      engine->CreateSortedCollection(global_skiplist, &global_collection_ptr),
-      Status::Ok);
-  // Test empty key
-  std::string key{""}, val{"val"}, got_val;
-  ASSERT_EQ(engine->SSet(global_skiplist, key, val), Status::Ok);
-  ++n_global_entries;
-  ASSERT_EQ(engine->SGet(global_skiplist, key, &got_val), Status::Ok);
-  ASSERT_EQ(val, got_val);
-  ASSERT_EQ(engine->SDelete(global_skiplist, key), Status::Ok);
-  --n_global_entries;
-  ASSERT_EQ(engine->SGet(global_skiplist, key, &got_val), Status::NotFound);
-  engine->ReleaseAccessThread();
-
-  auto SSetSGetSDelete = [&](uint32_t id) {
-    std::string k1, k2, v1, v2;
-    std::string got_v1, got_v2;
-
-    AssignData(v1, 10);
-
-    k1 = std::to_string(id);
-    k2 = std::to_string(id);
-
-    int cnt = 100;
-    while (cnt--) {
-      int v1_len = rand() % 1024;
-      int v2_len = rand() % 1024;
-      k1.append("k1");
-      k2.append("k2");
-
-      // insert
-      AssignData(v1, v1_len);
-      AssignData(v2, v2_len);
-      ASSERT_EQ(engine->SSet(global_skiplist, k1, v1), Status::Ok);
-      ++n_global_entries;
-      ASSERT_EQ(engine->SSet(global_skiplist, k2, v2), Status::Ok);
-      ++n_global_entries;
-      ASSERT_EQ(engine->SGet(global_skiplist, k1, &got_v1), Status::Ok);
-      ASSERT_EQ(engine->SGet(global_skiplist, k2, &got_v2), Status::Ok);
-      ASSERT_EQ(v1, got_v1);
-      ASSERT_EQ(v2, got_v2);
-
-      // update
-      AssignData(v1, v1_len);
-      ASSERT_EQ(engine->SSet(global_skiplist, k1, v1), Status::Ok);
-      ASSERT_EQ(engine->SGet(global_skiplist, k1, &got_v1), Status::Ok);
-      ASSERT_EQ(got_v1, v1);
-      AssignData(v2, v2_len);
-      ASSERT_EQ(engine->SSet(global_skiplist, k2, v2), Status::Ok);
-      ASSERT_EQ(engine->SGet(global_skiplist, k2, &got_v2), Status::Ok);
-      ASSERT_EQ(got_v2, v2);
-
-      // delete
-      ASSERT_EQ(engine->SDelete(global_skiplist, k1), Status::Ok);
-      --n_global_entries;
-      ASSERT_EQ(engine->SGet(global_skiplist, k1, &got_v1), Status::NotFound);
-    }
+  auto SortedSetFunc = [&](const std::string &collection,
+                           const std::string &key,
+                           const std::string &value) -> Status {
+    return engine->SSet(collection, key, value);
   };
 
-  auto IteratingThrough = [&](uint32_t id) {
-    std::vector<int> n_entries(num_threads, 0);
-
-    auto iter = engine->NewSortedIterator(global_skiplist);
-    ASSERT_TRUE(iter != nullptr);
-    iter->SeekToFirst();
-    if (iter->Valid()) {
-      ++n_entries[id];
-      std::string prev = iter->Key();
-      iter->Next();
-      while (iter->Valid()) {
-        ++n_entries[id];
-        std::string k = iter->Key();
-        iter->Next();
-        ASSERT_EQ(true, k.compare(prev) > 0);
-        prev = k;
-      }
-    }
-    ASSERT_EQ(n_global_entries, n_entries[id]);
-
-    iter->SeekToLast();
-    if (iter->Valid()) {
-      --n_entries[id];
-      std::string next = iter->Key();
-      iter->Prev();
-      while (iter->Valid()) {
-        --n_entries[id];
-        std::string k = iter->Key();
-        iter->Prev();
-        ASSERT_EQ(true, k.compare(next) < 0);
-        next = k;
-      }
-    }
-    ASSERT_EQ(n_entries[id], 0);
+  auto SortedGetFunc = [&](const std::string &collection,
+                           const std::string &key,
+                           std::string *value) -> Status {
+    return engine->SGet(collection, key, value);
   };
 
-  auto SeekToDeleted = [&](uint32_t id) {
-    auto t_iter2 = engine->NewSortedIterator(global_skiplist);
-    ASSERT_TRUE(t_iter2 != nullptr);
-    // First deleted key
-    t_iter2->Seek(std::to_string(id) + "k1");
-    ASSERT_TRUE(t_iter2->Valid());
-    // First valid key
-    t_iter2->Seek(std::to_string(id) + "k2");
-    ASSERT_TRUE(t_iter2->Valid());
-    ASSERT_EQ(t_iter2->Key(), std::to_string(id) + "k2");
+  auto SortedDeleteFunc = [&](const std::string &collection,
+                              const std::string &key) -> Status {
+    return engine->SDelete(collection, key);
   };
-  LaunchNThreads(num_threads, SSetSGetSDelete);
-  LaunchNThreads(num_threads, IteratingThrough);
-  LaunchNThreads(num_threads, SeekToDeleted);
 
+  ASSERT_EQ(Engine::Open(db_path.c_str(), &engine, configs, stdout),
+            Status::Ok);
+
+  std::string collection = "global_skiplist";
+  do {
+    TestGlobalCollection(collection, SortedSetFunc, SortedGetFunc,
+                         SortedDeleteFunc, Types::Sorted);
+    SeekIterator(collection, Types::Sorted, false);
+  } while (ChangedConfig());
   delete engine;
 }
 
@@ -957,155 +893,59 @@ TEST_F(EngineBasicTest, TestMultiThreadSortedRestore) {
 }
 
 TEST_F(EngineBasicTest, TestLocalUnorderedCollection) {
-  int num_threads = 16;
-  int count = 100;
-  configs.max_access_threads = num_threads;
+  auto UnorderedSetFunc = [&](const std::string &collection,
+                              const std::string &key,
+                              const std::string &value) -> Status {
+    return engine->HSet(collection, key, value);
+  };
+
+  auto UnorderedGetFunc = [&](const std::string &collection,
+                              const std::string &key,
+                              std::string *value) -> Status {
+    return engine->HGet(collection, key, value);
+  };
+
+  auto UnorderedDeleteFunc = [&](const std::string &collection,
+                                 const std::string &key) -> Status {
+    return engine->HDelete(collection, key);
+  };
+
   ASSERT_EQ(Engine::Open(db_path.c_str(), &engine, configs, stdout),
             Status::Ok);
-  // insert and delete some keys, then re-insert some deleted keys
 
-  std::vector<std::vector<std::string>> local_keys(num_threads);
-  std::vector<std::vector<std::string>> local_values(num_threads);
-  std::vector<std::string> local_collection_names(num_threads);
-  for (size_t i = 0; i < num_threads; i++) {
-    local_collection_names[i] = "local_uncoll_t" + std::to_string(i);
-    for (size_t j = 0; j < count * 2; j++) {
-      local_keys[i].push_back(std::string{"local_key_"} + std::to_string(j));
-      local_values[i].push_back(GetRandomString(1024));
-    }
-  }
-
-  auto HSetHGetHDelete = [&](uint32_t tid) {
-    std::string value_got;
-    for (size_t j = 0; j < count; j++) {
-      // insert
-      ASSERT_EQ(engine->HSet(local_collection_names[tid], local_keys[tid][j],
-                             local_values[tid][j]),
-                Status::Ok);
-      ASSERT_EQ(engine->HGet(local_collection_names[tid], local_keys[tid][j],
-                             &value_got),
-                Status::Ok);
-      ASSERT_EQ(local_values[tid][j], value_got);
-
-      // insert another
-      ASSERT_EQ(engine->HSet(local_collection_names[tid],
-                             local_keys[tid][j + count],
-                             local_values[tid][j + count]),
-                Status::Ok);
-      ASSERT_EQ(engine->HGet(local_collection_names[tid],
-                             local_keys[tid][j + count], &value_got),
-                Status::Ok);
-      ASSERT_EQ(local_values[tid][j + count], value_got);
-
-      // update
-      ASSERT_EQ(engine->HSet(local_collection_names[tid], local_keys[tid][j],
-                             local_values[tid][j] + "_new"),
-                Status::Ok);
-      ASSERT_EQ(engine->HGet(local_collection_names[tid], local_keys[tid][j],
-                             &value_got),
-                Status::Ok);
-      ASSERT_EQ(local_values[tid][j] + "_new", value_got);
-
-      // delete the other
-      ASSERT_EQ(engine->HDelete(local_collection_names[tid],
-                                local_keys[tid][j + count]),
-                Status::Ok);
-      ASSERT_EQ(engine->HGet(local_collection_names[tid],
-                             local_keys[tid][j + count], &value_got),
-                Status::NotFound);
-    }
-  };
-
-  auto IteratingThrough = [&](uint32_t tid) {
-    int n_entry = 0;
-
-    auto t_iter = engine->NewUnorderedIterator(local_collection_names[tid]);
-    ASSERT_TRUE(t_iter != nullptr);
-    for (t_iter->SeekToFirst(); t_iter->Valid(); t_iter->Next()) {
-      ++n_entry;
-    }
-    ASSERT_EQ(count, n_entry);
-  };
-
-  LaunchNThreads(num_threads, HSetHGetHDelete);
-  LaunchNThreads(num_threads, IteratingThrough);
-
+  do {
+    TestLocalCollection("thread_unordered", UnorderedSetFunc, UnorderedGetFunc,
+                        UnorderedDeleteFunc);
+    SeekIterator("thread_unordered", Types::Hash, true);
+  } while (ChangedConfig());
   delete engine;
 }
 
 TEST_F(EngineBasicTest, TestGlobalUnorderedCollection) {
-  int num_threads = 16;
-  int count = 100;
-  configs.max_access_threads = num_threads;
+  auto UnorderedSetFunc = [&](const std::string &collection,
+                              const std::string &key,
+                              const std::string &value) -> Status {
+    return engine->HSet(collection, key, value);
+  };
+
+  auto UnorderedGetFunc = [&](const std::string &collection,
+                              const std::string &key,
+                              std::string *value) -> Status {
+    return engine->HGet(collection, key, value);
+  };
+
+  auto UnorderedDeleteFunc = [&](const std::string &collection,
+                                 const std::string &key) -> Status {
+    return engine->HDelete(collection, key);
+  };
   ASSERT_EQ(Engine::Open(db_path.c_str(), &engine, configs, stdout),
             Status::Ok);
 
-  std::vector<std::vector<std::string>> global_keys(num_threads);
-  std::vector<std::vector<std::string>> global_values(num_threads);
-  std::string global_collection_name{"global_uncoll"};
-  for (size_t i = 0; i < num_threads; i++) {
-    for (size_t j = 0; j < count * 2; j++) {
-      global_keys[i].push_back(std::string{"global_key_t"} + std::to_string(i) +
-                               std::string{"_k_"} + std::to_string(j));
-      global_values[i].push_back(GetRandomString(1024));
-    }
-  }
-
-  auto HSetHGetHDelete = [&](uint32_t tid) {
-    std::string value_got;
-    for (size_t j = 0; j < count; j++) {
-      // insert
-      ASSERT_EQ(engine->HSet(global_collection_name, global_keys[tid][j],
-                             global_values[tid][j]),
-                Status::Ok);
-      ASSERT_EQ(
-          engine->HGet(global_collection_name, global_keys[tid][j], &value_got),
-          Status::Ok);
-      ASSERT_EQ(global_values[tid][j], value_got);
-
-      // insert another
-      ASSERT_EQ(engine->HSet(global_collection_name,
-                             global_keys[tid][j + count],
-                             global_values[tid][j + count]),
-                Status::Ok);
-      ASSERT_EQ(engine->HGet(global_collection_name,
-                             global_keys[tid][j + count], &value_got),
-                Status::Ok);
-      ASSERT_EQ(global_values[tid][j + count], value_got);
-
-      // update
-      ASSERT_EQ(engine->HSet(global_collection_name, global_keys[tid][j],
-                             global_values[tid][j] + "_new"),
-                Status::Ok);
-      ASSERT_EQ(
-          engine->HGet(global_collection_name, global_keys[tid][j], &value_got),
-          Status::Ok);
-      ASSERT_EQ(global_values[tid][j] + "_new", value_got);
-
-      // delete the other
-      ASSERT_EQ(
-          engine->HDelete(global_collection_name, global_keys[tid][j + count]),
-          Status::Ok);
-      ASSERT_EQ(engine->HGet(global_collection_name,
-                             global_keys[tid][j + count], &value_got),
-                Status::NotFound);
-    }
-  };
-
-  auto IteratingThrough = [&](uint32_t tid) {
-    int n_entry = 0;
-
-    auto t_iter = engine->NewUnorderedIterator(global_collection_name);
-    ASSERT_TRUE(t_iter != nullptr);
-    for (t_iter->SeekToFirst(); t_iter->Valid(); t_iter->Next()) {
-      ++n_entry;
-    }
-    ASSERT_EQ(count * num_threads, n_entry);
-  };
-
-  LaunchNThreads(num_threads, HSetHGetHDelete);
-  LaunchNThreads(num_threads, IteratingThrough);
-
+  do {
+    TestGlobalCollection("global_unordered", UnorderedSetFunc, UnorderedGetFunc,
+                         UnorderedDeleteFunc, Types::Hash);
+    SeekIterator("global_unordered", Types::Hash, false);
+  } while (ChangedConfig());
   delete engine;
 }
 

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -120,8 +120,9 @@ protected:
                 Status::Ok);
     }
     TestEmptyKey(collection, SetFunc, GetFunc, DeleteFunc);
-    LaunchNThreads(configs.max_access_threads,
-                   BasicOperator(collection, SetFunc, GetFunc, DeleteFunc));
+    LaunchNThreads(
+        configs.max_access_threads,
+        CreateBasicOperationTest(collection, SetFunc, GetFunc, DeleteFunc));
   }
 
   void TestLocalCollection(const std::string &collection, SetOpsFunc SetFunc,
@@ -135,8 +136,8 @@ protected:
 
       TestEmptyKey(thread_local_collection, SetFunc, GetFunc, DeleteFunc);
 
-      auto BasicOpFunc =
-          BasicOperator(thread_local_collection, SetFunc, GetFunc, DeleteFunc);
+      auto BasicOpFunc = CreateBasicOperationTest(thread_local_collection,
+                                                  SetFunc, GetFunc, DeleteFunc);
       BasicOpFunc(id);
     };
     LaunchNThreads(configs.max_access_threads, Local_XSetXGetXDelete);
@@ -215,10 +216,9 @@ private:
     engine->ReleaseAccessThread();
   }
 
-  std::function<void(uint32_t)> BasicOperator(const std::string &collection,
-                                              SetOpsFunc SetFunc,
-                                              GetOpsFunc GetFunc,
-                                              DeleteOpsFunc DeleteFunc) {
+  std::function<void(uint32_t)>
+  CreateBasicOperationTest(const std::string &collection, SetOpsFunc SetFunc,
+                           GetOpsFunc GetFunc, DeleteOpsFunc DeleteFunc) {
     return [&](uint32_t id) {
       std::string val1, val2, got_val1, got_val2;
       int t_cnt = cnt;


### PR DESCRIPTION

### What is changed and how it works?
     (1) Refactor tests
     (2) Add PMem Allocator test cases: Different configs; Fragmentation; Free list.
     (3) Fix some bugs
          Now we have a bug: When thread num is 1, we call `pmem_allocator->Free` function, then call `pmem_allocator->Background`,  the memory fragmentation have not be merged. Please see `TestPMemFragmentation`. However I used `TestPMemAlocFreeList`,  see the memory fragmentation can be merged.  @JiayuZzz 

- Unit test
    Add pmem allocator test.
    Refactor tests: integration same codes
- Integration test
- No code

Side effects
    No
