### PR TITLE
Fix miss-freed skiplist records in recover from a checkpoint

### DIFF
--- a/engine/kv_engine.cpp
+++ b/engine/kv_engine.cpp
@@ -559,8 +559,8 @@ Status KVEngine::RestoreSkiplistRecord(DLRecord *pmem_record,
   if (!linked_record) {
     if (!RecoverToCheckpoint()) {
       purgeAndFree(pmem_record);
+      return Status::Ok;
     }
-    return Status::Ok;
   }
 
   DataEntry existing_data_entry;

--- a/engine/pmem_allocator/free_list.cpp
+++ b/engine/pmem_allocator/free_list.cpp
@@ -194,7 +194,7 @@ void Freelist::Push(const SpaceEntry &entry) {
 }
 
 uint64_t Freelist::BatchPush(const std::vector<SpaceEntry> &entries) {
-  uint64_t pushed = 0;
+  uint64_t pushed_size = 0;
   Array<std::vector<PMemOffsetType>> moving_list(max_classified_b_size_);
   for (const SpaceEntry &entry : entries) {
     kvdk_assert(entry.size % block_size_ == 0,
@@ -211,7 +211,7 @@ uint64_t Freelist::BatchPush(const std::vector<SpaceEntry> &entries) {
       std::lock_guard<SpinMutex> lg(large_entries_spin_);
       large_entries_.emplace(entry);
     }
-    pushed += entry.size;
+    pushed_size += entry.size;
   }
 
   for (uint32_t b_size = 1; b_size < moving_list.size(); b_size++) {
@@ -219,6 +219,7 @@ uint64_t Freelist::BatchPush(const std::vector<SpaceEntry> &entries) {
       active_pool_.MoveEntryList(moving_list[b_size], b_size);
     }
   }
+  return pushed_size;
 }
 
 bool Freelist::Get(uint32_t size, SpaceEntry *space_entry) {

--- a/engine/skiplist.cpp
+++ b/engine/skiplist.cpp
@@ -674,8 +674,11 @@ Status SortedCollectionRebuilder::repairSkiplistLinkage(Skiplist *skiplist) {
           hash_hint, internal_key, SortedDataRecord | SortedDeleteRecord,
           &entry_ptr, &hash_entry, nullptr);
       if (s != Status::Ok) {
-        GlobalLogger.Error("Rebuild skiplist error, hash entry should be "
-                           "insert first before repair linkage\n");
+        GlobalLogger.Error(
+            "Rebuild skiplist error, hash entry should be "
+            "insert first before repair linkage\n",
+            string_view_2_string(Skiplist::UserKey(next_record)).c_str(),
+            next_record->entry.meta.type, s);
         return Status::Abort;
       }
       invalid_records.clear();

--- a/engine/skiplist.cpp
+++ b/engine/skiplist.cpp
@@ -674,8 +674,11 @@ Status SortedCollectionRebuilder::repairSkiplistLinkage(Skiplist *skiplist) {
           hash_hint, internal_key, SortedDataRecord | SortedDeleteRecord,
           &entry_ptr, &hash_entry, nullptr);
       if (s != Status::Ok) {
-        GlobalLogger.Error("Rebuild skiplist error, hash entry should be "
-                           "insert first before repair linkage");
+        GlobalLogger.Error(
+            "Rebuild skiplist error, hash entry should be "
+            "insert first before repair linkage, key %s type %u status %u",
+            string_view_2_string(Skiplist::UserKey(next_record)).c_str(),
+            next_record->entry.meta.type, s);
         return Status::Abort;
       }
       invalid_records.clear();

--- a/engine/skiplist.cpp
+++ b/engine/skiplist.cpp
@@ -674,11 +674,8 @@ Status SortedCollectionRebuilder::repairSkiplistLinkage(Skiplist *skiplist) {
           hash_hint, internal_key, SortedDataRecord | SortedDeleteRecord,
           &entry_ptr, &hash_entry, nullptr);
       if (s != Status::Ok) {
-        GlobalLogger.Error(
-            "Rebuild skiplist error, hash entry should be "
-            "insert first before repair linkage\n",
-            string_view_2_string(Skiplist::UserKey(next_record)).c_str(),
-            next_record->entry.meta.type, s);
+        GlobalLogger.Error("Rebuild skiplist error, hash entry should be "
+                           "insert first before repair linkage\n");
         return Status::Abort;
       }
       invalid_records.clear();

--- a/engine/skiplist.cpp
+++ b/engine/skiplist.cpp
@@ -674,11 +674,8 @@ Status SortedCollectionRebuilder::repairSkiplistLinkage(Skiplist *skiplist) {
           hash_hint, internal_key, SortedDataRecord | SortedDeleteRecord,
           &entry_ptr, &hash_entry, nullptr);
       if (s != Status::Ok) {
-        GlobalLogger.Error(
-            "Rebuild skiplist error, hash entry should be "
-            "insert first before repair linkage, key %s type %u status %u",
-            string_view_2_string(Skiplist::UserKey(next_record)).c_str(),
-            next_record->entry.meta.type, s);
+        GlobalLogger.Error("Rebuild skiplist error, hash entry should be "
+                           "insert first before repair linkage\n");
         return Status::Abort;
       }
       invalid_records.clear();

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -127,7 +127,7 @@ TEST_F(EngineBasicTest, TestBasicSnapshot) {
       }
     }
 
-    cnt = count;
+    cnt = count * 10;
     // Update / Delete, and insert new
     while (cnt--) {
       std::string key1(std::string(id + 1, 'a') + std::to_string(cnt));


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:

Some old version skiplist records are miss-freed due to checkpoint timestamp check

Tests <!-- At least one of them must be included. -->

- Unit test
