### PR TITLE
Access hash entry with 16 bytes atomic load/store

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,7 +68,7 @@ set(SOURCES
 # .a library
 add_library(engine SHARED ${SOURCES})
 target_include_directories(engine PUBLIC ./include ./extern)
-target_link_libraries(engine PUBLIC pthread pmem gflags hwloc)
+target_link_libraries(engine PUBLIC pthread pmem gflags hwloc atomic)
 
 configure_file(kvdk.pc.in kvdk.pc @ONLY)
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/kvdk.pc

--- a/doc/benchmark.md
+++ b/doc/benchmark.md
@@ -20,7 +20,7 @@ Explanation of arguments:
 
     -space: PMem space that allocate to the KVDK instance.
 
-    -max_write_threads: Max concurrent write threads of the KVDK instance, set it to the number of the hyper-threads for performance consideration.
+    -max_access_threads: Max concurrent access threads of the KVDK instance, set it to the number of the hyper-threads for performance consideration.
 
     -type: Type of key-value pairs to benchmark, it can be "string", "hash" or "sorted".
 

--- a/engine/dram_allocator.cpp
+++ b/engine/dram_allocator.cpp
@@ -16,7 +16,7 @@ void ChunkBasedAllocator::Free(const SpaceEntry& entry) {
 SpaceEntry ChunkBasedAllocator::Allocate(uint64_t size) {
   SpaceEntry entry;
   if (size > chunk_size_) {
-    void* addr = malloc(size);
+    void* addr = aligned_alloc(64, size);
     if (addr != nullptr) {
       entry.size = chunk_size_;
       entry.offset = addr2offset(addr);
@@ -26,7 +26,7 @@ SpaceEntry ChunkBasedAllocator::Allocate(uint64_t size) {
   }
 
   if (dalloc_thread_cache_[access_thread.id].usable_bytes < size) {
-    void* addr = malloc(chunk_size_);
+    void* addr = aligned_alloc(64, chunk_size_);
     if (addr == nullptr) {
       return entry;
     }

--- a/engine/hash_table.cpp
+++ b/engine/hash_table.cpp
@@ -28,9 +28,9 @@ HashTable* HashTable::NewHashTable(
     } else {
       table->main_buckets_ =
           table->dram_allocator_.offset2addr(main_buckets_space.offset);
-      kvdk_assert(
-          (uint64_t)table->main_buckets_ % sizeof(HashEntry) == 0,
-          "hash table bucket address should aligned to hash entry size");
+      kvdk_assert((uint64_t)table->main_buckets_ % sizeof(HashEntry) == 0,
+                  "hash table bucket address should aligned to hash entry size "
+                  "in create new hash table");
     }
   }
   return table;
@@ -161,9 +161,9 @@ Status HashTable::SearchForWrite(const KeyHashHint& hint, const StringView& key,
             return Status::MemoryOverflow;
           }
           void* next_off = dram_allocator_.offset2addr(space.offset);
-          kvdk_assert(
-              (uint64_t)next_off % sizeof(HashEntry) == 0,
-              "hash table bucket address should aligned to hash entry size");
+          kvdk_assert((uint64_t)next_off % sizeof(HashEntry) == 0,
+                      "hash table bucket address should aligned to hash entry "
+                      "size in allocate new bucket");
           memset(next_off, 0, space.size);
           memcpy_8(bucket_ptr + hash_bucket_size_ - 8, &next_off);
           *entry_ptr = (HashEntry*)next_off;

--- a/engine/hash_table.cpp
+++ b/engine/hash_table.cpp
@@ -38,7 +38,7 @@ HashTable* HashTable::NewHashTable(
 
 bool HashEntry::Match(const StringView& key, uint32_t hash_k_prefix,
                       uint16_t target_type, DataEntry* data_entry_metadata) {
-  if ((target_type & header_.data_type) &&
+  if ((target_type & header_.record_type) &&
       hash_k_prefix == header_.key_prefix) {
     void* pmem_record;
     StringView data_entry_key;
@@ -232,8 +232,10 @@ Status HashTable::SearchForRead(const KeyHashHint& hint, const StringView& key,
 }
 
 void HashTable::Insert(const KeyHashHint& hint, HashEntry* entry_ptr,
-                       uint16_t type, void* index, HashIndexType index_type) {
-  HashEntry new_hash_entry(hint.key_hash_value >> 32, type, index, index_type);
+                       RecordType record_type, void* index,
+                       HashIndexType index_type) {
+  HashEntry new_hash_entry(hint.key_hash_value >> 32, record_type, index,
+                           index_type);
   atomic_store_16(entry_ptr, &new_hash_entry);
 }
 

--- a/engine/hash_table.cpp
+++ b/engine/hash_table.cpp
@@ -28,61 +28,61 @@ HashTable* HashTable::NewHashTable(
     } else {
       table->main_buckets_ =
           table->dram_allocator_.offset2addr(main_buckets_space.offset);
+      kvdk_assert(
+          (uint64_t)table->main_buckets_ % sizeof(HashEntry) == 0,
+          "hash table bucket address should aligned to hash entry size");
     }
   }
   return table;
 }
 
-bool HashTable::MatchHashEntry(const StringView& key, uint32_t hash_k_prefix,
-                               uint16_t target_type,
-                               const HashEntry* hash_entry,
-                               DataEntry* data_entry_metadata) {
-  if ((target_type & hash_entry->header.data_type) &&
-      hash_k_prefix == hash_entry->header.key_prefix) {
+bool HashEntry::Match(const StringView& key, uint32_t hash_k_prefix,
+                      uint16_t target_type, DataEntry* data_entry_metadata) {
+  if ((target_type & header_.data_type) &&
+      hash_k_prefix == header_.key_prefix) {
     void* pmem_record;
     StringView data_entry_key;
 
-    switch (hash_entry->header.index_type) {
+    switch (header_.index_type) {
       case HashIndexType::Empty: {
         return false;
       }
       case HashIndexType::StringRecord: {
-        pmem_record = hash_entry->index.string_record;
-        data_entry_key = hash_entry->index.string_record->Key();
+        pmem_record = index_.string_record;
+        data_entry_key = index_.string_record->Key();
         break;
       }
       case HashIndexType::UnorderedCollectionElement:
       case HashIndexType::DLRecord: {
-        pmem_record = hash_entry->index.dl_record;
-        data_entry_key = hash_entry->index.dl_record->Key();
+        pmem_record = index_.dl_record;
+        data_entry_key = index_.dl_record->Key();
         break;
       }
       case HashIndexType::UnorderedCollection: {
-        UnorderedCollection* p_collection =
-            hash_entry->index.p_unordered_collection;
+        UnorderedCollection* p_collection = index_.p_unordered_collection;
         data_entry_key = p_collection->Name();
         break;
       }
       case HashIndexType::Queue: {
-        Queue* p_collection = hash_entry->index.queue_ptr;
+        Queue* p_collection = index_.queue_ptr;
         data_entry_key = p_collection->Name();
         break;
       }
       case HashIndexType::SkiplistNode: {
-        SkiplistNode* dram_node = hash_entry->index.skiplist_node;
+        SkiplistNode* dram_node = index_.skiplist_node;
         pmem_record = dram_node->record;
         data_entry_key = dram_node->record->Key();
         break;
       }
       case HashIndexType::Skiplist: {
-        Skiplist* skiplist = hash_entry->index.skiplist;
+        Skiplist* skiplist = index_.skiplist;
         pmem_record = skiplist->header()->record;
         data_entry_key = skiplist->Name();
         break;
       }
       default: {
-        GlobalLogger.Error("Not supported hash offset type: %u\n",
-                           hash_entry->header.index_type);
+        GlobalLogger.Error("Not supported hash index type: %u\n",
+                           header_.index_type);
         assert(false && "Trying to use invalid HashIndexType!");
         return false;
       }
@@ -117,9 +117,9 @@ Status HashTable::SearchForWrite(const KeyHashHint& hint, const StringView& key,
   // search cache
   *entry_ptr = slots_[hint.slot].hash_cache.entry_ptr;
   if (*entry_ptr != nullptr) {
-    memcpy_16(hash_entry_snap, *entry_ptr);
-    if (MatchHashEntry(key, key_hash_prefix, type_mask, hash_entry_snap,
-                       data_entry_meta)) {
+    atomic_load_16(hash_entry_snap, *entry_ptr);
+    if (hash_entry_snap->Match(key, key_hash_prefix, type_mask,
+                               data_entry_meta)) {
       found = true;
     }
   }
@@ -136,9 +136,9 @@ Status HashTable::SearchForWrite(const KeyHashHint& hint, const StringView& key,
       }
       *entry_ptr = (HashEntry*)bucket_ptr + (i % num_entries_per_bucket_);
 
-      memcpy_16(hash_entry_snap, *entry_ptr);
-      if (MatchHashEntry(key, key_hash_prefix, type_mask, hash_entry_snap,
-                         data_entry_meta)) {
+      atomic_load_16(hash_entry_snap, *entry_ptr);
+      if (hash_entry_snap->Match(key, key_hash_prefix, type_mask,
+                                 data_entry_meta)) {
         slots_[hint.slot].hash_cache.entry_ptr = *entry_ptr;
         found = true;
         break;
@@ -161,6 +161,9 @@ Status HashTable::SearchForWrite(const KeyHashHint& hint, const StringView& key,
             return Status::MemoryOverflow;
           }
           void* next_off = dram_allocator_.offset2addr(space.offset);
+          kvdk_assert(
+              (uint64_t)next_off % sizeof(HashEntry) == 0,
+              "hash table bucket address should aligned to hash entry size");
           memset(next_off, 0, space.size);
           memcpy_8(bucket_ptr + hash_bucket_size_ - 8, &next_off);
           *entry_ptr = (HashEntry*)next_off;
@@ -195,9 +198,9 @@ Status HashTable::SearchForRead(const KeyHashHint& hint, const StringView& key,
   // search cache
   *entry_ptr = slots_[hint.slot].hash_cache.entry_ptr;
   if (*entry_ptr != nullptr) {
-    memcpy_16(hash_entry_snap, *entry_ptr);
-    if (MatchHashEntry(key, key_hash_prefix, type_mask, hash_entry_snap,
-                       data_entry_meta)) {
+    atomic_load_16(hash_entry_snap, *entry_ptr);
+    if (hash_entry_snap->Match(key, key_hash_prefix, type_mask,
+                               data_entry_meta)) {
       return Status::Ok;
     }
   }
@@ -211,14 +214,14 @@ Status HashTable::SearchForRead(const KeyHashHint& hint, const StringView& key,
     }
     *entry_ptr = (HashEntry*)bucket_ptr + (i % num_entries_per_bucket_);
     while (1) {
-      memcpy_16(hash_entry_snap, *entry_ptr);
-      if (MatchHashEntry(key, key_hash_prefix, type_mask, hash_entry_snap,
-                         data_entry_meta)) {
+      atomic_load_16(hash_entry_snap, *entry_ptr);
+      if (hash_entry_snap->Match(key, key_hash_prefix, type_mask,
+                                 data_entry_meta)) {
         slots_[hint.slot].hash_cache.entry_ptr = *entry_ptr;
         return Status::Ok;
       } else {
         // check if hash entry modified by another write thread during
-        // MatchHashEntry
+        // match hash entry
         if (memcmp(hash_entry_snap, *(entry_ptr), sizeof(HashEntry)) == 0) {
           break;
         }
@@ -230,11 +233,8 @@ Status HashTable::SearchForRead(const KeyHashHint& hint, const StringView& key,
 
 void HashTable::Insert(const KeyHashHint& hint, HashEntry* entry_ptr,
                        uint16_t type, void* index, HashIndexType index_type) {
-  assert(access_thread.id >= 0);
-
   HashEntry new_hash_entry(hint.key_hash_value >> 32, type, index, index_type);
-
-  memcpy_16(entry_ptr, &new_hash_entry);
+  atomic_store_16(entry_ptr, &new_hash_entry);
 }
 
 }  // namespace KVDK_NAMESPACE

--- a/engine/hash_table.hpp
+++ b/engine/hash_table.hpp
@@ -40,7 +40,7 @@ enum class HashIndexType : uint16_t {
 
 struct HashHeader {
   uint32_t key_prefix;
-  uint16_t data_type;
+  RecordType record_type;
   HashIndexType index_type;
 };
 
@@ -68,10 +68,9 @@ struct alignas(16) HashEntry {
 
   HashEntry() = default;
 
-  HashEntry(uint32_t key_hash_prefix, uint16_t data_entry_type, void* _index,
+  HashEntry(uint32_t key_hash_prefix, RecordType record_type, void* _index,
             HashIndexType index_type)
-      : header_({key_hash_prefix, data_entry_type, index_type}),
-        index_(_index) {}
+      : header_({key_hash_prefix, record_type, index_type}), index_(_index) {}
 
   bool Empty() { return header_.index_type == HashIndexType::Empty; }
 
@@ -82,7 +81,7 @@ struct alignas(16) HashEntry {
 
   HashIndexType GetIndexType() const { return header_.index_type; }
 
-  uint16_t GetRecordType() const { return header_.data_type; }
+  RecordType GetRecordType() const { return header_.record_type; }
 
   // Check if "key" of data type "target_type" is indexed by "this". If
   // matches, copy data entry of data record of "key" to "data_entry_metadata"
@@ -156,7 +155,7 @@ class HashTable {
   // Insert a hash entry to hash table
   //
   // entry_ptr: position to insert, it's get from SearchForWrite()
-  void Insert(const KeyHashHint& hint, HashEntry* entry_ptr, uint16_t type,
+  void Insert(const KeyHashHint& hint, HashEntry* entry_ptr, RecordType type,
               void* index, HashIndexType index_type);
 
  private:

--- a/engine/hash_table.hpp
+++ b/engine/hash_table.hpp
@@ -74,7 +74,7 @@ struct alignas(16) HashEntry {
 
   bool Empty() { return header_.index_type == HashIndexType::Empty; }
 
-  // Make this hash entry reusable while its content been deleted
+  // Make this hash entry empty while its content been deleted
   void Clear() { header_.index_type = HashIndexType::Empty; }
 
   Index GetIndex() const { return index_; }
@@ -157,6 +157,12 @@ class HashTable {
   // entry_ptr: position to insert, it's get from SearchForWrite()
   void Insert(const KeyHashHint& hint, HashEntry* entry_ptr, RecordType type,
               void* index, HashIndexType index_type);
+
+  // Erase a hash entry so it can be reused in future
+  void Erase(HashEntry* entry_ptr) {
+    assert(entry_ptr != nullptr);
+    entry_ptr->Clear();
+  }
 
  private:
   HashTable(uint64_t hash_bucket_num, uint32_t hash_bucket_size,

--- a/engine/kv_engine.cpp
+++ b/engine/kv_engine.cpp
@@ -1801,7 +1801,7 @@ Status KVEngine::HDelete(StringView const collection_name,
 
           erase_result = p_collection->Erase(pmp_old_record, lock_record);
           if (erase_result.success) {
-            p_hash_entry->Clear();
+            hash_table_->Erase(p_hash_entry);
             purgeAndFree(pmp_old_record);
             return Status::Ok;
           } else {

--- a/engine/kv_engine.cpp
+++ b/engine/kv_engine.cpp
@@ -626,7 +626,7 @@ Status KVEngine::RestoreSkiplistRecord(DLRecord* pmem_record,
 }
 
 Status KVEngine::InitCollection(const StringView& collection, Collection** list,
-                                uint16_t collection_type) {
+                                RecordType collection_type) {
   if (!CheckKeySize(collection)) {
     return Status::InvalidDataSize;
   }
@@ -660,7 +660,7 @@ Status KVEngine::InitCollection(const StringView& collection, Collection** list,
   DLRecord* pmem_record = DLRecord::PersistDLRecord(
       pmem_allocator_->offset2addr(sized_space_entry.offset),
       sized_space_entry.size, version_controller_.GetCurrentTimestamp(),
-      (RecordType)collection_type, kNullPMemOffset, sized_space_entry.offset,
+      collection_type, kNullPMemOffset, sized_space_entry.offset,
       sized_space_entry.offset, collection, StringView((char*)&id, 8));
 
   {
@@ -1455,7 +1455,7 @@ Status KVEngine::StringBatchWriteImpl(const WriteBatch::KV& kv,
               : kNullPMemOffset,
         kv.key, kv.type == StringDataRecord ? kv.value : "");
 
-    hash_table_->Insert(hash_hint, entry_ptr, kv.type, block_base,
+    hash_table_->Insert(hash_hint, entry_ptr, (RecordType)kv.type, block_base,
                         HashIndexType::StringRecord);
 
     if (found) {

--- a/engine/kv_engine.hpp
+++ b/engine/kv_engine.hpp
@@ -188,7 +188,7 @@ class KVEngine : public Engine {
     if (s != Status::Ok) {
       return s;
     }
-    *collection_ptr = (CollectionType*)hash_entry.index.ptr;
+    *collection_ptr = (CollectionType*)hash_entry.GetIndex().ptr;
     return s;
   }
 

--- a/engine/kv_engine.hpp
+++ b/engine/kv_engine.hpp
@@ -170,7 +170,7 @@ class KVEngine : public Engine {
 
  private:
   Status InitCollection(const StringView& collection, Collection** list,
-                        uint16_t collection_type);
+                        RecordType collection_type);
   std::shared_ptr<UnorderedCollection> createUnorderedCollection(
       StringView const collection_name);
   std::unique_ptr<Queue> createQueue(StringView const collection_name);

--- a/engine/skiplist.cpp
+++ b/engine/skiplist.cpp
@@ -688,7 +688,7 @@ Status SortedCollectionRebuilder::repairSkiplistLinkage(Skiplist* skiplist) {
           asm volatile("pause");
           continue;
         }
-        entry_ptr->Clear();
+        hash_table_->Erase(entry_ptr);
       } else {
         if (valid_version_record != next_record) {
           // repair linkage of checkpoint version
@@ -872,7 +872,7 @@ Status SortedCollectionRebuilder::dealWithFirstHeight(uint64_t thread_id,
             asm volatile("pause");
             continue;
           }
-          entry_ptr->Clear();
+          hash_table_->Erase(entry_ptr);
         } else {
           // repair linkage of checkpoint version
           if (valid_version_record != next_record) {
@@ -1001,7 +1001,7 @@ Status SortedCollectionRebuilder::updateRecordOffsets() {
                                nullptr, pmem_allocator_, hash_table_)) {
             continue;
           }
-          entry_ptr->Clear();
+          hash_table_->Erase(entry_ptr);
         } else {
           // repair linkage of checkpoint version
           if (valid_version_record != hash_entry.GetIndex().dl_record) {

--- a/engine/utils/utils.hpp
+++ b/engine/utils/utils.hpp
@@ -29,6 +29,8 @@
 #include "xxhash.h"
 #undef XXH_INLINE_ALL
 
+#include <atomic>
+
 #include "../alias.hpp"
 #include "../macros.hpp"
 #include "kvdk/namespace.hpp"
@@ -51,6 +53,11 @@ Defer<F> defer_func(F f) {
 #define DEFER_2(x, y) DEFER_1(x, y)
 #define DEFER_3(x) DEFER_2(x, __COUNTER__)
 #define defer(code) auto DEFER_3(_defer_) = defer_func([&]() { code; })
+
+inline void atomic_memcpy_16(void* dst, void* src) {
+  ((std::atomic<__uint128_t>*)dst)
+      ->store(((std::atomic<__uint128_t>*)src)->load());
+}
 
 inline uint64_t hash_str(const char* str, uint64_t size) {
   return XXH3_64bits(str, size);
@@ -80,9 +87,19 @@ inline static uint64_t rdtsc() {
   return ((uint64_t)lo) | (((uint64_t)hi) << 32);
 }
 
+inline void atomic_load_16(void* dst, const void* src) {
+  (*(__uint128_t*)dst) = __atomic_load_16(src, std::memory_order_relaxed);
+}
+
+inline void atomic_store_16(void* dst, const void* src) {
+  __atomic_store_16(dst, (*(__uint128_t*)src), std::memory_order_relaxed);
+}
+
 inline void memcpy_16(void* dst, const void* src) {
   __m128i m0 = _mm_loadu_si128(((const __m128i*)src) + 0);
   _mm_storeu_si128(((__m128i*)dst) + 0, m0);
+  // ((std::atomic<__uint128_t>*)dst)
+  // ->store(((std::atomic<__uint128_t>*)src)->load());
 }
 
 inline void memcpy_8(void* dst, const void* src) {

--- a/engine/utils/utils.hpp
+++ b/engine/utils/utils.hpp
@@ -98,8 +98,6 @@ inline void atomic_store_16(void* dst, const void* src) {
 inline void memcpy_16(void* dst, const void* src) {
   __m128i m0 = _mm_loadu_si128(((const __m128i*)src) + 0);
   _mm_storeu_si128(((__m128i*)dst) + 0, m0);
-  // ((std::atomic<__uint128_t>*)dst)
-  // ->store(((std::atomic<__uint128_t>*)src)->load());
 }
 
 inline void memcpy_8(void* dst, const void* src) {

--- a/engine/version/old_records_cleaner.cpp
+++ b/engine/version/old_records_cleaner.cpp
@@ -196,10 +196,10 @@ SpaceEntry OldRecordsCleaner::purgeOldDeleteRecord(
       static_cast<DataEntry*>(old_delete_record.pmem_delete_record);
   switch (data_entry->meta.type) {
     case StringDeleteRecord: {
-      if (old_delete_record.hash_entry_ref->index.string_record ==
+      if (old_delete_record.hash_entry_ref->GetIndex().string_record ==
           old_delete_record.pmem_delete_record) {
         std::lock_guard<SpinMutex> lg(*old_delete_record.hash_entry_lock);
-        if (old_delete_record.hash_entry_ref->index.string_record ==
+        if (old_delete_record.hash_entry_ref->GetIndex().string_record ==
             old_delete_record.pmem_delete_record) {
           old_delete_record.hash_entry_ref->Clear();
         }
@@ -215,12 +215,12 @@ SpaceEntry OldRecordsCleaner::purgeOldDeleteRecord(
         std::lock_guard<SpinMutex> lg(*hash_entry_lock);
         DLRecord* hash_indexed_pmem_record = nullptr;
         SkiplistNode* dram_node = nullptr;
-        switch (hash_entry_ref->header.index_type) {
+        switch (hash_entry_ref->GetIndexType()) {
           case HashIndexType::DLRecord:
-            hash_indexed_pmem_record = hash_entry_ref->index.dl_record;
+            hash_indexed_pmem_record = hash_entry_ref->GetIndex().dl_record;
             break;
           case HashIndexType::SkiplistNode:
-            dram_node = hash_entry_ref->index.skiplist_node;
+            dram_node = hash_entry_ref->GetIndex().skiplist_node;
             hash_indexed_pmem_record = dram_node->record;
             break;
           case HashIndexType::Empty:
@@ -228,7 +228,7 @@ SpaceEntry OldRecordsCleaner::purgeOldDeleteRecord(
           default:
             GlobalLogger.Error(
                 "Wrong type %u in handle pending free skiplist delete record\n",
-                hash_entry_ref->header.index_type);
+                hash_entry_ref->GetIndexType());
             std::abort();
         }
 

--- a/engine/version/old_records_cleaner.cpp
+++ b/engine/version/old_records_cleaner.cpp
@@ -201,7 +201,7 @@ SpaceEntry OldRecordsCleaner::purgeOldDeleteRecord(
         std::lock_guard<SpinMutex> lg(*old_delete_record.hash_entry_lock);
         if (old_delete_record.hash_entry_ref->GetIndex().string_record ==
             old_delete_record.pmem_delete_record) {
-          old_delete_record.hash_entry_ref->Clear();
+          kv_engine_->hash_table_->Erase(old_delete_record.hash_entry_ref);
         }
       }
       // we don't need to purge a delete record
@@ -239,7 +239,7 @@ SpaceEntry OldRecordsCleaner::purgeOldDeleteRecord(
                   kv_engine_->hash_table_.get())) {
             continue;
           }
-          hash_entry_ref->Clear();
+          kv_engine_->hash_table_->Erase(hash_entry_ref);
         }
 
         return SpaceEntry(kv_engine_->pmem_allocator_->addr2offset(data_entry),

--- a/scripts/benchmark_impl.py
+++ b/scripts/benchmark_impl.py
@@ -145,7 +145,7 @@ def run_benchmark(
         "-populate={2} "\
         "-num_kv={3} "\
         "-threads={4} "\
-        "-max_write_threads={5} "\
+        "-max_access_threads={5} "\
         "-num_collection={6} "\
         "-timeout={7} "\
         "-value_size={8} "\


### PR DESCRIPTION
Signed-off-by: Jiayu Wu <jiayu.wu@intel.com>

<!--
Thank you for contributing to KVDK.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Problem Summary:

HashEntry in current impl has two 8 bytes field, meta and pointer, and data type of the pointer is indicated by meta, which may cause inconsistency while accessing these fields.

### What is changed and how it works?

1. load/store hash entry with 16bytes atomic operations
2. make meta and pointer private to avoid invalid access

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Stress test

Side effects

- Performance regression
    - ~10% decrease in string get, ~6% decrease in string insert
    - other type is in testing
