### PR TITLE
Fix recovery failure if Free() is directly called after Allocate()

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,23 +46,24 @@ endif()
 
 # source files
 set(SOURCES
+        engine/pmem_allocator/free_list.cpp
+        engine/pmem_allocator/guarded_space.cpp
+        engine/pmem_allocator/pmem_allocator.cpp
         engine/utils/utils.cpp
         engine/utils/sync_point.cpp
+        engine/version/old_records_cleaner.cpp
+        engine/c.cpp
+        engine/data_record.cpp
+        engine/dram_allocator.cpp
         engine/engine.cpp
+        engine/hash_table.cpp
         engine/kv_engine.cpp
         engine/logger.cpp
-        engine/hash_table.cpp
-        engine/skiplist.cpp
-        engine/write_batch.cpp
-        engine/dram_allocator.cpp
-        engine/pmem_allocator/pmem_allocator.cpp
-        engine/thread_manager.cpp
-        engine/pmem_allocator/free_list.cpp
-        engine/c.cpp
-        engine/unordered_collection.cpp
-        engine/data_record.cpp
         engine/queue.cpp
-        engine/version/old_records_cleaner.cpp
+        engine/skiplist.cpp
+        engine/thread_manager.cpp
+        engine/unordered_collection.cpp
+        engine/write_batch.cpp
         )
 
 # .a library

--- a/engine/data_record.hpp
+++ b/engine/data_record.hpp
@@ -4,8 +4,10 @@
 
 #pragma once
 
+#include <libpmem.h>
+
 #include "kvdk/namespace.hpp"
