### PR TITLE
Fix BatchWrite deadlock

### DIFF
--- a/engine/kv_engine.cpp
+++ b/engine/kv_engine.cpp
@@ -1206,7 +1206,7 @@ Status KVEngine::BatchWrite(const WriteBatch& write_batch) {
     }
   }
 
-  // Must release all spinlocks before delayFree(), 
+  // Must release all spinlocks before delayFree(),
   // otherwise may deadlock as delayFree() also try to acquire these spinlocks.
   ul_locks.clear();
 

--- a/engine/kv_engine.cpp
+++ b/engine/kv_engine.cpp
@@ -1206,10 +1206,10 @@ Status KVEngine::BatchWrite(const WriteBatch& write_batch) {
     }
   }
 
+  ul_locks.clear();
+
   engine_thread_cache_[access_thread.id]
       .persisted_pending_batch->PersistFinish();
-
-  std::string val;
 
   // Free updated kvs, we should purge all updated kvs before release locks
   // and after persist write stage

--- a/engine/kv_engine.cpp
+++ b/engine/kv_engine.cpp
@@ -1206,6 +1206,8 @@ Status KVEngine::BatchWrite(const WriteBatch& write_batch) {
     }
   }
 
+  // Must release all spinlocks before delayFree(), 
+  // otherwise may deadlock as delayFree() also try to acquire these spinlocks.
   ul_locks.clear();
 
   engine_thread_cache_[access_thread.id]

--- a/engine/kv_engine.cpp
+++ b/engine/kv_engine.cpp
@@ -1213,8 +1213,7 @@ Status KVEngine::BatchWrite(const WriteBatch& write_batch) {
   engine_thread_cache_[access_thread.id]
       .persisted_pending_batch->PersistFinish();
 
-  // Free updated kvs, we should purge all updated kvs before release locks
-  // and after persist write stage
+  // Free outdated kvs
   for (size_t i = 0; i < write_batch.Size(); i++) {
     TEST_SYNC_POINT_CALLBACK("KVEngine::BatchWrite::purgeAndFree::Before", &i);
     if (batch_hints[i].data_record_to_free != nullptr) {


### PR DESCRIPTION
Signed-off-by: ZiyanShi <ziyan.shi@intel.com>

<!--
Thank you for contributing to KVDK.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Fix a BatchWrite deadlock caused by acquiring locks in delayFree() in BatchWrite.

Tests <!-- At least one of them must be included. -->

- Unit test
