### PR TITLE
Bug fix: OldRecordCleaner and free un-written PMem space

### DIFF
--- a/engine/kv_engine.cpp
+++ b/engine/kv_engine.cpp
@@ -1051,6 +1051,8 @@ Status KVEngine::SDeleteImpl(Skiplist* skiplist, const StringView& user_key) {
 
     if (!need_write_delete_record) {
       if (sized_space_entry.size > 0) {
+        // We must mark a allocated but unused space on PMem, otherwise data may
+        // lost in recovery
         markEmptySpace(sized_space_entry);
         pmem_allocator_->Free(sized_space_entry);
       }
@@ -1435,6 +1437,8 @@ Status KVEngine::StringBatchWriteImpl(const WriteBatch::KV& kv,
     // Deleting kv is not existing
     if (kv.type == StringDeleteRecord && !found) {
       batch_hint.space_not_used = true;
+      // We must mark a allocated but unused space on PMem, otherwise data may
+      // lost in recovery
       markEmptySpace(batch_hint.allocated_space);
       return Status::Ok;
     }

--- a/engine/kv_engine.cpp
+++ b/engine/kv_engine.cpp
@@ -1051,6 +1051,7 @@ Status KVEngine::SDeleteImpl(Skiplist* skiplist, const StringView& user_key) {
 
     if (!need_write_delete_record) {
       if (sized_space_entry.size > 0) {
+        markEmptySpace(sized_space_entry);
         pmem_allocator_->Free(sized_space_entry);
       }
       return s;

--- a/engine/kv_engine.hpp
+++ b/engine/kv_engine.hpp
@@ -336,6 +336,7 @@ class KVEngine : public Engine {
                    data_entry->header.record_size));
   }
 
+  // Mark an unused space on PMem
   inline void markEmptySpace(const SpaceEntry& space_entry) {
     DataHeader header(0, space_entry.size);
     pmem_memcpy_persist(

--- a/engine/pmem_allocator/pmem_allocator.cpp
+++ b/engine/pmem_allocator/pmem_allocator.cpp
@@ -244,11 +244,9 @@ SpaceEntry PMEMAllocator::Allocate(uint64_t size) {
         // TODO optimize, do not write PMem
         if (extra_space >= kMinPaddingBlocks * block_size_) {
           assert(extra_space % block_size_ == 0);
-          DataEntry padding(0, static_cast<uint32_t>(extra_space), 0,
-                            RecordType::Padding, 0, 0);
-          pmem_memcpy_persist(
-              offset2addr(palloc_thread_cache.free_entry.offset + aligned_size),
-              &padding, sizeof(DataEntry));
+          persistSpaceEntry(
+              palloc_thread_cache.free_entry.offset + aligned_size,
+              extra_space);
         } else {
           aligned_size = palloc_thread_cache.free_entry.size;
         }

--- a/engine/version/old_records_cleaner.cpp
+++ b/engine/version/old_records_cleaner.cpp
@@ -106,11 +106,11 @@ void OldRecordsCleaner::TryGlobalClean() {
   if (space_pending.entries.size() > 0) {
     space_pending.release_time =
         kv_engine_->version_controller_.GetCurrentTimestamp();
-    pending_free_space_entries_.emplace_back(space_pending);
+    global_pending_free_space_entries_.emplace_back(space_pending);
   }
 
-  auto iter = pending_free_space_entries_.begin();
-  while (iter != pending_free_space_entries_.end()) {
+  auto iter = global_pending_free_space_entries_.begin();
+  while (iter != global_pending_free_space_entries_.end()) {
     if (iter->release_time < oldest_snapshot_ts) {
       kv_engine_->pmem_allocator_->BatchFree(iter->entries);
       iter++;
@@ -118,7 +118,8 @@ void OldRecordsCleaner::TryGlobalClean() {
       break;
     }
   }
-  pending_free_space_entries_.erase(pending_free_space_entries_.begin(), iter);
+  global_pending_free_space_entries_.erase(
+      global_pending_free_space_entries_.begin(), iter);
 
   if (space_to_free.size() > 0) {
     kv_engine_->pmem_allocator_->BatchFree(space_to_free);
@@ -144,8 +145,9 @@ void OldRecordsCleaner::TryCleanCachedOldRecords(size_t num_limit_clean) {
              clean_all_data_record_ts_ &&
          limit > 0;
          limit--) {
-      kv_engine_->pmem_allocator_->Free(
-          purgeOldDeleteRecord(tc.old_delete_records.front()));
+      tc.pending_free_space_entries.emplace_back(PendingFreeSpaceEntry{
+          purgeOldDeleteRecord(tc.old_delete_records.front()),
+          kv_engine_->version_controller_.GetCurrentTimestamp()});
       tc.old_delete_records.pop_front();
     }
 
@@ -159,6 +161,16 @@ void OldRecordsCleaner::TryCleanCachedOldRecords(size_t num_limit_clean) {
       kv_engine_->pmem_allocator_->Free(
           purgeOldDataRecord(tc.old_data_records.front()));
       tc.old_data_records.pop_front();
+    }
+
+    for (int limit = num_limit_clean;
+         tc.pending_free_space_entries.size() > 0 &&
+         tc.pending_free_space_entries.front().release_time < oldest_refer_ts &&
+         limit > 0;
+         limit--) {
+      kv_engine_->pmem_allocator_->Free(
+          tc.pending_free_space_entries.front().entry);
+      tc.pending_free_space_entries.pop_front();
     }
   }
 }

--- a/engine/version/old_records_cleaner.cpp
+++ b/engine/version/old_records_cleaner.cpp
@@ -94,7 +94,7 @@ void OldRecordsCleaner::TryGlobalClean() {
 
   // Find purge-able delete records
   // To avoid access invalid data, an old delete record can be freed only if
-  // no holding snapshot is older that its purging time
+  // no holding snapshot is older than its purging time
   for (auto& delete_records : global_old_delete_records_) {
     for (auto& record : delete_records) {
       if (record.release_time <= clean_all_data_record_ts_) {
@@ -148,7 +148,7 @@ void OldRecordsCleaner::TryCleanCachedOldRecords(size_t num_limit_clean) {
          limit > 0;
          limit--) {
       // To avoid access invalid data, an old delete record can be freed only if
-      // no holding snapshot is older that its purging time
+      // no holding snapshot is older than its purging time
       tc.pending_free_space_entries.emplace_back(PendingFreeSpaceEntry{
           purgeOldDeleteRecord(tc.old_delete_records.front()),
           kv_engine_->version_controller_.GetCurrentTimestamp()});

--- a/engine/version/old_records_cleaner.cpp
+++ b/engine/version/old_records_cleaner.cpp
@@ -92,7 +92,9 @@ void OldRecordsCleaner::TryGlobalClean() {
 
   clean_all_data_record_ts_ = oldest_snapshot_ts;
 
-  // Find free-able delete records
+  // Find purge-able delete records
+  // To avoid access invalid data, an old delete record can be freed only if
+  // no holding snapshot is older that its purging time
   for (auto& delete_records : global_old_delete_records_) {
     for (auto& record : delete_records) {
       if (record.release_time <= clean_all_data_record_ts_) {
@@ -145,6 +147,8 @@ void OldRecordsCleaner::TryCleanCachedOldRecords(size_t num_limit_clean) {
              clean_all_data_record_ts_ &&
          limit > 0;
          limit--) {
+      // To avoid access invalid data, an old delete record can be freed only if
+      // no holding snapshot is older that its purging time
       tc.pending_free_space_entries.emplace_back(PendingFreeSpaceEntry{
           purgeOldDeleteRecord(tc.old_delete_records.front()),
           kv_engine_->version_controller_.GetCurrentTimestamp()});

--- a/engine/version/old_records_cleaner.hpp
+++ b/engine/version/old_records_cleaner.hpp
@@ -42,6 +42,13 @@ struct PendingFreeSpaceEntries {
   TimeStampType release_time;
 };
 
+struct PendingFreeSpaceEntry {
+  SpaceEntry entry;
+  // Indicate timestamp of the oldest refered snapshot of kvdk instance while we
+  // could safely free this entry
+  TimeStampType release_time;
+};
+
 // OldRecordsCleaner is used to clean old version PMem records of kvdk
 //
 // To support multi-version machenism and consistent backup of kvdk,
@@ -69,6 +76,7 @@ class OldRecordsCleaner {
   struct CleanerThreadCache {
     std::deque<OldDeleteRecord> old_delete_records{};
     std::deque<OldDataRecord> old_data_records{};
+    std::deque<PendingFreeSpaceEntry> pending_free_space_entries{};
     SpinMutex old_records_lock;
   };
   const uint64_t kLimitCachedDeleteRecords = 1000000;
@@ -83,7 +91,7 @@ class OldRecordsCleaner {
 
   std::vector<std::deque<OldDataRecord>> global_old_data_records_;
   std::vector<std::deque<OldDeleteRecord>> global_old_delete_records_;
-  std::deque<PendingFreeSpaceEntries> pending_free_space_entries_;
+  std::deque<PendingFreeSpaceEntries> global_pending_free_space_entries_;
   TimeStampType clean_all_data_record_ts_{0};
 };
 }  // namespace KVDK_NAMESPACE


### PR DESCRIPTION
<!--
Thank you for contributing to KVDK.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Problem Summary:

1. In OldRecordCleaner, an old sorted delete record can not be freed immediately after it is purged, otherwise a running thread may access invalid data. This is guaranteed by two-phase free in global clean, but not implemented in foreground clean in current impl.
2. In Sorted Delete and Batch Write operations, a PMem space may be allocated and freed without write a header on it, so data followed may be lost in next recovery

### What is changed and how it works?

What's Changed:

1. Add two-phase free of delete record in foreground clean, a old delete record can be freed only if no holding snapshot is older that its purging time
2. Mark the size of an unused space on PMem before free it if nothing written

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Stress test

Side effects

No
