### PR TITLE
Quick fix wrong error message by logger

### DIFF
--- a/engine/kv_engine.cpp
+++ b/engine/kv_engine.cpp
@@ -355,10 +355,10 @@ Status KVEngine::RestoreData() {
       }
       default: {
         // Report Corrupted Record, but still release it and continues
-        GlobalLogger.Error(
+        GlobalLogger.Debug(
             "Corrupted Record met when recovering. It has invalid "
-            "type. Record type: %u\n",
-            data_entry_cached.meta.type);
+            "type. Record type: %u, Checksum: %u\n",
+            data_entry_cached.meta.type, data_entry_cached.header.checksum);
         data_entry_cached.meta.type = RecordType::Padding;
         break;
       }

--- a/engine/kv_engine.cpp
+++ b/engine/kv_engine.cpp
@@ -355,7 +355,7 @@ Status KVEngine::RestoreData() {
       }
       default: {
         // Report Corrupted Record, but still release it and continues
-        GlobalLogger.Debug(
+        GlobalLogger.Error(
             "Corrupted Record met when recovering. It has invalid "
             "type. Record type: %u, Checksum: %u\n",
             data_entry_cached.meta.type, data_entry_cached.header.checksum);

--- a/engine/kv_engine.cpp
+++ b/engine/kv_engine.cpp
@@ -359,6 +359,7 @@ Status KVEngine::RestoreData() {
             "Corrupted Record met when recovering. It has invalid "
             "type. Record type: %u, Checksum: %u\n",
             data_entry_cached.meta.type, data_entry_cached.header.checksum);
+        kvdk_assert(data_entry_cached.header.checksum == 0, "");
         data_entry_cached.meta.type = RecordType::Padding;
         break;
       }

--- a/engine/pmem_allocator/pmem_allocator.cpp
+++ b/engine/pmem_allocator/pmem_allocator.cpp
@@ -301,7 +301,9 @@ SpaceEntry PMEMAllocator::Allocate(uint64_t size) {
 }
 
 void PMEMAllocator::persistSpaceEntry(PMemOffsetType offset, uint64_t size) {
-  DataEntry padding{0, size, TimeStampType{}, RecordType::Padding, 0, 0};
+  std::uint32_t sz = static_cast<std::uint32_t>(size);
+  kvdk_assert(size == static_cast<std::uint64_t>(sz), "Integer Overflow!");
+  DataEntry padding{0, sz, TimeStampType{}, RecordType::Padding, 0, 0};
   pmem_memcpy_persist(offset2addr_checked(offset), &padding, sizeof(DataEntry));
 }
 

--- a/engine/pmem_allocator/pmem_allocator.cpp
+++ b/engine/pmem_allocator/pmem_allocator.cpp
@@ -301,8 +301,8 @@ SpaceEntry PMEMAllocator::Allocate(uint64_t size) {
 }
 
 void PMEMAllocator::persistSpaceEntry(PMemOffsetType offset, uint64_t size) {
-  DataHeader header(0, size);
-  pmem_memcpy_persist(offset2addr_checked(offset), &header, sizeof(DataHeader));
+  DataEntry padding{0, size, TimeStampType{}, RecordType::Padding, 0, 0};
+  pmem_memcpy_persist(offset2addr_checked(offset), &padding, sizeof(DataEntry));
 }
 
 Status PMEMAllocator::Backup(const std::string& backup_file_path) {

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -41,7 +41,7 @@ class EngineBasicTest : public testing::Test {
     str_pool.resize(str_pool_length);
     random_str(&str_pool[0], str_pool_length);
     // No logs by default, for debug, set it to All
-    configs.log_level = LogLevel::None;
+    configs.log_level = LogLevel::All;
     configs.pmem_file_size = (16ULL << 30);
     configs.populate_pmem_space = false;
     configs.hash_bucket_num = (1 << 10);


### PR DESCRIPTION
Signed-off-by: ZiyanShi <ziyan.shi@intel.com>

<!--
Thank you for contributing to KVDK.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Issue Number: close #xxx <!-- REMOVE this line if no issue to close -->

Problem Summary:
Logger gives wrong error message. When a `SpaceEntry` is sliced by `PMemAllocator`, the half at back will have wrong type, which during recovery will raise a error message in `RestoreData()`. This is expected behavior and should not be treated as error.

Tests <!-- At least one of them must be included. -->

- Unit test

