### PR TITLE
Handle no-hash-indexed delete record in record cleaner, and fix un-deleted engine in test

### DIFF
--- a/engine/hash_table.cpp
+++ b/engine/hash_table.cpp
@@ -44,35 +44,35 @@ bool HashEntry::Match(const StringView& key, uint32_t hash_k_prefix,
     StringView data_entry_key;
 
     switch (header_.index_type) {
-      case HashIndexType::Empty: {
+      case PointerType::Empty: {
         return false;
       }
-      case HashIndexType::StringRecord: {
+      case PointerType::StringRecord: {
         pmem_record = index_.string_record;
         data_entry_key = index_.string_record->Key();
         break;
       }
-      case HashIndexType::UnorderedCollectionElement:
-      case HashIndexType::DLRecord: {
+      case PointerType::UnorderedCollectionElement:
+      case PointerType::DLRecord: {
         pmem_record = index_.dl_record;
         data_entry_key = index_.dl_record->Key();
         break;
       }
-      case HashIndexType::List: {
+      case PointerType::List: {
         data_entry_key = index_.list->Name();
         break;
       }
-      case HashIndexType::UnorderedCollection: {
+      case PointerType::UnorderedCollection: {
         data_entry_key = index_.p_unordered_collection->Name();
         break;
       }
-      case HashIndexType::SkiplistNode: {
+      case PointerType::SkiplistNode: {
         SkiplistNode* dram_node = index_.skiplist_node;
         pmem_record = dram_node->record;
         data_entry_key = dram_node->record->Key();
         break;
       }
-      case HashIndexType::Skiplist: {
+      case PointerType::Skiplist: {
         Skiplist* skiplist = index_.skiplist;
         pmem_record = skiplist->Header()->record;
         data_entry_key = skiplist->Name();
@@ -81,7 +81,7 @@ bool HashEntry::Match(const StringView& key, uint32_t hash_k_prefix,
       default: {
         GlobalLogger.Error("Not supported hash index type: %u\n",
                            header_.index_type);
-        assert(false && "Trying to use invalid HashIndexType!");
+        assert(false && "Trying to use invalid PointerType!");
         return false;
       }
     }
@@ -231,7 +231,7 @@ Status HashTable::SearchForRead(const KeyHashHint& hint, const StringView& key,
 
 void HashTable::Insert(const KeyHashHint& hint, HashEntry* entry_ptr,
                        RecordType record_type, void* index,
-                       HashIndexType index_type) {
+                       PointerType index_type) {
   HashEntry new_hash_entry(hint.key_hash_value >> 32, record_type, index,
                            index_type);
   atomic_store_16(entry_ptr, &new_hash_entry);

--- a/engine/hash_table.hpp
+++ b/engine/hash_table.hpp
@@ -18,30 +18,10 @@
 #include "structures.hpp"
 
 namespace KVDK_NAMESPACE {
-enum class HashIndexType : uint16_t {
-  // Value initialized considered as Invalid
-  Invalid = 0,
-  // Index is PMem offset of a string record
-  StringRecord = 1,
-  // Index is PMem offset of a doubly linked record
-  DLRecord = 2,
-  // Index is pointer to a dram skiplist node
-  SkiplistNode = 3,
-  // Index is pointer to a dram skiplist struct
-  Skiplist = 4,
-  // Index field contains pointer to UnorderedCollection object on DRAM
-  UnorderedCollection = 5,
-  // Index field contains PMem pointer to element of UnorderedCollection
-  UnorderedCollectionElement = 6,
-  List = 7,
-  // Index is empty which point to nothing
-  Empty = 8,
-};
-
 struct HashHeader {
   uint32_t key_prefix;
   RecordType record_type;
-  HashIndexType index_type;
+  PointerType index_type;
 };
 
 class Skiplist;
@@ -68,17 +48,17 @@ struct alignas(16) HashEntry {
   HashEntry() = default;
 
   HashEntry(uint32_t key_hash_prefix, RecordType record_type, void* _index,
-            HashIndexType index_type)
+            PointerType index_type)
       : header_({key_hash_prefix, record_type, index_type}), index_(_index) {}
 
-  bool Empty() { return header_.index_type == HashIndexType::Empty; }
+  bool Empty() { return header_.index_type == PointerType::Empty; }
 
   // Make this hash entry empty while its content been deleted
-  void Clear() { header_.index_type = HashIndexType::Empty; }
+  void Clear() { header_.index_type = PointerType::Empty; }
 
   Index GetIndex() const { return index_; }
 
-  HashIndexType GetIndexType() const { return header_.index_type; }
+  PointerType GetIndexType() const { return header_.index_type; }
 
   RecordType GetRecordType() const { return header_.record_type; }
 
@@ -158,7 +138,7 @@ class HashTable {
   //
   // entry_ptr: position to insert, it's get from SearchForWrite()
   void Insert(const KeyHashHint& hint, HashEntry* entry_ptr, RecordType type,
-              void* index, HashIndexType index_type);
+              void* index, PointerType index_type);
 
   // Erase a hash entry so it can be reused in future
   void Erase(HashEntry* entry_ptr) {

--- a/engine/kv_engine.cpp
+++ b/engine/kv_engine.cpp
@@ -941,7 +941,8 @@ Status KVEngine::SDeleteImpl(Skiplist* skiplist, const StringView& user_key) {
               "Wrong existing record type while insert a delete reocrd for "
               "sorted collection");
           delayFree(OldDataRecord{ret.existing_record, new_ts});
-          delayFree(OldDeleteRecord{ret.write_record, new_ts});
+          delayFree(OldDeleteRecord{ret.write_record, new_ts,
+                                    ret.hash_entry_ptr, hint.spin});
         }
         return ret.s;
       default:

--- a/engine/kv_engine.cpp
+++ b/engine/kv_engine.cpp
@@ -942,14 +942,17 @@ Status KVEngine::SDeleteImpl(Skiplist* skiplist, const StringView& user_key) {
               "sorted collection");
           delayFree(OldDataRecord{ret.existing_record, new_ts});
           if (ret.hash_entry_ptr != nullptr) {
+            // delete record indexed by hash table
             delayFree(OldDeleteRecord(ret.write_record, ret.hash_entry_ptr,
                                       PointerType::HashEntry, new_ts,
                                       hint.spin));
           } else if (ret.dram_node != nullptr) {
+            // no hash index, by a skiplist node points to delete record
             delayFree(OldDeleteRecord(ret.write_record, ret.dram_node,
                                       PointerType::SkiplistNode, new_ts,
                                       hint.spin));
           } else {
+            // delete record nor pointed by hash entry nor skiplist node
             delayFree(OldDeleteRecord(ret.write_record, nullptr,
                                       PointerType::Empty, new_ts, hint.spin));
           }

--- a/engine/kv_engine.hpp
+++ b/engine/kv_engine.hpp
@@ -240,38 +240,38 @@ class KVEngine : public Engine {
                            : RecordType::Empty;
   }
 
-  static HashIndexType pointerType(RecordType rtype) {
+  static PointerType pointerType(RecordType rtype) {
     switch (rtype) {
       case RecordType::Empty: {
-        return HashIndexType::Empty;
+        return PointerType::Empty;
       }
       case RecordType::StringDataRecord:
       case RecordType::StringDeleteRecord: {
-        return HashIndexType::StringRecord;
+        return PointerType::StringRecord;
       }
       case RecordType::SortedDataRecord:
       case RecordType::SortedDeleteRecord: {
         kvdk_assert(false, "Not supported!");
-        return HashIndexType::Invalid;
+        return PointerType::Invalid;
       }
       case RecordType::SortedHeaderRecord: {
-        return HashIndexType::Skiplist;
+        return PointerType::Skiplist;
       }
       case RecordType::DlistDataRecord: {
-        return HashIndexType::UnorderedCollectionElement;
+        return PointerType::UnorderedCollectionElement;
       }
       case RecordType::DlistRecord: {
-        return HashIndexType::UnorderedCollection;
+        return PointerType::UnorderedCollection;
       }
       case RecordType::ListRecord: {
-        return HashIndexType::List;
+        return PointerType::List;
       }
       case RecordType::DlistHeadRecord:
       case RecordType::ListElem:
       default: {
         /// TODO: Remove Expire Flag
         kvdk_assert(false, "Invalid type!");
-        return HashIndexType::Invalid;
+        return PointerType::Invalid;
       }
     }
   }
@@ -327,8 +327,8 @@ class KVEngine : public Engine {
       return Status::Abort;
     }
 
-    HashIndexType ptype = pointerType(type);
-    kvdk_assert(ptype != HashIndexType::Invalid, "Invalid pointer type!");
+    PointerType ptype = pointerType(type);
+    kvdk_assert(ptype != PointerType::Invalid, "Invalid pointer type!");
     hash_table_->Insert(hint, entry_ptr, type, coll, ptype);
     return Status::Ok;
   }

--- a/engine/sorted_collection/rebuilder.cpp
+++ b/engine/sorted_collection/rebuilder.cpp
@@ -82,7 +82,7 @@ Status SortedCollectionRebuilder::AddHeader(DLRecord* header_record) {
       make_shared<Skiplist>(header_record, collection_name, id, comparator,
                             kv_engine_->pmem_allocator_,
                             kv_engine_->hash_table_,
-                            s_configs.index_with_hashtable && invalid_skiplist /* we do not build hash index for a invalid skiplist as it will be destroyed soon */);
+                            s_configs.index_with_hashtable && !invalid_skiplist /* we do not build hash index for a invalid skiplist as it will be destroyed soon */);
 
   if (invalid_skiplist) {
     std::lock_guard<SpinMutex> lg(lock_);

--- a/engine/sorted_collection/rebuilder.cpp
+++ b/engine/sorted_collection/rebuilder.cpp
@@ -105,7 +105,7 @@ Status SortedCollectionRebuilder::AddHeader(DLRecord* header_record) {
 
     // Always index skiplist header with hash table
     s = insertHashIndex(skiplist->Name(), skiplist.get(),
-                        HashIndexType::Skiplist);
+                        PointerType::Skiplist);
   }
   return s;
 }
@@ -230,7 +230,7 @@ Status SortedCollectionRebuilder::rebuildSegmentIndex(SkiplistNode* start_node,
   if (build_hash_index &&
       start_node->record->entry.meta.type != SortedHeaderRecord) {
     s = insertHashIndex(start_node->record->Key(), start_node,
-                        HashIndexType::SkiplistNode);
+                        PointerType::SkiplistNode);
     if (s != Status::Ok) {
       return s;
     }
@@ -289,10 +289,10 @@ Status SortedCollectionRebuilder::rebuildSegmentIndex(SkiplistNode* start_node,
           if (build_hash_index) {
             if (dram_node) {
               s = insertHashIndex(internal_key, dram_node,
-                                  HashIndexType::SkiplistNode);
+                                  PointerType::SkiplistNode);
             } else {
               s = insertHashIndex(internal_key, valid_version_record,
-                                  HashIndexType::DLRecord);
+                                  PointerType::DLRecord);
             }
 
             if (s != Status::Ok) {
@@ -457,10 +457,10 @@ Status SortedCollectionRebuilder::rebuildSkiplistIndex(Skiplist* skiplist) {
           Status s;
           if (dram_node) {
             s = insertHashIndex(internal_key, dram_node,
-                                HashIndexType::SkiplistNode);
+                                PointerType::SkiplistNode);
           } else {
             s = insertHashIndex(internal_key, valid_version_record,
-                                HashIndexType::DLRecord);
+                                PointerType::DLRecord);
           }
 
           if (s != Status::Ok) {
@@ -498,11 +498,8 @@ Status SortedCollectionRebuilder::listBasedIndexRebuild() {
 }
 
 bool SortedCollectionRebuilder::checkRecordLinkage(DLRecord* record) {
-  PMEMAllocator* pmem_allocator = kv_engine_->pmem_allocator_.get();
-  uint64_t offset = pmem_allocator->addr2offset_checked(record);
-  DLRecord* prev = pmem_allocator->offset2addr_checked<DLRecord>(record->prev);
-  DLRecord* next = pmem_allocator->offset2addr_checked<DLRecord>(record->next);
-  return prev->next == offset && next->prev == offset;
+  return Skiplist::CheckRecordLinkage(record,
+                                      kv_engine_->pmem_allocator_.get());
 }
 
 bool SortedCollectionRebuilder::checkAndRepairRecordLinkage(DLRecord* record) {
@@ -555,17 +552,17 @@ void SortedCollectionRebuilder::addRecoverySegment(SkiplistNode* start_node) {
 
 Status SortedCollectionRebuilder::insertHashIndex(const StringView& key,
                                                   void* index_ptr,
-                                                  HashIndexType index_type) {
+                                                  PointerType index_type) {
   uint16_t search_type_mask;
   RecordType record_type;
-  if (index_type == HashIndexType::DLRecord) {
+  if (index_type == PointerType::DLRecord) {
     search_type_mask = SortedDataRecord | SortedDeleteRecord;
     record_type = static_cast<DLRecord*>(index_ptr)->entry.meta.type;
-  } else if (index_type == HashIndexType::SkiplistNode) {
+  } else if (index_type == PointerType::SkiplistNode) {
     search_type_mask = SortedDataRecord | SortedDeleteRecord;
     record_type =
         static_cast<SkiplistNode*>(index_ptr)->record->entry.meta.type;
-  } else if (index_type == HashIndexType::Skiplist) {
+  } else if (index_type == PointerType::Skiplist) {
     search_type_mask = SortedHeaderRecord;
     record_type = SortedHeaderRecord;
   }

--- a/engine/sorted_collection/rebuilder.hpp
+++ b/engine/sorted_collection/rebuilder.hpp
@@ -106,7 +106,7 @@ class SortedCollectionRebuilder {
   // insert hash index "ptr" for "key", the key should be locked before call
   // this function
   Status insertHashIndex(const StringView& key, void* ptr,
-                         HashIndexType index_type);
+                         PointerType index_type);
 
   void addUnlinkedRecord(DLRecord* pmem_record) {
     assert(access_thread.id >= 0);

--- a/engine/sorted_collection/skiplist.cpp
+++ b/engine/sorted_collection/skiplist.cpp
@@ -622,6 +622,7 @@ Skiplist::WriteResult Skiplist::deleteImplWithHash(
           prev_offset, next_offset, internal_key, "");
       linkDLRecord(prev_record, next_record, delete_record);
       ret.write_record = delete_record;
+      ret.hash_entry_ptr = entry_ptr;
 
       break;
     }
@@ -696,6 +697,7 @@ Skiplist::WriteResult Skiplist::setImplWithHash(
           space_to_write.size, timestamp, SortedDataRecord, existing_offset,
           prev_offset, next_offset, internal_key, value);
       ret.write_record = new_record;
+      ret.hash_entry_ptr = entry_ptr;
       linkDLRecord(prev_record, next_record, new_record);
 
       break;

--- a/engine/sorted_collection/skiplist.cpp
+++ b/engine/sorted_collection/skiplist.cpp
@@ -61,13 +61,13 @@ void Skiplist::SeekNode(const StringView& key, SkiplistNode* start_node,
   std::vector<SkiplistNode*> to_delete;
   assert(start_node->height >= start_height && end_height >= 1);
   SkiplistNode* prev = start_node;
-  PointerWithTag<SkiplistNode> next;
+  PointerWithTag<SkiplistNode, SkiplistNode::NodeStatus> next;
   for (uint8_t i = start_height; i >= end_height; i--) {
     uint64_t round = 0;
     while (1) {
       next = prev->Next(i);
       // prev is logically deleted, roll back to prev height.
-      if (next.GetTag()) {
+      if (next.GetTag() == SkiplistNode::NodeStatus::Deleted) {
         if (i < start_height) {
           i++;
           prev = result_splice->prevs[i];
@@ -93,7 +93,7 @@ void Skiplist::SeekNode(const StringView& key, SkiplistNode* start_node,
 
       // Physically remove deleted "next" nodes from skiplist
       auto next_next = next->Next(i);
-      if (next_next.GetTag()) {
+      if (next_next.GetTag() == SkiplistNode::NodeStatus::Deleted) {
         if (prev->CASNext(i, next, next_next.RawPointer())) {
           if (--next->valid_links == 0) {
             to_delete.push_back(next.RawPointer());
@@ -197,7 +197,7 @@ Status Skiplist::CheckIndex() {
         return Status::Abort;
       }
 
-      if (hash_entry.GetIndexType() == HashIndexType::SkiplistNode) {
+      if (hash_entry.GetIndexType() == PointerType::SkiplistNode) {
         if (hash_entry.GetIndex().skiplist_node != next_node) {
           return Status::Abort;
         }
@@ -480,11 +480,11 @@ Status Skiplist::Get(const StringView& key, std::string* value) {
 
     DLRecord* pmem_record;
     switch (hash_entry.GetIndexType()) {
-      case HashIndexType::SkiplistNode: {
+      case PointerType::SkiplistNode: {
         pmem_record = hash_entry.GetIndex().skiplist_node->record;
         break;
       }
-      case HashIndexType::DLRecord: {
+      case PointerType::DLRecord: {
         pmem_record = hash_entry.GetIndex().dl_record;
         break;
       }
@@ -584,12 +584,12 @@ Skiplist::WriteResult Skiplist::deleteImplWithHash(
         return ret;
       }
 
-      if (hash_entry.GetIndexType() == HashIndexType::SkiplistNode) {
+      if (hash_entry.GetIndexType() == PointerType::SkiplistNode) {
         ret.dram_node = hash_entry.GetIndex().skiplist_node;
         ret.existing_record = ret.dram_node->record;
       } else {
         ret.dram_node = nullptr;
-        assert(hash_entry.GetIndexType() == HashIndexType::DLRecord);
+        assert(hash_entry.GetIndexType() == PointerType::DLRecord);
         ret.existing_record = hash_entry.GetIndex().dl_record;
       }
       assert(timestamp > ret.existing_record->entry.meta.timestamp);
@@ -634,11 +634,11 @@ Skiplist::WriteResult Skiplist::deleteImplWithHash(
   assert(ret.write_record != nullptr);
   if (ret.dram_node == nullptr) {
     hash_table_->Insert(locked_hash_hint, entry_ptr, SortedDeleteRecord,
-                        ret.write_record, HashIndexType::DLRecord);
+                        ret.write_record, PointerType::DLRecord);
   } else {
     ret.dram_node->record = ret.write_record;
     hash_table_->Insert(locked_hash_hint, entry_ptr, SortedDeleteRecord,
-                        ret.dram_node, HashIndexType::SkiplistNode);
+                        ret.dram_node, PointerType::SkiplistNode);
   }
 
   return ret;
@@ -660,12 +660,12 @@ Skiplist::WriteResult Skiplist::setImplWithHash(
 
   switch (ret.s) {
     case Status::Ok: {
-      if (hash_entry.GetIndexType() == HashIndexType::SkiplistNode) {
+      if (hash_entry.GetIndexType() == PointerType::SkiplistNode) {
         ret.dram_node = hash_entry.GetIndex().skiplist_node;
         ret.existing_record = ret.dram_node->record;
       } else {
         ret.dram_node = nullptr;
-        assert(hash_entry.GetIndexType() == HashIndexType::DLRecord);
+        assert(hash_entry.GetIndexType() == PointerType::DLRecord);
         ret.existing_record = hash_entry.GetIndex().dl_record;
       }
       assert(timestamp > ret.existing_record->entry.meta.timestamp);
@@ -721,11 +721,11 @@ Skiplist::WriteResult Skiplist::setImplWithHash(
   assert(ret.write_record != nullptr);
   if (ret.dram_node == nullptr) {
     hash_table_->Insert(locked_hash_hint, entry_ptr, SortedDataRecord,
-                        ret.write_record, HashIndexType::DLRecord);
+                        ret.write_record, PointerType::DLRecord);
   } else {
     ret.dram_node->record = ret.write_record;
     hash_table_->Insert(locked_hash_hint, entry_ptr, SortedDataRecord,
-                        ret.dram_node, HashIndexType::SkiplistNode);
+                        ret.dram_node, PointerType::SkiplistNode);
   }
 
   return ret;
@@ -801,7 +801,7 @@ Skiplist::WriteResult Skiplist::setImplNoHash(
           auto now_next = splice.prevs[i]->Next(i);
           // if next has been changed or been deleted, re-compute
           if (now_next.RawPointer() == splice.nexts[i] &&
-              now_next.GetTag() == 0) {
+              now_next.GetTag() == SkiplistNode::NodeStatus::Normal) {
             ret.dram_node->RelaxedSetNext(i, splice.nexts[i]);
             if (splice.prevs[i]->CASNext(i, splice.nexts[i], ret.dram_node)) {
               break;

--- a/engine/sorted_collection/skiplist.hpp
+++ b/engine/sorted_collection/skiplist.hpp
@@ -30,8 +30,12 @@ struct Splice;
  * */
 struct SkiplistNode {
  public:
+  enum class NodeStatus : uint8_t {
+    Normal = 0,
+    Deleted = 1,
+  };
   // Tagged pointers means this node has been logically removed from the list
-  std::atomic<PointerWithTag<SkiplistNode>> next[0];
+  std::atomic<PointerWithTag<SkiplistNode, NodeStatus>> next[0];
   // Doubly linked record on PMem
   DLRecord* record;
   // TODO: save memory
@@ -75,28 +79,28 @@ struct SkiplistNode {
 
   CollectionIDType SkiplistID();
 
-  PointerWithTag<SkiplistNode> Next(int l) {
+  PointerWithTag<SkiplistNode, NodeStatus> Next(int l) {
     assert(l > 0 && l <= height && "should be less than node's height");
     return next[-l].load(std::memory_order_acquire);
   }
 
-  bool CASNext(int l, PointerWithTag<SkiplistNode> expected,
-               PointerWithTag<SkiplistNode> x) {
+  bool CASNext(int l, PointerWithTag<SkiplistNode, NodeStatus> expected,
+               PointerWithTag<SkiplistNode, NodeStatus> x) {
     assert(l > 0 && l <= height && "should be less than node's height");
     return (next[-l].compare_exchange_strong(expected, x));
   }
 
-  PointerWithTag<SkiplistNode> RelaxedNext(int l) {
+  PointerWithTag<SkiplistNode, NodeStatus> RelaxedNext(int l) {
     assert(l > 0 && l <= height && "should be less than node's height");
     return next[-l].load(std::memory_order_relaxed);
   }
 
-  void SetNext(int l, PointerWithTag<SkiplistNode> x) {
+  void SetNext(int l, PointerWithTag<SkiplistNode, NodeStatus> x) {
     assert(l > 0 && l <= height && "should be less than node's height");
     next[-l].store(x, std::memory_order_release);
   }
 
-  void RelaxedSetNext(int l, PointerWithTag<SkiplistNode> x) {
+  void RelaxedSetNext(int l, PointerWithTag<SkiplistNode, NodeStatus> x) {
     assert(l > 0 && l <= height && "should be less than node's height");
     next[-l].store(x, std::memory_order_relaxed);
   }
@@ -107,10 +111,11 @@ struct SkiplistNode {
       while (1) {
         auto next = RelaxedNext(l);
         // This node alread tagged by another thread
-        if (next.GetTag()) {
+        if (next.GetTag() == NodeStatus::Deleted) {
           continue;
         }
-        auto tagged = PointerWithTag<SkiplistNode>(next.RawPointer(), 1);
+        auto tagged = PointerWithTag<SkiplistNode, NodeStatus>(
+            next.RawPointer(), NodeStatus::Deleted);
         if (CASNext(l, next, tagged)) {
           break;
         }
@@ -226,6 +231,17 @@ class Skiplist : public Collection {
   Status CheckIndex();
 
   void CleanObsoletedNodes();
+
+  // Check if record correctly linked on list
+  static bool CheckRecordLinkage(DLRecord* record,
+                                 PMEMAllocator* pmem_allocator) {
+    uint64_t offset = pmem_allocator->addr2offset_checked(record);
+    DLRecord* prev =
+        pmem_allocator->offset2addr_checked<DLRecord>(record->prev);
+    DLRecord* next =
+        pmem_allocator->offset2addr_checked<DLRecord>(record->next);
+    return prev->next == offset && next->prev == offset;
+  }
 
   // Purge a dl record from its skiplist by remove it from linkage
   //
@@ -430,7 +446,8 @@ struct Splice {
         assert(seeking_list != nullptr);
         start_height = kMaxHeight;
         start_node = seeking_list->Header();
-      } else if (prevs[start_height]->Next(start_height).GetTag()) {
+      } else if (prevs[start_height]->Next(start_height).GetTag() ==
+                 SkiplistNode::NodeStatus::Deleted) {
         // If prev on this height has been deleted, roll back to higher height
         start_height++;
         continue;

--- a/engine/sorted_collection/skiplist.hpp
+++ b/engine/sorted_collection/skiplist.hpp
@@ -154,6 +154,7 @@ class Skiplist : public Collection {
     DLRecord* existing_record = nullptr;
     DLRecord* write_record = nullptr;
     SkiplistNode* dram_node = nullptr;
+    HashEntry* hash_entry_ptr = nullptr;
   };
 
   Skiplist(DLRecord* h, const std::string& name, CollectionIDType id,

--- a/engine/structures.hpp
+++ b/engine/structures.hpp
@@ -38,52 +38,52 @@ enum class PointerType : uint8_t {
 };
 
 // A pointer with additional information on high 16 bits
-template <typename T_Pointer, typename T_Tag>
+template <typename PointerType, typename TagType>
 class PointerWithTag {
  public:
   static constexpr uint64_t kPointerMask = (((uint64_t)1 << 48) - 1);
 
   // TODO: Maybe explicit
-  PointerWithTag(T_Pointer* pointer) : tagged_pointer((uint64_t)pointer) {
-    assert(sizeof(T_Tag) <= 2);
+  PointerWithTag(PointerType* pointer) : tagged_pointer((uint64_t)pointer) {
+    assert(sizeof(TagType) <= 2);
   }
 
-  explicit PointerWithTag(T_Pointer* pointer, T_Tag tag)
+  explicit PointerWithTag(PointerType* pointer, TagType tag)
       : tagged_pointer((uint64_t)pointer | ((uint64_t)tag << 48)) {
-    assert(sizeof(T_Tag) <= 2);
+    assert(sizeof(TagType) <= 2);
   }
 
   PointerWithTag() : tagged_pointer(0) {}
 
-  T_Pointer* RawPointer() {
-    return (T_Pointer*)(tagged_pointer & kPointerMask);
+  PointerType* RawPointer() {
+    return (PointerType*)(tagged_pointer & kPointerMask);
   }
 
-  const T_Pointer* RawPointer() const {
-    return (const T_Pointer*)(tagged_pointer & kPointerMask);
+  const PointerType* RawPointer() const {
+    return (const PointerType*)(tagged_pointer & kPointerMask);
   }
 
   bool Null() const { return RawPointer() == nullptr; }
 
-  T_Tag GetTag() const { return static_cast<T_Tag>(tagged_pointer >> 48); }
+  TagType GetTag() const { return static_cast<TagType>(tagged_pointer >> 48); }
 
   void ClearTag() { tagged_pointer &= kPointerMask; }
 
-  void SetTag(T_Tag tag) { tagged_pointer |= ((uint64_t)tag << 48); }
+  void SetTag(TagType tag) { tagged_pointer |= ((uint64_t)tag << 48); }
 
-  const T_Pointer& operator*() const { return *RawPointer(); }
+  const PointerType& operator*() const { return *RawPointer(); }
 
-  T_Pointer& operator*() { return *(RawPointer()); }
+  PointerType& operator*() { return *(RawPointer()); }
 
-  const T_Pointer* operator->() const { return RawPointer(); }
+  const PointerType* operator->() const { return RawPointer(); }
 
-  T_Pointer* operator->() { return RawPointer(); }
+  PointerType* operator->() { return RawPointer(); }
 
-  bool operator==(const T_Pointer* raw_pointer) {
+  bool operator==(const PointerType* raw_pointer) {
     return RawPointer() == raw_pointer;
   }
 
-  bool operator==(const T_Pointer* raw_pointer) const {
+  bool operator==(const PointerType* raw_pointer) const {
     return RawPointer() == raw_pointer;
   }
 

--- a/engine/version/old_records_cleaner.hpp
+++ b/engine/version/old_records_cleaner.hpp
@@ -38,7 +38,7 @@ struct OldDeleteRecord {
       : pmem_delete_record(_pmem_delete_record),
         release_time(_release_time),
         key_lock(_key_lock),
-        index_pointer(_record_index, _index_type) {}
+        record_index(_record_index, _index_type) {}
 
   void* pmem_delete_record;
   // Indicate timestamp of the oldest refered snapshot of kvdk instance while we
@@ -50,7 +50,7 @@ struct OldDeleteRecord {
   //
   // The tag of pointer indicates the type of pointer, like hash ptr or skiplist
   // node
-  RecordIndex index_pointer;
+  RecordIndex record_index;
   SpinMutex* key_lock;
 };
 

--- a/examples/graph_sim/src/graph_impl.cpp
+++ b/examples/graph_sim/src/graph_impl.cpp
@@ -329,7 +329,7 @@ Status GraphSimulator::GetTopN(
     edge_list.EdgeListDecode(&value);
     top_n.Push(std::make_pair(vertex, edge_list.Num()));
   }
-
+  delete iter;
   if (top_n.Size() == 0) {
     return Status::Abort;
   }

--- a/examples/graph_sim/src/graph_impl_test.cpp
+++ b/examples/graph_sim/src/graph_impl_test.cpp
@@ -216,6 +216,7 @@ TEST_F(GraphSimulatorTest, MemoryEngineTest) {
     ASSERT_EQ(it->Key().c_str(), "key" + std::to_string(i));
     i++;
   }
+  delete it;
   delete kv_engine;
 }
 

--- a/examples/graph_sim/src/kv_engines/kvdk.cpp
+++ b/examples/graph_sim/src/kv_engines/kvdk.cpp
@@ -66,8 +66,14 @@ Status PMemKVDK::Delete(const std::string& key) {
 
 class PMemKVDKIterator : public KVEngine::Iterator {
  public:
-  explicit PMemKVDKIterator(kvdk::Iterator* it) : iter_(it) {}
-  ~PMemKVDKIterator() = default;
+  explicit PMemKVDKIterator(kvdk::Iterator* it, kvdk::Engine* engine)
+      : iter_(it), engine_(engine) {}
+
+  ~PMemKVDKIterator() {
+    if (iter_) {
+      engine_->ReleaseSortedIterator(iter_);
+    }
+  }
 
   void Seek(const std::string& key) override { iter_->Seek(key); }
   void SeekToFirst() override { iter_->SeekToFirst(); }
@@ -78,14 +84,15 @@ class PMemKVDKIterator : public KVEngine::Iterator {
   std::string Value() override { return iter_->Value(); }
 
  private:
-  kvdk::Iterator* iter_;
+  kvdk::Iterator* iter_ = nullptr;
+  kvdk::Engine* engine_ = nullptr;
 };
 
 KVEngine::Iterator* PMemKVDK::NewIterator() {
   if (!collection_.empty()) {
     // TODO fix snapshot
     auto it = db_->NewSortedIterator(collection_);
-    return new PMemKVDKIterator(it);
+    return new PMemKVDKIterator(it, db_);
   }
   return nullptr;
 }

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -650,6 +650,8 @@ TEST_F(EngineBasicTest, TestStringModify) {
   std::string val;
   ASSERT_EQ(engine->Get(plus_key, &val), Status::Ok);
   ASSERT_EQ(std::stoi(val), ops_per_thread * num_threads);
+
+  delete engine;
 }
 
 TEST_F(EngineBasicTest, TestBatchWrite) {

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -1812,21 +1812,21 @@ TEST_F(EngineBasicTest, TestHashTableIterator) {
       auto end_bucket_iter = slot_iter.End();
       while (bucket_iter != end_bucket_iter) {
         switch (bucket_iter->GetIndexType()) {
-          case HashIndexType::StringRecord: {
+          case PointerType::StringRecord: {
             total_entry_num++;
             ASSERT_EQ(string_view_2_string(
                           bucket_iter->GetIndex().string_record->Value()),
                       "stringval");
             break;
           }
-          case HashIndexType::Skiplist: {
+          case PointerType::Skiplist: {
             total_entry_num++;
             ASSERT_EQ(
                 string_view_2_string(bucket_iter->GetIndex().skiplist->Name()),
                 collection_name);
             break;
           }
-          case HashIndexType::SkiplistNode: {
+          case PointerType::SkiplistNode: {
             total_entry_num++;
             ASSERT_EQ(
                 string_view_2_string(
@@ -1834,7 +1834,7 @@ TEST_F(EngineBasicTest, TestHashTableIterator) {
                 "sortedval");
             break;
           }
-          case HashIndexType::DLRecord: {
+          case PointerType::DLRecord: {
             total_entry_num++;
             ASSERT_EQ(string_view_2_string(
                           bucket_iter->GetIndex().dl_record->Value()),
@@ -1842,8 +1842,8 @@ TEST_F(EngineBasicTest, TestHashTableIterator) {
             break;
           }
           default:
-            ASSERT_EQ((bucket_iter->GetIndexType() == HashIndexType::Invalid) ||
-                          (bucket_iter->GetIndexType() == HashIndexType::Empty),
+            ASSERT_EQ((bucket_iter->GetIndexType() == PointerType::Invalid) ||
+                          (bucket_iter->GetIndexType() == PointerType::Empty),
                       true);
             break;
         }
@@ -2389,7 +2389,7 @@ TEST_F(EngineBasicTest, TestHashTableRangeIter) {
       auto bucket_iter = slot_iter.Begin();
       auto end_bucket_iter = slot_iter.End();
       while (bucket_iter != end_bucket_iter) {
-        if (bucket_iter->GetIndexType() == HashIndexType::StringRecord) {
+        if (bucket_iter->GetIndexType() == PointerType::StringRecord) {
           TEST_SYNC_POINT("ScanHashTable");
           sleep(2);
           ASSERT_EQ(bucket_iter->GetIndex().string_record->Key(), key);


### PR DESCRIPTION
What's Changed:

- Fix: Engine not deleted in TestStringModify
- Cleaner: Handle old delete record of skiplist which not indexed by hash table
- Reorg PointerWithTag to make it more clear