### PR TITLE
Fix Unit Test failure for UnorderedCollection

### DIFF
--- a/engine/kv_engine.cpp
+++ b/engine/kv_engine.cpp
@@ -1855,7 +1855,7 @@ Status KVEngine::RestoreDlistRecords(DLRecord* pmp_record) {
       std::string collection_name = p_collection->Name();
       HashTable::KeyHashHint hint_collection =
           hash_table_->GetHint(collection_name);
-      std::unique_lock<SpinMutex>{*hint_collection.spin};
+      std::unique_lock<SpinMutex> guard{*hint_collection.spin};
 
       HashEntry hash_entry_collection;
       HashEntry* p_hash_entry_collection = nullptr;


### PR DESCRIPTION
Signed-off-by: ZiyanShi <ziyan.shi@intel.com>

<!--
Thank you for contributing to KVDK.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

Problem Summary:
A std::unique_lock does not lock the HashTable appropriately during recovery, causing some Insertion by other threads overwritten by this insertion.

### What is changed and how it works?
Repair the syntax error.

Tests <!-- At least one of them must be included. -->

- Unit test
