### PR TITLE
Fix memory access errors in dbtest when there's no sufficient disk space

### DIFF
--- a/engine/kv_engine.cpp
+++ b/engine/kv_engine.cpp
@@ -80,6 +80,12 @@ void KVEngine::FreeSkiplistDramNodes() {
 }
 
 void KVEngine::ReportPMemUsage() {
+  // Check pmem allocator is initialized before use it.
+  // It may not be successfully initialized due to file operation errors.
+  if (pmem_allocator_ == nullptr) {
+    return;
+  }
+
   auto total = pmem_allocator_->PMemUsageInBytes();
   GlobalLogger.Info("PMem Usage: %ld B, %ld KB, %ld MB, %ld GB\n", total,
                     (total / (1LL << 10)), (total / (1LL << 20)),

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -80,7 +80,7 @@ class EngineBasicTest : public testing::Test {
       return false;
     } else {
       ReopenEngine();
-      return true;
+      return engine != nullptr;
     }
   }
 


### PR DESCRIPTION
<!--
Thank you for contributing to KVDK.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Problem Summary: to fix possible dump errors when running `dbtest` if there is no enough disk space.

`dbtest` will stop when such memory access errors happen:

```
root@a3d19aa4582a:/git/kvdk/build# ./tests/dbtest
[==========] Running 23 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 23 tests from EngineBasicTest
[ RUN      ] EngineBasicTest.TestThreadManager
[       OK ] EngineBasicTest.TestThreadManager (3035 ms)
[ RUN      ] EngineBasicTest.TestBasicSnapshot
ASAN:DEADLYSIGNAL
=================================================================
==19647==ERROR: AddressSanitizer: SEGV on unknown address 0x000000000018 (pc 0x7f5b4063506f bp 0x7fffd6796c20 sp 0x7fffd6796c10 T0)
==19647==The signal is caused by a READ memory access.
==19647==Hint: address points to the zero page.
...
```


### What is changed and how it works?

What's Changed:
* Added some check logic to make `dbtest` more robust

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
