### PR TITLE
Use heap memory for checksum verification

### DIFF
--- a/engine/kv_engine.cpp
+++ b/engine/kv_engine.cpp
@@ -874,6 +874,7 @@ Status KVEngine::HashGetImpl(const StringView& key, std::string* value,
       continue;
     }
 
+    // TODO. remove checksum validation when unordered_collection supports mvcc
     void* data_buffer = malloc(record_size);
     memcpy(data_buffer, pmem_record, record_size);
     // If the pmem data record is corrupted or modified during get, redo search

--- a/engine/kv_engine.cpp
+++ b/engine/kv_engine.cpp
@@ -873,14 +873,18 @@ Status KVEngine::HashGetImpl(const StringView& key, std::string* value,
     if (record_size > configs_.pmem_segment_blocks * configs_.pmem_block_size) {
       continue;
     }
-    char data_buffer[record_size];
+
+    void* data_buffer = malloc(record_size);
     memcpy(data_buffer, pmem_record, record_size);
     // If the pmem data record is corrupted or modified during get, redo search
-    if (ValidateRecordAndGetValue(data_buffer, data_entry.header.checksum,
-                                  value)) {
+    bool valid = ValidateRecordAndGetValue(data_buffer,
+                                           data_entry.header.checksum, value);
+    free(data_buffer);
+    if (valid) {
       break;
     }
   }
+
   return Status::Ok;
 }
 

--- a/examples/tutorial/c_api_tutorial.c
+++ b/examples/tutorial/c_api_tutorial.c
@@ -48,6 +48,7 @@ void AnonymousCollectionExample(KVDKEngine* kvdk_engine) {
   assert(s == Ok);
   cmp = CmpCompare(read_v1, read_v1_len, value1, value1_len);
   assert(cmp == 0);
+  free(read_v1);
   s = KVDKSet(kvdk_engine, key1, key1_len, value2, value2_len, write_option);
   assert(s == Ok);
   s = KVDKGet(kvdk_engine, key1, key1_len, &read_v1_len, &read_v1);
@@ -100,6 +101,7 @@ void SortedCollectionExample(KVDKEngine* kvdk_engine) {
   assert(s == Ok);
   cmp = CmpCompare(read_v1, read_v1_len, value1, strlen(value1));
   assert(cmp == 0);
+  free(read_v1);
   s = KVDKSortedSet(kvdk_engine, collection1, strlen(collection1), key1,
                     strlen(key1), value2, strlen(value2));
   assert(s == Ok);

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -848,6 +848,24 @@ TEST_F(EngineBasicTest, TestStringRestore) {
   delete engine;
 }
 
+TEST_F(EngineBasicTest, TestStringLargeValue) {
+  configs.pmem_block_size = (1UL << 6);
+  configs.pmem_segment_blocks = (1UL << 24);
+  ASSERT_EQ(Engine::Open(db_path.c_str(), &engine, configs, stdout),
+            Status::Ok);
+
+  for (size_t sz = 1024; sz < (1UL << 30); sz *= 2) {
+    std::string key{"large"};
+    std::string value(sz, 'a');
+    std::string sink;
+
+    ASSERT_EQ(engine->Set(key, value), Status::Ok);
+    ASSERT_EQ(engine->Get(key, &sink), Status::Ok);
+    ASSERT_EQ(value, sink);
+  }
+  delete engine;
+}
+
 TEST_F(EngineBasicTest, TestSortedRestore) {
   int num_threads = 16;
   configs.max_access_threads = num_threads;


### PR DESCRIPTION
Signed-off-by: Yu, Peng <peng.yu@intel.com>

<!--
Thank you for contributing to KVDK.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Problem Summary: Use heap memory for checksum verification to avoid stack overflow.

### What is changed and how it works?


What's Changed:

* use heap memory for data buffer before verifying checksum
* add an unit test for large string values
* fix some memory leak issues in `c_api_tutorial`

Tests <!-- At least one of them must be included. -->

- Unit test

