### PR TITLE
Persist customized compare function of sorted collection

### DIFF
--- a/engine/alias.hpp
+++ b/engine/alias.hpp
@@ -17,6 +17,5 @@ using PMemOffsetType = std::uint64_t;
 using TimeStampType = std::uint64_t;
 using CollectionIDType = std::uint64_t;
 using KeyHashType = std::uint64_t;
-using CompFunc =
-    std::function<int(const StringView& src, const StringView& target)>;
+using ConfigFieldSizeType = std::uint32_t;
 }  // namespace KVDK_NAMESPACE

--- a/engine/c.cpp
+++ b/engine/c.cpp
@@ -128,17 +128,17 @@ void KVDKRemovePMemContents(const char* name) {
   int ret __attribute__((unused)) = system(res.c_str());
 }
 
-void KVDKRegisterCompFunc(KVDKEngine* engine, const char* compara_name,
-                          size_t compara_len,
-                          int (*compare)(const char* src, size_t src_len,
-                                         const char* target,
-                                         size_t target_len)) {
+int KVDKRegisterCompFunc(KVDKEngine* engine, const char* compara_name,
+                         size_t compara_len,
+                         int (*compare)(const char* src, size_t src_len,
+                                        const char* target,
+                                        size_t target_len)) {
   auto comp_func = [compare](const StringView& src,
                              const StringView& target) -> int {
     return compare(src.data(), src.size(), target.data(), target.size());
   };
-  engine->rep->RegisterCompareFunc(StringView(compara_name, compara_len),
-                                   comp_func);
+  return engine->rep->RegisterCompareFunc(StringView(compara_name, compara_len),
+                                          comp_func);
 }
 
 KVDKStatus KVDKCreateSortedCollection(KVDKEngine* engine,

--- a/engine/c.cpp
+++ b/engine/c.cpp
@@ -81,8 +81,7 @@ KVDKSortedCollectionConfigs* KVDKCreateSortedCollectionConfigs() {
 void KVDKSetSortedCollectionConfigs(KVDKSortedCollectionConfigs* configs,
                                     const char* comp_func_name,
                                     size_t comp_func_len) {
-  configs->rep.compare_function_name =
-      std::string(comp_func_name, comp_func_len);
+  configs->rep.comparator_name = std::string(comp_func_name, comp_func_len);
 }
 
 void KVDKDestroySortedCollectionConfigs(KVDKSortedCollectionConfigs* configs) {
@@ -137,8 +136,8 @@ int KVDKRegisterCompFunc(KVDKEngine* engine, const char* compara_name,
                              const StringView& target) -> int {
     return compare(src.data(), src.size(), target.data(), target.size());
   };
-  return engine->rep->RegisterCompareFunc(StringView(compara_name, compara_len),
-                                          comp_func);
+  return engine->rep->RegisterComparator(StringView(compara_name, compara_len),
+                                         comp_func);
 }
 
 KVDKStatus KVDKCreateSortedCollection(KVDKEngine* engine,

--- a/engine/c.cpp
+++ b/engine/c.cpp
@@ -137,7 +137,8 @@ void KVDKRegisterCompFunc(KVDKEngine* engine, const char* compara_name,
                              const StringView& target) -> int {
     return compare(src.data(), src.size(), target.data(), target.size());
   };
-  engine->rep->SetCompareFunc(StringView(compara_name, compara_len), comp_func);
+  engine->rep->RegisterCompareFunc(StringView(compara_name, compara_len),
+                                   comp_func);
 }
 
 KVDKStatus KVDKCreateSortedCollection(KVDKEngine* engine,

--- a/engine/kv_engine.cpp
+++ b/engine/kv_engine.cpp
@@ -63,7 +63,6 @@ KVEngine::~KVEngine() {
 Status KVEngine::Open(const std::string& name, Engine** engine_ptr,
                       const Configs& configs) {
   KVEngine* engine = new KVEngine(configs);
-  engine->RegisterCompareFunc("default", compare_string_view);
   Status s = engine->Init(name, configs);
   if (s == Status::Ok) {
     *engine_ptr = engine;
@@ -174,6 +173,7 @@ Status KVEngine::Init(const std::string& name, const Configs& configs) {
     return Status::Abort;
   }
 
+  RegisterCompareFunc("default", compare_string_view);
   s = Recovery();
   startBackgroundWorks();
 

--- a/engine/kv_engine.cpp
+++ b/engine/kv_engine.cpp
@@ -181,9 +181,9 @@ Status KVEngine::Init(const std::string& name, const Configs& configs) {
   return s;
 }
 
-Status KVEngine::CreateSortedCollection(const StringView collection_name,
-                                        Collection** collection_ptr,
-                                        const StringView& comp_name) {
+Status KVEngine::CreateSortedCollection(
+    const StringView collection_name, Collection** collection_ptr,
+    const SortedCollectionConfigs& configs) {
   *collection_ptr = nullptr;
   Status s = MaybeInitAccessThread();
   if (s != Status::Ok) {
@@ -193,13 +193,14 @@ Status KVEngine::CreateSortedCollection(const StringView collection_name,
                      RecordType::SortedHeaderRecord);
   if (s == Status::Ok) {
     auto skiplist = (Skiplist*)(*collection_ptr);
-    if (!comp_name.empty()) {
-      auto compare_func = comparator_.GetComparaFunc(comp_name);
+    if (!configs.compare_function_name.empty()) {
+      auto compare_func =
+          comparator_.GetComparaFunc(configs.compare_function_name);
       if (compare_func != nullptr) {
         skiplist->SetCompareFunc(compare_func);
       } else {
         GlobalLogger.Error("Compare function %s is not registered\n",
-                           comp_name);
+                           configs.compare_function_name);
         s = Status::Abort;
       }
     }

--- a/engine/kv_engine.cpp
+++ b/engine/kv_engine.cpp
@@ -209,7 +209,7 @@ Status KVEngine::CreateSortedCollection(
     *collection_ptr = static_cast<Collection*>(hash_entry.GetIndex().ptr);
   } else if (s == Status::NotFound) {
     auto compare_func =
-        comparator_.GetComparaFunc(s_configs.compare_function_name);
+        comparators_.GetCompareFunc(s_configs.compare_function_name);
     if (compare_func == nullptr) {
       GlobalLogger.Error("Compare function %s is not registered\n",
                          s_configs.compare_function_name);
@@ -515,7 +515,7 @@ Status KVEngine::RestoreSkiplistHead(DLRecord* pmem_record,
   }
 
   auto compare_func =
-      comparator_.GetComparaFunc(s_configs.compare_function_name);
+      comparators_.GetCompareFunc(s_configs.compare_function_name);
   if (compare_func == nullptr) {
     GlobalLogger.Error(
         "Compare function %s of restoring sorted collection %s is not "

--- a/engine/kv_engine.hpp
+++ b/engine/kv_engine.hpp
@@ -120,7 +120,8 @@ class KVEngine : public Engine {
   KVEngine(const Configs& configs)
       : engine_thread_cache_(configs.max_access_threads),
         version_controller_(configs.max_access_threads),
-        old_records_cleaner_(this, configs.max_access_threads){};
+        old_records_cleaner_(this, configs.max_access_threads),
+        comparator_(configs.comparator){};
 
   struct BatchWriteHint {
     TimeStampType timestamp{0};
@@ -157,11 +158,9 @@ class KVEngine : public Engine {
 
   inline Status MaybeInitAccessThread();
 
-  void SetCompareFunc(
-      const StringView& collection_name,
-      std::function<int(const StringView& src, const StringView& target)>
-          comp_func) {
-    comparator_.SetComparaFunc(collection_name, comp_func);
+  void RegisterCompareFunc(const StringView& collection_name,
+                           CompFunc comp_func) {
+    comparator_.RegisterComparaFunc(collection_name, comp_func);
   }
 
   Status CreateSortedCollection(

--- a/engine/kv_engine.hpp
+++ b/engine/kv_engine.hpp
@@ -168,8 +168,6 @@ class KVEngine : public Engine {
       const SortedCollectionConfigs& configs) override;
 
  private:
-  Status InitCollection(const StringView& collection, Collection** list,
-                        RecordType collection_type, void* collection_configs);
   std::shared_ptr<UnorderedCollection> createUnorderedCollection(
       StringView const collection_name);
   std::unique_ptr<Queue> createQueue(StringView const collection_name);

--- a/engine/kv_engine.hpp
+++ b/engine/kv_engine.hpp
@@ -170,7 +170,7 @@ class KVEngine : public Engine {
 
  private:
   Status InitCollection(const StringView& collection, Collection** list,
-                        RecordType collection_type);
+                        RecordType collection_type, void* collection_configs);
   std::shared_ptr<UnorderedCollection> createUnorderedCollection(
       StringView const collection_name);
   std::unique_ptr<Queue> createQueue(StringView const collection_name);

--- a/engine/kv_engine.hpp
+++ b/engine/kv_engine.hpp
@@ -121,7 +121,7 @@ class KVEngine : public Engine {
       : engine_thread_cache_(configs.max_access_threads),
         version_controller_(configs.max_access_threads),
         old_records_cleaner_(this, configs.max_access_threads),
-        comparator_(configs.comparator){};
+        comparators_(configs.comparator){};
 
   struct BatchWriteHint {
     TimeStampType timestamp{0};
@@ -158,9 +158,9 @@ class KVEngine : public Engine {
 
   inline Status MaybeInitAccessThread();
 
-  void RegisterCompareFunc(const StringView& collection_name,
-                           CompFunc comp_func) {
-    comparator_.RegisterComparaFunc(collection_name, comp_func);
+  bool RegisterCompareFunc(const StringView& collection_name,
+                           CompareFunc comp_func) {
+    return comparators_.RegisterCompareFunc(collection_name, comp_func);
   }
 
   Status CreateSortedCollection(
@@ -389,7 +389,7 @@ class KVEngine : public Engine {
 
   bool bg_cleaner_processing_;
 
-  Comparator comparator_;
+  ComparatorTable comparators_;
 
   struct BackgroundWorkSignals {
     BackgroundWorkSignals() = default;

--- a/engine/kv_engine.hpp
+++ b/engine/kv_engine.hpp
@@ -158,9 +158,9 @@ class KVEngine : public Engine {
 
   inline Status MaybeInitAccessThread();
 
-  bool RegisterCompareFunc(const StringView& collection_name,
-                           CompareFunc comp_func) {
-    return comparators_.RegisterCompareFunc(collection_name, comp_func);
+  bool RegisterComparator(const StringView& collection_name,
+                          Comparator comp_func) {
+    return comparators_.RegisterComparator(collection_name, comp_func);
   }
 
   Status CreateSortedCollection(

--- a/engine/kv_engine.hpp
+++ b/engine/kv_engine.hpp
@@ -164,9 +164,9 @@ class KVEngine : public Engine {
     comparator_.SetComparaFunc(collection_name, comp_func);
   }
 
-  Status CreateSortedCollection(const StringView collection_name,
-                                Collection** collection_ptr,
-                                const StringView& comp_name) override;
+  Status CreateSortedCollection(
+      const StringView collection_name, Collection** collection_ptr,
+      const SortedCollectionConfigs& configs) override;
 
  private:
   Status InitCollection(const StringView& collection, Collection** list,

--- a/engine/skiplist.cpp
+++ b/engine/skiplist.cpp
@@ -1049,4 +1049,15 @@ SkiplistNode* Skiplist::NewNodeBuild(DLRecord* pmem_record) {
   return dram_node;
 }
 
+std::string Skiplist::EncodeSortedCollectionConfigs(
+    const SortedCollectionConfigs& s_configs) {
+  return s_configs.compare_function_name;
+}
+
+SortedCollectionConfigs Skiplist::DecodeSortedCollectionConfigs(
+    StringView s_configs_str) {
+  SortedCollectionConfigs configs;
+  configs.compare_function_name = string_view_2_string(s_configs_str);
+  return configs;
+}
 }  // namespace KVDK_NAMESPACE

--- a/engine/skiplist.cpp
+++ b/engine/skiplist.cpp
@@ -1055,16 +1055,16 @@ std::string Skiplist::EncodeSortedCollectionValue(
   std::string value_str(
       sizeof(CollectionIDType) +
           sizeof(ConfigFieldSizeType) * (num_config_fields + 1 /* end mark */) +
-          s_configs.compare_function_name.size(),
+          s_configs.comparator_name.size(),
       ' ');
   size_t cur = 0;
   memcpy(&value_str[cur], &id, sizeof(CollectionIDType));
   cur += sizeof(CollectionIDType);
 
-  ConfigFieldSizeType field_size = s_configs.compare_function_name.size();
+  ConfigFieldSizeType field_size = s_configs.comparator_name.size();
   memcpy(&value_str[cur], &field_size, sizeof(ConfigFieldSizeType));
   cur += sizeof(ConfigFieldSizeType);
-  memcpy(&value_str[cur], s_configs.compare_function_name.data(), field_size);
+  memcpy(&value_str[cur], s_configs.comparator_name.data(), field_size);
   cur += field_size;
 
   memcpy(&value_str[cur], &kEncodedConfigsEndMark, sizeof(ConfigFieldSizeType));
@@ -1105,7 +1105,7 @@ Status Skiplist::DecodeSortedCollectionValue(
 
     switch (setting_config_field) {
       case 0: {
-        s_configs.compare_function_name = config_field_str;
+        s_configs.comparator_name = config_field_str;
         break;
       }
 

--- a/engine/skiplist.hpp
+++ b/engine/skiplist.hpp
@@ -150,7 +150,7 @@ struct SkiplistNode {
 class Skiplist : public Collection {
  public:
   Skiplist(DLRecord* h, const std::string& name, CollectionIDType id,
-           CompFunc comp_func, std::shared_ptr<PMEMAllocator> pmem_allocator,
+           CompareFunc comp_func, std::shared_ptr<PMEMAllocator> pmem_allocator,
            std::shared_ptr<HashTable> hash_table)
       : Collection(name, id),
         compare_func_(comp_func),
@@ -427,7 +427,7 @@ class Skiplist : public Collection {
   SpinMutex obsolete_nodes_spin_;
   // protect pending_deletion_nodes_
   SpinMutex pending_delete_nodes_spin_;
-  CompFunc compare_func_ = compare_string_view;
+  CompareFunc compare_func_ = compare_string_view;
 };
 
 class SortedIterator : public Iterator {

--- a/engine/skiplist.hpp
+++ b/engine/skiplist.hpp
@@ -149,9 +149,10 @@ struct SkiplistNode {
 class Skiplist : public Collection {
  public:
   Skiplist(DLRecord* h, const std::string& name, CollectionIDType id,
-           std::shared_ptr<PMEMAllocator> pmem_allocator,
+           CompFunc comp_func, std::shared_ptr<PMEMAllocator> pmem_allocator,
            std::shared_ptr<HashTable> hash_table)
       : Collection(name, id),
+        compare_func_(comp_func),
         pmem_allocator_(pmem_allocator),
         hash_table_(hash_table) {
     header_ = SkiplistNode::NewNode(name, h, kMaxHeight);
@@ -350,10 +351,14 @@ class Skiplist : public Collection {
       std::unique_lock<SpinMutex>* prev_record_lock,
       PMEMAllocator* pmem_allocator, HashTable* hash_table);
 
-  void SetCompareFunc(CompFunc comp_func) { compare_func_ = comp_func; }
-
   // Build a skiplist node for "pmem_record"
   static SkiplistNode* NewNodeBuild(DLRecord* pmem_record);
+
+  static std::string EncodeSortedCollectionConfigs(
+      const SortedCollectionConfigs& s_configs);
+
+  static SortedCollectionConfigs DecodeSortedCollectionConfigs(
+      StringView s_configs_str);
 
  private:
   inline void LinkDLRecord(DLRecord* prev, DLRecord* next, DLRecord* linking) {

--- a/engine/skiplist.hpp
+++ b/engine/skiplist.hpp
@@ -143,6 +143,9 @@ struct SkiplistNode {
 // implemented in O(logn) time. Meanwhile, the skiplist nodes is also indexed by
 // the global hash table, so the updates/delete and point read operations can be
 // indexed by hash table and implemented in ~O(1) time
+// Each skiplist has a header record persisted on PMem, the key of header record
+// is the skiplist name, the value of header record is encoded by skiplist id
+// and configs
 class Skiplist : public Collection {
  public:
   Skiplist(DLRecord* h, const std::string& name, CollectionIDType id,

--- a/engine/skiplist.hpp
+++ b/engine/skiplist.hpp
@@ -356,13 +356,14 @@ class Skiplist : public Collection {
   static SkiplistNode* NewNodeBuild(DLRecord* pmem_record);
 
   // Format:
-  // field size (4 bytes), field value|field size, field value|...| end mark (4
-  // bytes)
-  static std::string EncodeSortedCollectionConfigs(
-      const SortedCollectionConfigs& s_configs);
+  // id (8 bytes) | config size (4 bytes), config | config size, config |...|
+  // end mark (4 bytes)
+  static std::string EncodeSortedCollectionValue(
+      CollectionIDType id, const SortedCollectionConfigs& s_configs);
 
-  static Status DecodeSortedCollectionConfigs(
-      StringView s_configs_str, SortedCollectionConfigs& s_configs);
+  static Status DecodeSortedCollectionValue(StringView value_str,
+                                            CollectionIDType& id,
+                                            SortedCollectionConfigs& s_configs);
 
  private:
   inline void LinkDLRecord(DLRecord* prev, DLRecord* next, DLRecord* linking) {

--- a/engine/skiplist.hpp
+++ b/engine/skiplist.hpp
@@ -150,10 +150,10 @@ struct SkiplistNode {
 class Skiplist : public Collection {
  public:
   Skiplist(DLRecord* h, const std::string& name, CollectionIDType id,
-           CompareFunc comp_func, std::shared_ptr<PMEMAllocator> pmem_allocator,
+           Comparator comparator, std::shared_ptr<PMEMAllocator> pmem_allocator,
            std::shared_ptr<HashTable> hash_table)
       : Collection(name, id),
-        compare_func_(comp_func),
+        comparator_(comparator),
         pmem_allocator_(pmem_allocator),
         hash_table_(hash_table) {
     header_ = SkiplistNode::NewNode(name, h, kMaxHeight);
@@ -410,7 +410,7 @@ class Skiplist : public Collection {
   }
 
   int compare(const StringView& src_key, const StringView& target_key) {
-    return compare_func_(src_key, target_key);
+    return comparator_(src_key, target_key);
   }
 
   SkiplistNode* header_;
@@ -427,7 +427,7 @@ class Skiplist : public Collection {
   SpinMutex obsolete_nodes_spin_;
   // protect pending_deletion_nodes_
   SpinMutex pending_delete_nodes_spin_;
-  CompareFunc compare_func_ = compare_string_view;
+  Comparator comparator_ = compare_string_view;
 };
 
 class SortedIterator : public Iterator {

--- a/engine/skiplist.hpp
+++ b/engine/skiplist.hpp
@@ -20,6 +20,7 @@ namespace KVDK_NAMESPACE {
 class KVEngine;
 static const uint8_t kMaxHeight = 32;
 static const uint8_t kCacheHeight = 3;
+const ConfigFieldSizeType kEncodedConfigsEndMark = 0;
 
 struct Splice;
 
@@ -354,11 +355,14 @@ class Skiplist : public Collection {
   // Build a skiplist node for "pmem_record"
   static SkiplistNode* NewNodeBuild(DLRecord* pmem_record);
 
+  // Format:
+  // field size (4 bytes), field value|field size, field value|...| end mark (4
+  // bytes)
   static std::string EncodeSortedCollectionConfigs(
       const SortedCollectionConfigs& s_configs);
 
-  static SortedCollectionConfigs DecodeSortedCollectionConfigs(
-      StringView s_configs_str);
+  static Status DecodeSortedCollectionConfigs(
+      StringView s_configs_str, SortedCollectionConfigs& s_configs);
 
  private:
   inline void LinkDLRecord(DLRecord* prev, DLRecord* next, DLRecord* linking) {

--- a/engine/utils/utils.hpp
+++ b/engine/utils/utils.hpp
@@ -396,11 +396,10 @@ inline static std::string ID2String(CollectionIDType id) {
 
 inline static CollectionIDType string2ID(const StringView& string_id) {
   CollectionIDType id;
-  kvdk_assert(sizeof(CollectionIDType) == string_id.size(),
+  kvdk_assert(sizeof(CollectionIDType) <= string_id.size(),
               "size of string id does not match CollectionIDType size!");
   memcpy(&id, string_id.data(), sizeof(CollectionIDType));
   return id;
 }
-
 }  // namespace CollectionUtils
 }  // namespace KVDK_NAMESPACE

--- a/examples/tutorial/c_api_tutorial.c
+++ b/examples/tutorial/c_api_tutorial.c
@@ -81,12 +81,14 @@ void SortedCollectionExample(KVDKEngine* kvdk_engine) {
   int cmp;
 
   KVDKCollection* collecton1_ptr;
-  KVDKStatus s = KVDKCreateSortedCollection(
-      kvdk_engine, &collecton1_ptr, collection1, strlen(collection1), "", 0);
+  KVDKSortedCollectionConfigs* s_configs = KVDKCreateSortedCollectionConfigs();
+  KVDKStatus s =
+      KVDKCreateSortedCollection(kvdk_engine, &collecton1_ptr, collection1,
+                                 strlen(collection1), s_configs);
   assert(s == Ok);
   KVDKCollection* collecton2_ptr;
   s = KVDKCreateSortedCollection(kvdk_engine, &collecton2_ptr, collection2,
-                                 strlen(collection2), "", 0);
+                                 strlen(collection2), s_configs);
   assert(s == Ok);
   s = KVDKSortedSet(kvdk_engine, collection1, strlen(collection1), key1,
                     strlen(key1), value1, strlen(value1));
@@ -122,6 +124,7 @@ void SortedCollectionExample(KVDKEngine* kvdk_engine) {
   free(read_v2);
   KVDKDestorySortedCollection(collecton1_ptr);
   KVDKDestorySortedCollection(collecton2_ptr);
+  KVDKDestroySortedCollectionConfigs(s_configs);
   printf(
       "Successfully performed SortedGet, SortedSet, SortedDelete "
       "operations on named "
@@ -134,9 +137,10 @@ void SortedCollectinIterExample(KVDKEngine* kvdk_engine) {
                                  "5", "6", "7", "8", "9"};
   const char* sorted_collection = "sorted_collection";
   KVDKCollection* collecton_ptr;
+  KVDKSortedCollectionConfigs* s_configs = KVDKCreateSortedCollectionConfigs();
   KVDKStatus s =
       KVDKCreateSortedCollection(kvdk_engine, &collecton_ptr, sorted_collection,
-                                 strlen(sorted_collection), "", 0);
+                                 strlen(sorted_collection), s_configs);
   assert(s == Ok);
   for (int i = 0; i < 10; ++i) {
     char key[10] = "key", value[10] = "value";
@@ -200,6 +204,7 @@ void SortedCollectinIterExample(KVDKEngine* kvdk_engine) {
   printf("Successfully iterated through a sorted named collections.\n");
   KVDKDestroyIterator(kvdk_engine, kvdk_iter);
   KVDKDestorySortedCollection(collecton_ptr);
+  KVDKDestroySortedCollectionConfigs(s_configs);
 }
 
 int score_cmp(const char* a, size_t a_len, const char* b, size_t b_len) {
@@ -231,9 +236,10 @@ void CompFuncForSortedCollectionExample(KVDKEngine* kvdk_engine) {
   KVDKRegisterCompFunc(kvdk_engine, comp_name, strlen(comp_name), score_cmp);
   // create sorted collection
   KVDKCollection* collecton_ptr;
-  KVDKStatus s = KVDKCreateSortedCollection(kvdk_engine, &collecton_ptr,
-                                            collection, strlen(collection),
-                                            comp_name, strlen(comp_name));
+  KVDKSortedCollectionConfigs* s_configs = KVDKCreateSortedCollectionConfigs();
+  KVDKSetSortedCollectionConfigs(s_configs, comp_name, strlen(comp_name));
+  KVDKStatus s = KVDKCreateSortedCollection(
+      kvdk_engine, &collecton_ptr, collection, strlen(collection), s_configs);
   assert(s == Ok);
   for (int i = 0; i < 5; ++i) {
     s = KVDKSortedSet(kvdk_engine, collection, strlen(collection),
@@ -266,6 +272,7 @@ void CompFuncForSortedCollectionExample(KVDKEngine* kvdk_engine) {
   KVDKDestroyIterator(kvdk_engine, iter);
   printf("Successfully collections sorted by number.\n");
   KVDKDestorySortedCollection(collecton_ptr);
+  KVDKDestroySortedCollectionConfigs(s_configs);
 }
 
 void BatchWriteAnonCollectionExample(KVDKEngine* kvdk_engine) {
@@ -381,8 +388,8 @@ void ListsCollectionExample(KVDKEngine* kvdk_engine) {
 int main() {
   // Initialize a KVDK instance.
   KVDKConfigs* kvdk_configs = KVDKCreateConfigs();
-  KVDKUserConfigs(kvdk_configs, 48, 1ull << 20, 1u, 64u, 1ull << 8, 128u,
-                  1ull << 10, 1 << 4);
+  KVDKSetConfigs(kvdk_configs, 48, 1ull << 20, 1u, 64u, 1ull << 8, 128u,
+                 1ull << 10, 1 << 4);
 
   const char* engine_path = "/mnt/pmem0/tutorial_kvdk_example";
   // Purge old KVDK instance
@@ -412,7 +419,7 @@ int main() {
   // Listes Collection Example
   ListsCollectionExample(kvdk_engine);
 
-  KVDKConfigsDestory(kvdk_configs);
+  KVDKDestroyConfigs(kvdk_configs);
   KVDKCloseEngine(kvdk_engine);
   return 0;
 }

--- a/examples/tutorial/cpp_api_tutorial.cpp
+++ b/examples/tutorial/cpp_api_tutorial.cpp
@@ -274,8 +274,10 @@ static void test_customer_sorted_func() {
   engine->SetCompareFunc(comp_name, score_cmp);
   // create sorted collection
   kvdk::Collection* collection_ptr;
+  kvdk::SortedCollectionConfigs s_configs;
+  s_configs.compare_function_name = comp_name;
   kvdk::Status s =
-      engine->CreateSortedCollection(collection, &collection_ptr, comp_name);
+      engine->CreateSortedCollection(collection, &collection_ptr, s_configs);
   assert(s == Ok);
   for (int i = 0; i < 5; ++i) {
     s = engine->SSet(collection, array[i].number_key, array[i].value);

--- a/examples/tutorial/cpp_api_tutorial.cpp
+++ b/examples/tutorial/cpp_api_tutorial.cpp
@@ -271,11 +271,11 @@ static void test_customer_sorted_func() {
     else
       return -1;
   };
-  engine->RegisterCompareFunc(comp_name, score_cmp);
+  engine->RegisterComparator(comp_name, score_cmp);
   // create sorted collection
   kvdk::Collection* collection_ptr;
   kvdk::SortedCollectionConfigs s_configs;
-  s_configs.compare_function_name = comp_name;
+  s_configs.comparator_name = comp_name;
   kvdk::Status s =
       engine->CreateSortedCollection(collection, &collection_ptr, s_configs);
   assert(s == Ok);

--- a/examples/tutorial/cpp_api_tutorial.cpp
+++ b/examples/tutorial/cpp_api_tutorial.cpp
@@ -271,7 +271,7 @@ static void test_customer_sorted_func() {
     else
       return -1;
   };
-  engine->SetCompareFunc(comp_name, score_cmp);
+  engine->RegisterCompareFunc(comp_name, score_cmp);
   // create sorted collection
   kvdk::Collection* collection_ptr;
   kvdk::SortedCollectionConfigs s_configs;

--- a/include/kvdk/comparator.hpp
+++ b/include/kvdk/comparator.hpp
@@ -13,19 +13,26 @@
 
 namespace KVDK_NAMESPACE {
 using StringView = pmem::obj::string_view;
-using CompFunc =
+using CompareFunc =
     std::function<int(const StringView& src, const StringView& target)>;
 
-class Comparator {
+class ComparatorTable {
  public:
-  void RegisterComparaFunc(const StringView& compara_name, CompFunc comp_func) {
+  // Register a string compare function to the table
+  //
+  // Return true on success, return false if compara_name already existed
+  bool RegisterCompareFunc(const StringView& compara_name,
+                           CompareFunc comp_func) {
     std::string name(compara_name.data(), compara_name.size());
     if (compara_table_.find(name) == compara_table_.end()) {
       compara_table_.emplace(name, comp_func);
+      return true;
+    } else {
+      return false;
     }
   }
 
-  CompFunc GetComparaFunc(const StringView& compara_name) {
+  CompareFunc GetCompareFunc(const StringView& compara_name) {
     std::string name(compara_name.data(), compara_name.size());
     auto iter = compara_table_.find(name);
     if (iter != compara_table_.end()) {
@@ -35,6 +42,6 @@ class Comparator {
   };
 
  private:
-  std::unordered_map<std::string, CompFunc> compara_table_;
+  std::unordered_map<std::string, CompareFunc> compara_table_;
 };
 }  // namespace KVDK_NAMESPACE

--- a/include/kvdk/comparator.hpp
+++ b/include/kvdk/comparator.hpp
@@ -13,35 +13,37 @@
 
 namespace KVDK_NAMESPACE {
 using StringView = pmem::obj::string_view;
-using CompareFunc =
+using Comparator =
     std::function<int(const StringView& src, const StringView& target)>;
 
 class ComparatorTable {
  public:
   // Register a string compare function to the table
   //
-  // Return true on success, return false if compara_name already existed
-  bool RegisterCompareFunc(const StringView& compara_name,
-                           CompareFunc comp_func) {
-    std::string name(compara_name.data(), compara_name.size());
-    if (compara_table_.find(name) == compara_table_.end()) {
-      compara_table_.emplace(name, comp_func);
+  // Return true on success, return false if comparator_name already existed
+  bool RegisterComparator(const StringView& comparator_name,
+                          Comparator comp_func) {
+    std::string name(comparator_name.data(), comparator_name.size());
+    if (comparator_table_.find(name) == comparator_table_.end()) {
+      comparator_table_.emplace(name, comp_func);
       return true;
     } else {
       return false;
     }
   }
 
-  CompareFunc GetCompareFunc(const StringView& compara_name) {
-    std::string name(compara_name.data(), compara_name.size());
-    auto iter = compara_table_.find(name);
-    if (iter != compara_table_.end()) {
+  // Return a registered comparator "comparator_name" on success, return nullptr
+  // if it's not existing
+  Comparator GetComparator(const StringView& comparator_name) {
+    std::string name(comparator_name.data(), comparator_name.size());
+    auto iter = comparator_table_.find(name);
+    if (iter != comparator_table_.end()) {
       return iter->second;
     }
     return nullptr;
   };
 
  private:
-  std::unordered_map<std::string, CompareFunc> compara_table_;
+  std::unordered_map<std::string, Comparator> comparator_table_;
 };
 }  // namespace KVDK_NAMESPACE

--- a/include/kvdk/configs.hpp
+++ b/include/kvdk/configs.hpp
@@ -16,6 +16,7 @@ enum class LogLevel : uint8_t {
   Debug,
   Info,
   Error,
+  None,
 };
 
 // A snapshot indicates a immutable view of a KVDK engine at a certain time

--- a/include/kvdk/configs.hpp
+++ b/include/kvdk/configs.hpp
@@ -21,7 +21,7 @@ enum class LogLevel : uint8_t {
 struct Snapshot {};
 
 struct SortedCollectionConfigs {
-  std::string compare_function_name = "";
+  std::string compare_function_name = "default";
 };
 
 struct Configs {

--- a/include/kvdk/configs.hpp
+++ b/include/kvdk/configs.hpp
@@ -6,6 +6,7 @@
 
 #include <string>
 
+#include "comparator.hpp"
 #include "namespace.hpp"
 
 namespace KVDK_NAMESPACE {
@@ -20,6 +21,9 @@ enum class LogLevel : uint8_t {
 // A snapshot indicates a immutable view of a KVDK engine at a certain time
 struct Snapshot {};
 
+// Configs of created sorted collection
+// For correctness of encoding, please add new config field in the end of the
+// existing fields
 struct SortedCollectionConfigs {
   std::string compare_function_name = "default";
 };
@@ -127,6 +131,10 @@ struct Configs {
   // Notice: If opening a backup instance, this will always be set to true
   // during recovery.
   bool recover_to_checkpoint = false;
+
+  // If customer compare functions is used in a kvdk engine, these functions
+  // should be registered to the comparator before open engine
+  Comparator comparator;
 };
 
 }  // namespace KVDK_NAMESPACE

--- a/include/kvdk/configs.hpp
+++ b/include/kvdk/configs.hpp
@@ -20,6 +20,10 @@ enum class LogLevel : uint8_t {
 // A snapshot indicates a immutable view of a KVDK engine at a certain time
 struct Snapshot {};
 
+struct SortedCollectionConfigs {
+  std::string compare_function_name = "";
+};
+
 struct Configs {
   // Max number of access threads to read/write data to kvdk instance.
   //

--- a/include/kvdk/configs.hpp
+++ b/include/kvdk/configs.hpp
@@ -134,7 +134,7 @@ struct Configs {
 
   // If customer compare functions is used in a kvdk engine, these functions
   // should be registered to the comparator before open engine
-  Comparator comparator;
+  ComparatorTable comparator;
 };
 
 }  // namespace KVDK_NAMESPACE

--- a/include/kvdk/configs.hpp
+++ b/include/kvdk/configs.hpp
@@ -25,7 +25,7 @@ struct Snapshot {};
 // For correctness of encoding, please add new config field in the end of the
 // existing fields
 struct SortedCollectionConfigs {
-  std::string compare_function_name = "default";
+  std::string comparator_name = "default";
 };
 
 struct Configs {

--- a/include/kvdk/engine.h
+++ b/include/kvdk/engine.h
@@ -34,17 +34,26 @@ typedef struct KVDKWriteBatch KVDKWriteBatch;
 typedef struct KVDKIterator KVDKIterator;
 typedef struct KVDKCollection KVDKCollection;
 typedef struct KVDKSnapshot KVDKSnapshot;
+typedef struct KVDKSortedCollectionConfigs KVDKSortedCollectionConfigs;
 
 typedef enum { SORTED, HASH } KVDKIterType;
 
 extern KVDK_LIBRARY_API KVDKConfigs* KVDKCreateConfigs(void);
-extern KVDK_LIBRARY_API void KVDKUserConfigs(
+extern KVDK_LIBRARY_API void KVDKSetConfigs(
     KVDKConfigs* kv_config, uint64_t max_access_threads,
     uint64_t pmem_file_size, unsigned char populate_pmem_space,
     uint32_t pmem_block_size, uint64_t pmem_segment_blocks,
     uint32_t hash_bucket_size, uint64_t hash_bucket_num,
     uint32_t num_buckets_per_slot);
-extern KVDK_LIBRARY_API void KVDKConfigsDestory(KVDKConfigs* kv_config);
+extern KVDK_LIBRARY_API void KVDKDestroyConfigs(KVDKConfigs* kv_config);
+
+extern KVDK_LIBRARY_API KVDKSortedCollectionConfigs*
+KVDKCreateSortedCollectionConfigs();
+extern KVDK_LIBRARY_API void KVDKSetSortedCollectionConfigs(
+    KVDKSortedCollectionConfigs* configs, const char* comp_func_name,
+    size_t comp_func_len);
+extern KVDK_LIBRARY_API void KVDKDestroySortedCollectionConfigs(
+    KVDKSortedCollectionConfigs* configs);
 
 extern KVDK_LIBRARY_API KVDKStatus KVDKOpen(const char* name,
                                             const KVDKConfigs* config,
@@ -67,7 +76,7 @@ extern KVDK_LIBRARY_API void KVDKRegisterCompFunc(
 extern KVDK_LIBRARY_API KVDKStatus KVDKCreateSortedCollection(
     KVDKEngine* engine, KVDKCollection** sorted_collection,
     const char* collection_name, size_t collection_len,
-    const char* compara_name, size_t compara_len);
+    KVDKSortedCollectionConfigs* configs);
 
 extern KVDK_LIBRARY_API void KVDKDestorySortedCollection(
     KVDKCollection* collection);

--- a/include/kvdk/engine.h
+++ b/include/kvdk/engine.h
@@ -67,7 +67,7 @@ extern KVDK_LIBRARY_API KVDKSnapshot* KVDKGetSnapshot(KVDKEngine* engine,
 extern KVDK_LIBRARY_API void KVDKReleaseSnapshot(KVDKEngine* engine,
                                                  KVDKSnapshot* snapshot);
 
-extern KVDK_LIBRARY_API void KVDKRegisterCompFunc(
+extern KVDK_LIBRARY_API int KVDKRegisterCompFunc(
     KVDKEngine* engine, const char* compara_name, size_t compara_len,
     int (*compare)(const char* src, size_t src_len, const char* target,
                    size_t target_len));

--- a/include/kvdk/engine.hpp
+++ b/include/kvdk/engine.hpp
@@ -131,9 +131,8 @@ class Engine {
   // part. New write requests of this thread need to re-request write resources.
   virtual void ReleaseAccessThread() = 0;
 
-  virtual void SetCompareFunc(
-      const StringView& collection_name,
-      std::function<int(const StringView& src, const StringView& target)>) = 0;
+  virtual void RegisterCompareFunc(const StringView& collection_name,
+                                   CompFunc) = 0;
 
   // Close the instance on exit.
   virtual ~Engine() = 0;

--- a/include/kvdk/engine.hpp
+++ b/include/kvdk/engine.hpp
@@ -135,8 +135,8 @@ class Engine {
   //
   // Return true on success, return false if a comparator of comparator_name
   // already existed
-  virtual bool RegisterCompareFunc(const StringView& comparator_name,
-                                   CompareFunc) = 0;
+  virtual bool RegisterComparator(const StringView& comparator_name,
+                                  Comparator) = 0;
 
   // Close the instance on exit.
   virtual ~Engine() = 0;

--- a/include/kvdk/engine.hpp
+++ b/include/kvdk/engine.hpp
@@ -51,9 +51,9 @@ class Engine {
   // error.
   virtual Status Delete(const StringView key) = 0;
 
-  virtual Status CreateSortedCollection(const StringView collection_name,
-                                        Collection** sorted_collection,
-                                        const StringView& comp_name = "") = 0;
+  virtual Status CreateSortedCollection(
+      const StringView collection_name, Collection** sorted_collection,
+      const SortedCollectionConfigs& configs = SortedCollectionConfigs()) = 0;
 
   // Insert a SORTED-type KV to set "key" of sorted collection "collection"
   // to hold "value", if "collection" not exist, it will be created, return Ok

--- a/include/kvdk/engine.hpp
+++ b/include/kvdk/engine.hpp
@@ -131,8 +131,12 @@ class Engine {
   // part. New write requests of this thread need to re-request write resources.
   virtual void ReleaseAccessThread() = 0;
 
-  virtual void RegisterCompareFunc(const StringView& collection_name,
-                                   CompFunc) = 0;
+  // Register a customized comparator to the engine on runtime
+  //
+  // Return true on success, return false if a comparator of comparator_name
+  // already existed
+  virtual bool RegisterCompareFunc(const StringView& comparator_name,
+                                   CompareFunc) = 0;
 
   // Close the instance on exit.
   virtual ~Engine() = 0;

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -1514,9 +1514,9 @@ TEST_F(EngineBasicTest, TestSortedCustomCompareFunction) {
     return std::make_pair(k, std::string(1, v));
   });
 
-  // registed compare function
-  engine->SetCompareFunc("collection0_cmp", cmp0);
-  engine->SetCompareFunc("collection1_cmp", cmp1);
+  // register compare function
+  engine->RegisterCompareFunc("collection0_cmp", cmp0);
+  engine->RegisterCompareFunc("collection1_cmp", cmp1);
   for (size_t i = 0; i < collections.size(); ++i) {
     Collection* collection_ptr;
     Status s;
@@ -1541,6 +1541,15 @@ TEST_F(EngineBasicTest, TestSortedCustomCompareFunction) {
     };
     LaunchNThreads(threads, Write);
   }
+
+  delete engine;
+  // Reopen engine error as the comparator is not registered in configs
+  ASSERT_EQ(Engine::Open(db_path.c_str(), &engine, configs, stdout),
+            Status::Abort);
+  configs.comparator.RegisterComparaFunc("collection0_cmp", cmp0);
+  configs.comparator.RegisterComparaFunc("collection1_cmp", cmp1);
+  ASSERT_EQ(Engine::Open(db_path.c_str(), &engine, configs, stdout),
+            Status::Ok);
 
   for (size_t i = 0; i < collections.size(); ++i) {
     std::vector<kvpair> expected_res(dedup_kvs.begin(), dedup_kvs.end());

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -1522,8 +1522,10 @@ TEST_F(EngineBasicTest, TestSortedCustomCompareFunction) {
     Status s;
     if (i < 2) {
       std::string comp_name = "collection" + std::to_string(i) + "_cmp";
+      SortedCollectionConfigs s_configs;
+      s_configs.compare_function_name = comp_name;
       s = engine->CreateSortedCollection(collections[i], &collection_ptr,
-                                         comp_name);
+                                         s_configs);
     } else {
       s = engine->CreateSortedCollection(collections[i], &collection_ptr);
     }

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -1546,8 +1546,8 @@ TEST_F(EngineBasicTest, TestSortedCustomCompareFunction) {
   // Reopen engine error as the comparator is not registered in configs
   ASSERT_EQ(Engine::Open(db_path.c_str(), &engine, configs, stdout),
             Status::Abort);
-  configs.comparator.RegisterComparaFunc("collection0_cmp", cmp0);
-  configs.comparator.RegisterComparaFunc("collection1_cmp", cmp1);
+  configs.comparator.RegisterCompareFunc("collection0_cmp", cmp0);
+  configs.comparator.RegisterCompareFunc("collection1_cmp", cmp1);
   ASSERT_EQ(Engine::Open(db_path.c_str(), &engine, configs, stdout),
             Status::Ok);
 

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -1515,15 +1515,15 @@ TEST_F(EngineBasicTest, TestSortedCustomCompareFunction) {
   });
 
   // register compare function
-  engine->RegisterCompareFunc("collection0_cmp", cmp0);
-  engine->RegisterCompareFunc("collection1_cmp", cmp1);
+  engine->RegisterComparator("collection0_cmp", cmp0);
+  engine->RegisterComparator("collection1_cmp", cmp1);
   for (size_t i = 0; i < collections.size(); ++i) {
     Collection* collection_ptr;
     Status s;
     if (i < 2) {
       std::string comp_name = "collection" + std::to_string(i) + "_cmp";
       SortedCollectionConfigs s_configs;
-      s_configs.compare_function_name = comp_name;
+      s_configs.comparator_name = comp_name;
       s = engine->CreateSortedCollection(collections[i], &collection_ptr,
                                          s_configs);
     } else {
@@ -1546,8 +1546,8 @@ TEST_F(EngineBasicTest, TestSortedCustomCompareFunction) {
   // Reopen engine error as the comparator is not registered in configs
   ASSERT_EQ(Engine::Open(db_path.c_str(), &engine, configs, stdout),
             Status::Abort);
-  configs.comparator.RegisterCompareFunc("collection0_cmp", cmp0);
-  configs.comparator.RegisterCompareFunc("collection1_cmp", cmp1);
+  configs.comparator.RegisterComparator("collection0_cmp", cmp0);
+  configs.comparator.RegisterComparator("collection1_cmp", cmp1);
   ASSERT_EQ(Engine::Open(db_path.c_str(), &engine, configs, stdout),
             Status::Ok);
 

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -40,6 +40,8 @@ class EngineBasicTest : public testing::Test {
   virtual void SetUp() override {
     str_pool.resize(str_pool_length);
     random_str(&str_pool[0], str_pool_length);
+    // No logs by default, for debug, set it to All
+    configs.log_level = LogLevel::None;
     configs.pmem_file_size = (16ULL << 30);
     configs.populate_pmem_space = false;
     configs.hash_bucket_num = (1 << 10);
@@ -47,7 +49,6 @@ class EngineBasicTest : public testing::Test {
     configs.pmem_segment_blocks = 8 * 1024;
     // For faster test, no interval so it would not block engine closing
     configs.background_work_interval = 0.1;
-    configs.log_level = LogLevel::All;
     configs.max_access_threads = 1;
     db_path = "/mnt/pmem0/kvdk-test";
     backup_path = "/mnt/pmem0/kvdk-test-backup";
@@ -639,7 +640,6 @@ TEST_F(EngineBasicTest, TestSeek) {
             Status::Ok);
   uint64_t z = 0;
   auto zero_filled_str = uint64_to_string(z);
-  printf("%s\n", zero_filled_str.c_str());
   ASSERT_EQ(engine->SSet(collection, zero_filled_str, zero_filled_str),
             Status::Ok);
   ASSERT_EQ(engine->SGet(collection, zero_filled_str, &val), Status::Ok);


### PR DESCRIPTION
<!--
Thank you for contributing to KVDK.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

In current impl. customized compare function of sorted collections is not persisted on PMem, so these information will be lost in recovery.

### What is changed and how it works?

- Add a sorted collection configs struct in CreateSortedCollection API to specify compare function and other future configs
- Add functions to encode/decode sorted collection configs to/from a string, persist these string in value of SortedHeaderRecord followed by collection id
- Add comparator to engine configs, so the customized compare functions can be registered before open the engine
- In recovery, decode sorted collection configs from PMem so the customized compare functions can be recovered

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Stress test

Side effects

No