-#include "libpmem.h"
+#include "pmem_allocator/guarded_space.hpp"
 #include "utils/utils.hpp"
 
 namespace KVDK_NAMESPACE {
@@ -109,7 +111,7 @@ struct StringRecord {
   }
 
   // Construct and persist a string record at pmem address "addr"
-  static StringRecord* PersistStringRecord(void* addr, uint32_t record_size,
+  static StringRecord* PersistStringRecord(GuardedSpace& space,
                                            TimeStampType timestamp,
                                            RecordType type,
                                            PMemOffsetType older_version_record,
@@ -219,8 +221,8 @@ struct DLRecord {
   }
 
   // Construct and persist a dl record to PMem address "addr"
-  static DLRecord* PersistDLRecord(void* addr, uint32_t record_size,
-                                   TimeStampType timestamp, RecordType type,
+  static DLRecord* PersistDLRecord(GuardedSpace& space, TimeStampType timestamp,
+                                   RecordType type,
                                    PMemOffsetType older_version_record,
                                    PMemOffsetType prev, PMemOffsetType next,
                                    const StringView& key,

--- a/engine/dlinked_list.hpp
+++ b/engine/dlinked_list.hpp
@@ -177,7 +177,7 @@ class DLinkedList {
           tail_space.second, tail_space.first.size, timestamp, TailType,
           NullPMemOffset, head_space.first.offset, NullPMemOffset, key, value);
       head_pmmptr_ = DLRecord::PersistDLRecord(
-          head_space.second, head_space.first.size, timestamp, HeadType, 
+          head_space.second, head_space.first.size, timestamp, HeadType,
           NullPMemOffset, NullPMemOffset, tail_space.first.offset, key, value);
     }
   }

--- a/engine/dlinked_list.hpp
+++ b/engine/dlinked_list.hpp
@@ -175,8 +175,8 @@ class DLinkedList {
       head_pmmptr_ = DLRecord::PersistDLRecord(
           head_space.Address(), head_space.Size(), timestamp, HeadType,
           NullPMemOffset, NullPMemOffset, tail_space.Offset(), key, value);
-      head_space = nullptr;
-      tail_space = nullptr;
+      head_space.Release();
+      tail_space.Release();
     }
   }
 
@@ -357,7 +357,7 @@ class DLinkedList {
     iter_next->prev = space.Offset();
     pmem_persist(&iter_next->prev, sizeof(PMemOffsetType));
 
-    space = nullptr;
+    space.Release();
 
     return iterator{pmem_allocator_ptr_, record};
   }

--- a/engine/kv_engine.cpp
+++ b/engine/kv_engine.cpp
@@ -1231,7 +1231,7 @@ Status KVEngine::CheckConfigs(const Configs& configs) {
     return Status::InvalidConfiguration;
   }
 
-  if (configs.pmem_segment_blocks * configs.pmem_block_size >=
+  if (configs.pmem_segment_blocks * configs.pmem_block_size >
       std::numeric_limits<std::uint32_t>::max()) {
     GlobalLogger.Error("PMem segment size too large!\n");
     return Status::InvalidConfiguration;

--- a/engine/kv_engine.cpp
+++ b/engine/kv_engine.cpp
@@ -1393,7 +1393,7 @@ Status KVEngine::BatchWrite(const WriteBatch& write_batch) {
   for (size_t i = 0; i < alloc_guards.size(); i++) {
     alloc_guards[i].Release();
   }
-  
+
   std::string val;
 
   // Free updated kvs, we should purge all updated kvs before release locks and

--- a/engine/kv_engine.cpp
+++ b/engine/kv_engine.cpp
@@ -1380,8 +1380,8 @@ Status KVEngine::BatchWrite(const WriteBatch& write_batch) {
     // Something wrong
     // TODO: roll back finished writes (hard to roll back hash table now)
     if (s != Status::Ok) {
-      assert(s == Status::MemoryOverflow);
-      std::abort();
+      kvdk_assert(s == Status::MemoryOverflow, "");
+      return s;
     }
   }
 

--- a/engine/kv_engine.cpp
+++ b/engine/kv_engine.cpp
@@ -1345,7 +1345,7 @@ Status KVEngine::BatchWrite(const WriteBatch& write_batch) {
     spins_to_lock.emplace(batch_hints[i].hash_hint.spin);
   }
   for (size_t i = 0; i < write_batch.Size(); i++) {
-    batch_hints[i].allocated_space = alloc_guards[i].Release().first;
+    batch_hints[i].allocated_space = alloc_guards[i].AllocatedSpace();
     space_entry_offsets.emplace_back(batch_hints[i].allocated_space.offset);
   }
 
@@ -1390,6 +1390,10 @@ Status KVEngine::BatchWrite(const WriteBatch& write_batch) {
   engine_thread_cache_[access_thread.id]
       .persisted_pending_batch->PersistFinish();
 
+  for (size_t i = 0; i < alloc_guards.size(); i++) {
+    alloc_guards[i].Release();
+  }
+  
   std::string val;
 
   // Free updated kvs, we should purge all updated kvs before release locks and

--- a/engine/kv_engine.cpp
+++ b/engine/kv_engine.cpp
@@ -1016,7 +1016,6 @@ Status KVEngine::SDeleteImpl(Skiplist* skiplist, const StringView& user_key) {
   }
 
   PMemAllocatorGuard alloc_guard{*pmem_allocator_};
-  bool has_allocated_space = false;
 
   while (1) {
     SkiplistNode* dram_node = nullptr;
@@ -1045,12 +1044,11 @@ Status KVEngine::SDeleteImpl(Skiplist* skiplist, const StringView& user_key) {
           return Status::Ok;
         } else {
           kvdk_assert(hash_entry.header.data_type == SortedDataRecord, "");
-          if (!has_allocated_space) {
+          if (alloc_guard.AllocatedSpace().size == 0) {
             if (!alloc_guard.TryAllocate(sizeof(DLRecord) +
                                          collection_key.size())) {
               return Status::PmemOverflow;
             }
-            has_allocated_space = true;
           }
           break;
         }

--- a/engine/kv_engine.cpp
+++ b/engine/kv_engine.cpp
@@ -1044,8 +1044,8 @@ Status KVEngine::SDeleteImpl(Skiplist* skiplist, const StringView& user_key) {
         if (hash_entry.header.data_type == SortedDeleteRecord) {
           return Status::Ok;
         } else {
-          kvdk_assert(hash_entry.header.data_type == SortedDataRecord,
-                      "") if (!has_allocated_space) {
+          kvdk_assert(hash_entry.header.data_type == SortedDataRecord, "");
+          if (!has_allocated_space) {
             if (!alloc_guard.TryAllocate(sizeof(DLRecord) +
                                          collection_key.size())) {
               return Status::PmemOverflow;

--- a/engine/kv_engine.hpp
+++ b/engine/kv_engine.hpp
@@ -124,7 +124,7 @@ class KVEngine : public Engine {
 
   struct BatchWriteHint {
     TimeStampType timestamp{0};
-    PMEMAllocator::GuardedSpace allocated_space{};
+    GuardedSpace allocated_space{};
     HashTable::KeyHashHint hash_hint{};
     HashEntry* hash_entry_ptr = nullptr;
     void* data_record_to_free = nullptr;

--- a/engine/kv_engine.hpp
+++ b/engine/kv_engine.hpp
@@ -335,13 +335,6 @@ class KVEngine : public Engine {
                    data_entry->header.record_size));
   }
 
-  inline void markEmptySpace(const SpaceEntry& space_entry) {
-    DataHeader header(0, space_entry.size);
-    pmem_memcpy_persist(
-        pmem_allocator_->offset2addr_checked(space_entry.offset), &header,
-        sizeof(DataHeader));
-  }
-
   // Run in background to clean old records regularly
   void backgroundOldRecordCleaner();
 

--- a/engine/kv_engine.hpp
+++ b/engine/kv_engine.hpp
@@ -124,12 +124,11 @@ class KVEngine : public Engine {
 
   struct BatchWriteHint {
     TimeStampType timestamp{0};
-    SpaceEntry allocated_space{};
+    PMEMAllocator::GuardedSpace allocated_space{};
     HashTable::KeyHashHint hash_hint{};
     HashEntry* hash_entry_ptr = nullptr;
     void* data_record_to_free = nullptr;
     void* delete_record_to_free = nullptr;
-    bool space_not_used{false};
   };
 
   struct EngineThreadCache {

--- a/engine/pmem_allocator/guarded_space.cpp
+++ b/engine/pmem_allocator/guarded_space.cpp
@@ -8,7 +8,6 @@
 
 #include "../data_record.hpp"
 #include "../logger.hpp"
-
 #include "pmem_allocator.hpp"
 
 namespace KVDK_NAMESPACE {

--- a/engine/pmem_allocator/guarded_space.cpp
+++ b/engine/pmem_allocator/guarded_space.cpp
@@ -1,0 +1,54 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright(c) 2021 Intel Corporation
+ */
+
+#include "guarded_space.hpp"
+
+#include <libpmem.h>
+
+#include "../data_record.hpp"
+#include "../logger.hpp"
+
+#include "pmem_allocator.hpp"
+
+namespace KVDK_NAMESPACE {
+GuardedSpace::GuardedSpace(PMEMAllocator& a, size_type sz) : alloc{&a} {
+  SpaceEntry se = alloc->Allocate(sz);
+  offset = se.offset;
+  size = se.size;
+}
+
+GuardedSpace::GuardedSpace(GuardedSpace&& other) { *this = std::move(other); }
+GuardedSpace& GuardedSpace::operator=(GuardedSpace&& other) {
+  kvdk_assert(alloc == nullptr && size == 0,
+              "Cannot asigned to non-empty GuardedSpace");
+
+  using std::swap;
+  swap(alloc, other.alloc);
+  swap(offset, other.offset);
+  swap(size, other.size);
+  return *this;
+}
+// Release ownership of allocated space.
+SpaceEntry GuardedSpace::Release() {
+  SpaceEntry ret{ToSpaceEntry()};
+  alloc = nullptr;
+  offset = kNullPMemOffset;
+  size = 0;
+  return ret;
+}
+void* GuardedSpace::Address() const { return alloc->offset2addr(offset); }
+SpaceEntry GuardedSpace::ToSpaceEntry() { return SpaceEntry{offset, size}; }
+GuardedSpace::~GuardedSpace() {
+  if (alloc != nullptr && size != 0) {
+#if DEBUG_LEVEL > 0
+    GlobalLogger.Info("GuardedSpace unused. Padded and freed!\n");
+#endif
+    DataHeader padding{0, size};
+    static_assert(sizeof(DataHeader) == 8, "");
+    pmem_memcpy_persist(Address(), &padding, sizeof(DataHeader));
+    alloc->Free(ToSpaceEntry());
+  }
+}
+
+}  // namespace KVDK_NAMESPACE

--- a/engine/pmem_allocator/guarded_space.hpp
+++ b/engine/pmem_allocator/guarded_space.hpp
@@ -1,0 +1,48 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright(c) 2021 Intel Corporation
+ */
+
+#pragma once
+#ifndef GUARDED_SPACE_HPP
+#define GUARDED_SPACE_HPP
+
+#include <cstdint>
+
+#include "../alias.hpp"
+#include "../allocator.hpp"
+
+namespace KVDK_NAMESPACE {
+static constexpr PMemOffsetType NullPMemOffset =
+    std::numeric_limits<PMemOffsetType>::max();
+class PMEMAllocator;
+class GuardedSpace {
+ private:
+  friend class PMEMAllocator;
+  using size_type = std::uint32_t;
+
+  PMEMAllocator* alloc{nullptr};
+  PMemOffsetType offset{NullPMemOffset};
+  size_type size{};
+
+  GuardedSpace(PMEMAllocator& a, size_type sz);
+
+ public:
+  GuardedSpace() = default;
+  GuardedSpace(GuardedSpace const&) = delete;
+  GuardedSpace& operator=(GuardedSpace const&) = delete;
+  // Transfer ownership to another guard
+  GuardedSpace(GuardedSpace&& other);
+  GuardedSpace& operator=(GuardedSpace&& other);
+
+  // Release ownership of allocated space.
+  SpaceEntry Release();
+
+  PMemOffsetType Offset() const { return offset; }
+  void* Address() const;
+  size_type Size() const { return size; }
+  SpaceEntry ToSpaceEntry();
+  ~GuardedSpace();
+};
+}  // namespace KVDK_NAMESPACE
+
+#endif  // GUARDED_SPACE_HPP

--- a/engine/pmem_allocator/pmem_allocator.hpp
+++ b/engine/pmem_allocator/pmem_allocator.hpp
@@ -217,11 +217,12 @@ class PMemAllocatorGuard {
     using std::swap;
     swap(temp, space);
     alloc = nullptr;
-    
+
     return std::make_pair(temp, addr);
   }
-  // Let caller use the allocated space,
-  // but caller must call Release() later if the space is used!
+  // Let caller access the allocated space,
+  // but caller must call Release() later to gain the ownership of space,
+  // otherwise the space will be padded and Free()-ed.
   SpaceEntry AllocatedSpace() { return space; }
   ~PMemAllocatorGuard() {
     if (alloc != nullptr && space.size != 0) {

--- a/engine/pmem_allocator/pmem_allocator.hpp
+++ b/engine/pmem_allocator/pmem_allocator.hpp
@@ -222,7 +222,7 @@ class PMemAllocatorGuard {
   }
   // Let caller access the allocated space,
   // but caller must call Release() later to gain the ownership of space,
-  // otherwise the space will be padded and Free()-ed.
+  // otherwise PMemAllocatorGuard will still pad and free the space!
   SpaceEntry AllocatedSpace() { return space; }
   ~PMemAllocatorGuard() {
     if (alloc != nullptr && space.size != 0) {

--- a/engine/pmem_allocator/pmem_allocator.hpp
+++ b/engine/pmem_allocator/pmem_allocator.hpp
@@ -4,14 +4,12 @@
 
 #pragma once
 
-#include <memory>
-#include <set>
-#include <vector>
-
 #include <fcntl.h>
 #include <sys/mman.h>
 
-#include "kvdk/namespace.hpp"
+#include <memory>
+#include <set>
+#include <vector>
 
 #include "../allocator.hpp"
 #include "../data_record.hpp"
@@ -19,6 +17,7 @@
 #include "../version/version_controller.hpp"
 #include "free_list.hpp"
 #include "guarded_space.hpp"
+#include "kvdk/namespace.hpp"
 
 namespace KVDK_NAMESPACE {
 

--- a/engine/pmem_allocator/pmem_allocator.hpp
+++ b/engine/pmem_allocator/pmem_allocator.hpp
@@ -221,7 +221,7 @@ class PMemAllocatorGuard {
     return std::make_pair(temp, addr);
   }
   // Let caller access the allocated space,
-  // but caller must call Release() later to gain the ownership of space,
+  // but caller must call Release() later to acquire the ownership of space,
   // otherwise PMemAllocatorGuard will still pad and Free() the space!
   SpaceEntry AllocatedSpace() { return space; }
   ~PMemAllocatorGuard() {

--- a/engine/pmem_allocator/pmem_allocator.hpp
+++ b/engine/pmem_allocator/pmem_allocator.hpp
@@ -222,7 +222,7 @@ class PMemAllocatorGuard {
   }
   // Let caller access the allocated space,
   // but caller must call Release() later to gain the ownership of space,
-  // otherwise PMemAllocatorGuard will still pad and free the space!
+  // otherwise PMemAllocatorGuard will still pad and Free() the space!
   SpaceEntry AllocatedSpace() { return space; }
   ~PMemAllocatorGuard() {
     if (alloc != nullptr && space.size != 0) {

--- a/engine/pmem_allocator/pmem_allocator.hpp
+++ b/engine/pmem_allocator/pmem_allocator.hpp
@@ -205,20 +205,20 @@ class PMemAllocatorGuard {
     return *this;
   }
   bool TryAllocate(std::size_t sz) {
-    if (space.size != 0) {
-      kvdk_assert(
-          false,
-          "Should not TryAllocate() second time if first time succeeded!");
-      return true;
-    }
+    kvdk_assert(alloc != nullptr && space.size == 0, "Invalid state!");
     space = alloc->Allocate(sz);
     return (space.size != 0);
   }
   // Transfer ownership to caller.
   std::pair<SpaceEntry, void*> Release() {
     void* addr = alloc->offset2addr_checked(space.offset);
+
+    SpaceEntry temp;
+    using std::swap;
+    swap(temp, space);
     alloc = nullptr;
-    return std::make_pair(space, addr);
+    
+    return std::make_pair(temp, addr);
   }
   // Let caller use the allocated space,
   // but caller must call Release() later if the space is used!

--- a/engine/queue.cpp
+++ b/engine/queue.cpp
@@ -9,20 +9,18 @@ Queue::Queue(PMEMAllocator* pmem_allocator_ptr, std::string const name,
                     CollectionUtils::ID2String(id), StringView{""}},
       timestamp_{timestamp} {
   {
-    auto list_record_space = dlinked_list_.pmem_allocator_ptr_->Allocate(
-        sizeof(DLRecord) + Name().size() + sizeof(CollectionIDType));
-    if (list_record_space.size == 0) {
+    PMemAllocatorGuard alloc_guard{*dlinked_list_.pmem_allocator_ptr_};
+    if (!alloc_guard.TryAllocate(sizeof(DLRecord) + Name().size() +
+                                 sizeof(CollectionIDType))) {
       dlinked_list_.purgeAndFree(dlinked_list_.Head().GetCurrentAddress());
       dlinked_list_.purgeAndFree(dlinked_list_.Tail().GetCurrentAddress());
       dlinked_list_.head_pmmptr_ = nullptr;
       dlinked_list_.tail_pmmptr_ = nullptr;
       throw std::bad_alloc{};
     }
-    PMemOffsetType offset_list_record = list_record_space.offset;
+    auto space = alloc_guard.Release();
     collection_record_ptr_ = DLRecord::PersistDLRecord(
-        dlinked_list_.pmem_allocator_ptr_->offset2addr_checked(
-            offset_list_record),
-        list_record_space.size, timestamp, RecordType::QueueRecord,
+        space.second, space.first.size, timestamp, RecordType::QueueRecord,
         kNullPMemOffset, dlinked_list_.Head().GetCurrentOffset(),
         dlinked_list_.Tail().GetCurrentOffset(), Name(),
         CollectionUtils::ID2String(ID()));

--- a/engine/queue.cpp
+++ b/engine/queue.cpp
@@ -19,11 +19,10 @@ Queue::Queue(PMEMAllocator* pmem_allocator_ptr, std::string const name,
       throw std::bad_alloc{};
     }
     collection_record_ptr_ = DLRecord::PersistDLRecord(
-        space.Address(), space.Size(), timestamp, RecordType::QueueRecord,
-        kNullPMemOffset, dlinked_list_.Head().GetCurrentOffset(),
+        space, timestamp, RecordType::QueueRecord, kNullPMemOffset,
+        dlinked_list_.Head().GetCurrentOffset(),
         dlinked_list_.Tail().GetCurrentOffset(), Name(),
         CollectionUtils::ID2String(ID()));
-    space.Release();
   }
 }
 

--- a/engine/queue.cpp
+++ b/engine/queue.cpp
@@ -23,7 +23,7 @@ Queue::Queue(PMEMAllocator* pmem_allocator_ptr, std::string const name,
         kNullPMemOffset, dlinked_list_.Head().GetCurrentOffset(),
         dlinked_list_.Tail().GetCurrentOffset(), Name(),
         CollectionUtils::ID2String(ID()));
-    space = nullptr;
+    space.Release();
   }
 }
 

--- a/engine/skiplist.hpp
+++ b/engine/skiplist.hpp
@@ -247,7 +247,7 @@ class Skiplist : public Collection {
   // Return true on success, return false on fail.
   bool Insert(const StringView& key, const StringView& value,
               const SpinMutex* inserting_key_lock, TimeStampType timestamp,
-              SkiplistNode** dram_node, const SpaceEntry& space_to_write);
+              SkiplistNode** dram_node, GuardedSpace& space);
 
   // Update "key" in the skiplist
   //
@@ -262,7 +262,7 @@ class Skiplist : public Collection {
   bool Update(const StringView& key, const StringView& value,
               const DLRecord* updating_record,
               const SpinMutex* updating_record_lock, TimeStampType timestamp,
-              SkiplistNode* dram_node, const SpaceEntry& space_to_write);
+              SkiplistNode* dram_node, GuardedSpace& space);
 
   // Delete "key" from the skiplist by replace it with a delete record
   //
@@ -275,7 +275,7 @@ class Skiplist : public Collection {
   // Return true on success, return false on fail.
   bool Delete(const StringView& key, DLRecord* deleting_record,
               const SpinMutex* deleting_record_lock, TimeStampType timestamp,
-              SkiplistNode* dram_node, const SpaceEntry& space_to_write);
+              SkiplistNode* dram_node, GuardedSpace& space);
 
   // Purge a dl record from its skiplist by remove it from linkage
   //

--- a/engine/unordered_collection.cpp
+++ b/engine/unordered_collection.cpp
@@ -23,11 +23,10 @@ UnorderedCollection::UnorderedCollection(HashTable* hash_table_ptr,
       throw std::bad_alloc{};
     }
     collection_record_ptr_ = DLRecord::PersistDLRecord(
-        space.Address(), space.Size(), timestamp, RecordType::DlistRecord,
-        kNullPMemOffset, dlinked_list_.Head().GetCurrentOffset(),
+        space, timestamp, RecordType::DlistRecord, kNullPMemOffset,
+        dlinked_list_.Head().GetCurrentOffset(),
         dlinked_list_.Tail().GetCurrentOffset(), Name(),
         CollectionUtils::ID2String(ID()));
-    space.Release();
   }
 }
 

--- a/engine/unordered_collection.cpp
+++ b/engine/unordered_collection.cpp
@@ -27,7 +27,7 @@ UnorderedCollection::UnorderedCollection(HashTable* hash_table_ptr,
         kNullPMemOffset, dlinked_list_.Head().GetCurrentOffset(),
         dlinked_list_.Tail().GetCurrentOffset(), Name(),
         CollectionUtils::ID2String(ID()));
-    space = nullptr;
+    space.Release();
   }
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to KVDK.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Problem Summary:
1. If `Free()` is directly called after `Allocate()`, `RestoreData()` may meet this empty space on next startup and treat the rest of segment as empty, resulting in `Recovery()` failure.
2. If user config a segment size equal to or larger than 4GB, due to DataEntry can only track space less than 4GB with a `std::uint32_t` field, integer overflow may occur and data layout on PMem will be incorrect.

### What is changed and how it works?

What's Changed:

Add `PMemAllocatorGuard` class to manage Allocated space with RAII idiom. If  a `PMemAllocatorGuard` instance allocated piece of space not used by caller, it will write padding information on it when destroyed.
Add check for segment size.

Tests <!-- At least one of them must be included. -->

- Unit test
