### PR TITLE
PMemAllocator: Persist and repair allocated space size on PMem

### DIFF
--- a/engine/kv_engine.cpp
+++ b/engine/kv_engine.cpp
@@ -177,8 +177,7 @@ Status KVEngine::Init(const std::string& name, const Configs& configs) {
   startBackgroundWorks();
 
   ReportPMemUsage();
-  // kvdk_assert(pmem_allocator_->PMemUsageInBytes() >= 0, "Invalid PMem
-  // Usage");
+  kvdk_assert(pmem_allocator_->PMemUsageInBytes() >= 0, "Invalid PMem Usage");
   return s;
 }
 

--- a/engine/kv_engine.cpp
+++ b/engine/kv_engine.cpp
@@ -258,9 +258,10 @@ Status KVEngine::RestoreData() {
       fetch = true;
     }
     if (fetch) {
-      if (!pmem_allocator_->FreeAndFetchSegment(&segment_recovering)) {
+      if (!pmem_allocator_->FetchSegment(&segment_recovering)) {
         break;
       }
+      assert(segment_recovering.size % configs_.pmem_block_size == 0);
       fetch = false;
     }
 
@@ -268,10 +269,31 @@ Status KVEngine::RestoreData() {
         pmem_allocator_->offset2addr_checked(segment_recovering.offset);
     memcpy(&data_entry_cached, recovering_pmem_record, sizeof(DataEntry));
 
-    // reach the of of this segment or the segment is empty
     if (data_entry_cached.header.record_size == 0) {
-      fetch = true;
-      continue;
+      if (segment_recovering.size ==
+          configs_.pmem_segment_blocks * configs_.pmem_block_size) {
+        // A never allocated segment, continue fetch
+        fetch = true;
+        continue;
+      } else {
+        // Iter through data blocks until find a valid size space entry or reach
+        // end of the segment
+        PMemOffsetType offset =
+            segment_recovering.offset + configs_.pmem_block_size;
+        uint64_t size = segment_recovering.size - configs_.pmem_block_size;
+        while (size > 0 &&
+               pmem_allocator_->offset2addr_checked<DataHeader>(offset)
+                       ->record_size == 0) {
+          size -= configs_.pmem_block_size;
+          offset += configs_.pmem_block_size;
+        }
+        uint64_t padding_size = offset - segment_recovering.offset;
+        DataEntry* recovering_pmem_data_entry =
+            static_cast<DataEntry*>(recovering_pmem_record);
+        recovering_pmem_data_entry->header.record_size = padding_size;
+        recovering_pmem_data_entry->meta.type = RecordType::Padding;
+        data_entry_cached = *recovering_pmem_data_entry;
+      }
     }
 
     segment_recovering.size -= data_entry_cached.header.record_size;
@@ -1051,9 +1073,6 @@ Status KVEngine::SDeleteImpl(Skiplist* skiplist, const StringView& user_key) {
 
     if (!need_write_delete_record) {
       if (sized_space_entry.size > 0) {
-        // We must mark a allocated but unused space on PMem, otherwise data may
-        // lost in recovery
-        markEmptySpace(sized_space_entry);
         pmem_allocator_->Free(sized_space_entry);
       }
       return s;
@@ -1327,14 +1346,6 @@ Status KVEngine::BatchWrite(const WriteBatch& write_batch) {
   std::set<SpinMutex*> spins_to_lock;
   std::vector<BatchWriteHint> batch_hints(write_batch.Size());
   std::vector<uint64_t> space_entry_offsets;
-  auto free_space_on_failure = [&]() {
-    for (size_t i = 0; i < batch_hints.size(); i++) {
-      if (batch_hints[i].allocated_space.size > 0) {
-        this->markEmptySpace(batch_hints[i].allocated_space);
-        this->pmem_allocator_->Free(batch_hints[i].allocated_space);
-      }
-    }
-  };
 
   for (size_t i = 0; i < write_batch.Size(); i++) {
     auto& kv = write_batch.kvs[i];
@@ -1350,7 +1361,6 @@ Status KVEngine::BatchWrite(const WriteBatch& write_batch) {
     batch_hints[i].allocated_space = pmem_allocator_->Allocate(requested_size);
     // No enough space for batch write
     if (batch_hints[i].allocated_space.size == 0) {
-      free_space_on_failure();
       return Status::PmemOverflow;
     }
     space_entry_offsets.emplace_back(batch_hints[i].allocated_space.offset);
@@ -1386,7 +1396,6 @@ Status KVEngine::BatchWrite(const WriteBatch& write_batch) {
       s = StringBatchWriteImpl(write_batch.kvs[i], batch_hints[i]);
       TEST_SYNC_POINT_CALLBACK("KVEnigne::BatchWrite::BatchWriteRecord", &i);
     } else {
-      free_space_on_failure();
       return Status::NotSupported;
     }
 
@@ -1444,9 +1453,6 @@ Status KVEngine::StringBatchWriteImpl(const WriteBatch::KV& kv,
     // Deleting kv is not existing
     if (kv.type == StringDeleteRecord && !found) {
       batch_hint.space_not_used = true;
-      // We must mark a allocated but unused space on PMem, otherwise data may
-      // lost in recovery
-      markEmptySpace(batch_hint.allocated_space);
       return Status::Ok;
     }
 

--- a/engine/kv_engine.hpp
+++ b/engine/kv_engine.hpp
@@ -336,14 +336,6 @@ class KVEngine : public Engine {
                    data_entry->header.record_size));
   }
 
-  // Mark an unused space on PMem
-  inline void markEmptySpace(const SpaceEntry& space_entry) {
-    DataHeader header(0, space_entry.size);
-    pmem_memcpy_persist(
-        pmem_allocator_->offset2addr_checked(space_entry.offset), &header,
-        sizeof(DataHeader));
-  }
-
   // Run in background to clean old records regularly
   void backgroundOldRecordCleaner();
 

--- a/engine/pmem_allocator/pmem_allocator.cpp
+++ b/engine/pmem_allocator/pmem_allocator.cpp
@@ -154,6 +154,7 @@ bool PMEMAllocator::FetchSegment(SpaceEntry* segment_space_entry) {
       offset2addr<DataHeader>(offset_head_)->record_size != 0) {
     *segment_space_entry = SpaceEntry{offset_head_, segment_size_};
     offset_head_ += segment_size_;
+    LogAllocation(-1, segment_size_);
     return true;
   }
   return false;

--- a/engine/pmem_allocator/pmem_allocator.cpp
+++ b/engine/pmem_allocator/pmem_allocator.cpp
@@ -149,7 +149,7 @@ PMEMAllocator* PMEMAllocator::NewPMEMAllocator(
 bool PMEMAllocator::FetchSegment(SpaceEntry* segment_space_entry) {
   assert(segment_space_entry);
 
-  std::lock_guard<SpinMutex> lg(segment_lock_);
+  std::lock_guard<SpinMutex> lg(offset_head_lock_);
   if (offset_head_ <= pmem_size_ - segment_size_ &&
       offset2addr<DataHeader>(offset_head_)->record_size != 0) {
     *segment_space_entry = SpaceEntry{offset_head_, segment_size_};
@@ -161,7 +161,7 @@ bool PMEMAllocator::FetchSegment(SpaceEntry* segment_space_entry) {
 }
 
 bool PMEMAllocator::allocateSegmentSpace(SpaceEntry* segment_entry) {
-  std::lock_guard<SpinMutex> lg(segment_lock_);
+  std::lock_guard<SpinMutex> lg(offset_head_lock_);
   if (offset_head_ <= pmem_size_ - segment_size_) {
     *segment_entry = SpaceEntry{offset_head_, segment_size_};
     offset_head_ += segment_size_;
@@ -387,7 +387,7 @@ Status PMEMAllocator::Backup(const std::string& backup_file_path) {
   memcpy(backup_file, pmem_, copy_offset_1st_end);
   //  multi_thread_memcpy((char *)backup_file, pmem_, copy_offset_1st, 4);
   {
-    std::lock_guard<SpinMutex> lg(segment_lock_);
+    std::lock_guard<SpinMutex> lg(offset_head_lock_);
     copy_offset_2nd_end = offset_head_;
   }
   memcpy((char*)backup_file + copy_offset_2nd_start,

--- a/engine/pmem_allocator/pmem_allocator.hpp
+++ b/engine/pmem_allocator/pmem_allocator.hpp
@@ -89,8 +89,10 @@ class PMEMAllocator : public Allocator {
     return offset < pmem_size_ && offset != kNullPMemOffset;
   }
 
-  // Free segment_space_entry and fetch an allocated segment to
-  // segment_space_entry, until reach the end of allocated space
+  // Try to fetch an used segment to segment_space_entry, until reach the a
+  // never used segment or end of pmem space
+  //
+  // Notice: Please only use this function in recovery
   bool FetchSegment(SpaceEntry* segment_space_entry);
 
   // Regularly execute by background thread of KVDK
@@ -168,7 +170,7 @@ class PMEMAllocator : public Allocator {
   void persistSpaceEntry(PMemOffsetType offset, uint64_t size);
 
   // Protect PMem offset head
-  SpinMutex offset_head_lock_;
+  SpinMutex segment_lock_;
   uint64_t offset_head_;
   std::vector<PAllocThreadCache, AlignedAllocator<PAllocThreadCache>>
       palloc_thread_cache_;

--- a/engine/pmem_allocator/pmem_allocator.hpp
+++ b/engine/pmem_allocator/pmem_allocator.hpp
@@ -170,7 +170,7 @@ class PMEMAllocator : public Allocator {
   void persistSpaceEntry(PMemOffsetType offset, uint64_t size);
 
   // Protect PMem offset head
-  SpinMutex segment_lock_;
+  SpinMutex offset_head_lock_;
   uint64_t offset_head_;
   std::vector<PAllocThreadCache, AlignedAllocator<PAllocThreadCache>>
       palloc_thread_cache_;

--- a/engine/pmem_allocator/pmem_allocator.hpp
+++ b/engine/pmem_allocator/pmem_allocator.hpp
@@ -91,7 +91,7 @@ class PMEMAllocator : public Allocator {
 
   // Free segment_space_entry and fetch an allocated segment to
   // segment_space_entry, until reach the end of allocated space
-  bool FreeAndFetchSegment(SpaceEntry* segment_space_entry);
+  bool FetchSegment(SpaceEntry* segment_space_entry);
 
   // Regularly execute by background thread of KVDK
   void BackgroundWork() { free_list_.OrganizeFreeSpace(); }
@@ -145,9 +145,6 @@ class PMEMAllocator : public Allocator {
 
   static bool checkDevDaxAndGetSize(const char* path, uint64_t* size);
 
-  // Mark and persist a space entry on PMem
-  void persistSpaceEntry(PMemOffsetType offset, uint64_t size);
-
   // Populate PMem space so the following access can be faster
   // Warning! this will zero the entire PMem space
   void populateSpace();
@@ -166,6 +163,9 @@ class PMEMAllocator : public Allocator {
     }
     return data_size / block_size_ + (data_size % block_size_ == 0 ? 0 : 1);
   }
+
+  // Mark and persist a space entry on PMem
+  void persistSpaceEntry(PMemOffsetType offset, uint64_t size);
 
   // Protect PMem offset head
   SpinMutex offset_head_lock_;

--- a/tests/test_pmem_allocator.cpp
+++ b/tests/test_pmem_allocator.cpp
@@ -62,6 +62,7 @@ TEST_F(EnginePMemAllocatorTest, TestBasicAlloc) {
       auto TestPmemAlloc = [&](uint64_t id) {
         std::vector<SpaceEntry> records;
         thread_manager_->MaybeInitThread(access_thread);
+        remove(pmem_path.c_str());
         PMEMAllocator* pmem_alloc = PMEMAllocator::NewPMEMAllocator(
             pmem_path, pmem_size, num_segment_blocks[i], block_sizes[i],
             num_thread, true, false, nullptr);


### PR DESCRIPTION
<!--
Thank you for contributing to KVDK.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Allocated space of PMemAllocator is not persisted on PMem, for correctness in recovery, we need to manually mark a unused space while free it if we do not write data on it, which is error prone

### What is changed and how it works?

What's Changed:

1. Mark space size on PMem while we split a large reused free space entry
2. While allocate from a new allocated segment, as the content must be 0, it's easy to restore the actual allocation size in recovery, so we do not persist size in allocation for performance consideration
3. Size of a un-splited reused free space entry must be persisted in previous usage, so we do not need to persist its size in allocation

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Stress test

Side effects

We need a extra persist operation while split a large free space entry, so the update performance  can be decreased

- string: < ~1%
- collections: no significant change
