### PR TITLE
Bug fix purgeOldDeleteRecord

### DIFF
--- a/engine/version/old_records_cleaner.cpp
+++ b/engine/version/old_records_cleaner.cpp
@@ -222,9 +222,12 @@ SpaceEntry OldRecordsCleaner::purgeOldDeleteRecord(
         dram_node = hash_entry_ref->index.skiplist_node;
         hash_indexed_pmem_record = dram_node->record;
         break;
+      case HashIndexType::Empty:
+        break;
       default:
         GlobalLogger.Error(
-            "Wrong time in handle pending free skiplist delete record\n");
+            "Wrong type %u in handle pending free skiplist delete record\n",
+            hash_entry_ref->header.index_type);
         std::abort();
       }
 


### PR DESCRIPTION
Signed-off-by: Jiayu Wu <jiayu.wu@intel.com>

<!--
Thank you for contributing to KVDK.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Issue Number: close #xxx <!-- REMOVE this line if no issue to close -->

Problem Summary:

In #178 we mark empty hash entry in HashIndexType field, which cause OldRecordCleaner::purgeOldDeleteRecord failed as HashIndexType::Empty is not catched

What's Changed:

Catch HashIndexType::Empty in purgeOldDeleteRecord

Tests <!-- At least one of them must be included. -->

- Unit test
