### PR TITLE
Fix benchmark with value size distribution set to random

### DIFF
--- a/benchmark/bench.cpp
+++ b/benchmark/bench.cpp
@@ -117,7 +117,7 @@ size_t operations_per_thread;
 bool has_timed_out;
 std::vector<int> has_finished;  // std::vector<bool> is a trap!
 
-std::vector<PaddedEngine> engines;
+std::vector<PaddedEngine> random_engines;
 std::vector<PaddedRangeIterators> ranges;
 
 enum class DataType {
@@ -143,10 +143,10 @@ std::uint64_t generate_key(size_t tid) {
       return ranges[tid].gen();
     }
     case KeyDistribution::Random: {
-      return uniform(engines[tid].gen);
+      return uniform(random_engines[tid].gen);
     }
     case KeyDistribution::Zipf: {
-      return zipf(engines[tid].gen);
+      return zipf(random_engines[tid].gen);
     }
     default: {
       throw;
@@ -160,7 +160,7 @@ size_t generate_value_size(size_t tid) {
       return FLAGS_value_size;
     }
     case ValueSizeDistribution::Random: {
-      return engines[tid].gen() % FLAGS_value_size + 1;
+      return random_engines[tid].gen() % FLAGS_value_size + 1;
     }
     default: {
       throw;
@@ -439,7 +439,7 @@ void ProcessBenchmarkConfigs() {
     throw std::invalid_argument{"value size too large"};
   }
 
-  engines.resize(FLAGS_threads);
+  random_engines.resize(FLAGS_threads);
   if (FLAGS_fill) {
     assert(FLAGS_read_ratio == 0);
     key_dist = KeyDistribution::Range;

--- a/benchmark/bench.cpp
+++ b/benchmark/bench.cpp
@@ -439,7 +439,8 @@ void ProcessBenchmarkConfigs() {
     throw std::invalid_argument{"value size too large"};
   }
 
-  if (FLAGS_fill || FLAGS_key_distribution == "uniform") {
+  engines.resize(FLAGS_threads);
+  if (FLAGS_fill) {
     assert(FLAGS_read_ratio == 0);
     key_dist = KeyDistribution::Range;
     operations_per_thread = FLAGS_num_kv / FLAGS_max_access_threads + 1;
@@ -449,7 +450,6 @@ void ProcessBenchmarkConfigs() {
     }
   } else {
     operations_per_thread = FLAGS_num_operations / FLAGS_threads;
-    engines.resize(FLAGS_threads);
     if (FLAGS_key_distribution == "random") {
       key_dist = KeyDistribution::Random;
     } else if (FLAGS_key_distribution == "zipf") {

--- a/scripts/benchmark_impl.py
+++ b/scripts/benchmark_impl.py
@@ -116,11 +116,11 @@ def run_benchmark(
     # calculate num kv to fill
     header_sz = 24 if (key_distribution == 'string') else 40
     k_sz = 8
-    avg_v_sz = value_size if (value_size_distribution == 'constant') else (value_size / 2)
+    avg_v_sz = value_size if (value_size_distribution == 'constant') else (value_size // 2)
     avg_kv_size = (header_sz + k_sz + avg_v_sz + 63) // 64 * 64
 
     # 1/4 for fill, 1/4 for insert, 1/4 for batch_write
-    num_kv = int(pmem_size // 4 // avg_kv_size)
+    num_kv = pmem_size // 4 // avg_kv_size
 
     # create report dir
     timestamp = datetime.datetime.now().strftime("%Y%m%d-%H%M")

--- a/scripts/benchmark_impl.py
+++ b/scripts/benchmark_impl.py
@@ -120,7 +120,7 @@ def run_benchmark(
     avg_kv_size = (header_sz + k_sz + avg_v_sz + 63) // 64 * 64
 
     # 1/4 for fill, 1/4 for insert, 1/4 for batch_write
-    num_kv = pmem_size // 4 // avg_kv_size
+    num_kv = int(pmem_size // 4 // avg_kv_size)
 
     # create report dir
     timestamp = datetime.datetime.now().strftime("%Y%m%d-%H%M")

--- a/scripts/run_benchmark.py
+++ b/scripts/run_benchmark.py
@@ -11,7 +11,7 @@ num_thread = 64
 value_sizes = [120]
 # constant: value size always be "value_size",
 # random: value size uniformly distributed in [1, value_size]
-value_size_distributions = ['random']
+value_size_distributions = ['constant']
 timeout = 30                          # For operations other than fill
 populate_on_fill = 1                  # For fill only
 pmem_size = 384 * 1024 * 1024 * 1024  # we need enough space to test insert

--- a/scripts/run_benchmark.py
+++ b/scripts/run_benchmark.py
@@ -11,7 +11,7 @@ num_thread = 64
 value_sizes = [120]
 # constant: value size always be "value_size",
 # random: value size uniformly distributed in [1, value_size]
-value_size_distributions = ['constant']
+value_size_distributions = ['random']
 timeout = 30                          # For operations other than fill
 populate_on_fill = 1                  # For fill only
 pmem_size = 384 * 1024 * 1024 * 1024  # we need enough space to test insert


### PR DESCRIPTION
Signed-off-by: ZiyanShi <ziyan.shi@intel.com>

<!--
Thank you for contributing to KVDK.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Problem Summary:

Segfault when value size distribution set to random because vector of random engines is not initialized.

What's Changed:
Initialize the vector.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
