### PR TITLE
fix pmem allocator test

### DIFF
--- a/tests/test_pmem_allocator.cpp
+++ b/tests/test_pmem_allocator.cpp
@@ -52,51 +52,50 @@ TEST_F(EnginePMemAllocatorTest, TestBasicAlloc) {
   // params config
   std::vector<uint64_t> num_segment_blocks{1024, 2 * 1024, 2 * 1024 * 1024};
   std::vector<uint32_t> block_sizes{32, 64};
-  std::vector<uint32_t> num_threads = {1, 16};
+  uint32_t single_thread = 1;
 
   for (auto num_segment_block : num_segment_blocks) {
-    for (auto block_size : block_sizes)
-      for (auto num_thread : num_threads) {
-        thread_manager_.reset(new ThreadManager(num_thread));
-        // Test function.
-        auto TestPmemAlloc = [&](size_t) {
-          std::vector<SpaceEntry> records;
-          thread_manager_->MaybeInitThread(access_thread);
-          remove(pmem_path.c_str());
-          PMEMAllocator* pmem_alloc = PMEMAllocator::NewPMEMAllocator(
-              pmem_path, pmem_size, num_segment_block, block_size, num_thread,
-              true, false, nullptr);
-          ASSERT_NE(pmem_alloc, nullptr);
+    for (auto block_size : block_sizes) {
+      thread_manager_.reset(new ThreadManager(single_thread));
+      // Test function.
+      auto TestPmemAlloc = [&](size_t) {
+        std::vector<SpaceEntry> records;
+        thread_manager_->MaybeInitThread(access_thread);
+        remove(pmem_path.c_str());
+        PMEMAllocator* pmem_alloc = PMEMAllocator::NewPMEMAllocator(
+            pmem_path, pmem_size, num_segment_block, block_size, single_thread,
+            true, false, nullptr);
+        ASSERT_NE(pmem_alloc, nullptr);
 
-          uint64_t kvpairs = pmem_size / block_size;
-          for (uint64_t j = 0; j < kvpairs; ++j) {
-            auto space_entry = pmem_alloc->Allocate(alloc_size);
-            records.push_back(space_entry);
-          }
+        uint64_t kvpairs = pmem_size / block_size;
+        for (uint64_t j = 0; j < kvpairs; ++j) {
+          auto space_entry = pmem_alloc->Allocate(alloc_size);
+          records.push_back(space_entry);
+        }
 
-          auto alloc_bytes = pmem_alloc->PMemUsageInBytes();
+        auto alloc_bytes = pmem_alloc->PMemUsageInBytes();
 
-          for (uint64_t j = 0; j < records.size(); ++j) {
-            pmem_alloc->Free(records[j]);
-          }
+        for (uint64_t j = 0; j < records.size(); ++j) {
+          pmem_alloc->Free(records[j]);
+        }
 
-          ASSERT_EQ(pmem_alloc->PMemUsageInBytes(), 0LL);
-          records.clear();
+        ASSERT_EQ(pmem_alloc->PMemUsageInBytes(), 0LL);
+        records.clear();
 
-          uint64_t alloc_cnt = 1;
-          // again allocate pmem
-          while (true) {
-            auto space_entry = pmem_alloc->Allocate(alloc_size);
-            ASSERT_EQ(space_entry.size != 0, true);
-            if (pmem_alloc->PMemUsageInBytes() == alloc_bytes) break;
-            alloc_cnt++;
-          }
-          ASSERT_EQ(kvpairs, alloc_cnt);
-          delete pmem_alloc;
-        };
+        uint64_t alloc_cnt = 1;
+        // again allocate pmem
+        while (true) {
+          auto space_entry = pmem_alloc->Allocate(alloc_size);
+          ASSERT_EQ(space_entry.size != 0, true);
+          if (pmem_alloc->PMemUsageInBytes() == alloc_bytes) break;
+          alloc_cnt++;
+        }
+        ASSERT_EQ(kvpairs, alloc_cnt);
+        delete pmem_alloc;
+      };
 
-        LaunchNThreads(num_thread, TestPmemAlloc);
-      }
+      LaunchNThreads(single_thread, TestPmemAlloc);
+    }
   }
 }
 


### PR DESCRIPTION


### What problem does this PR solve?
Fix pmem allocator test case:  remove `block_size` is 16 case.

Problem Summary:
  1. `DataEntry`  is 24 bytes, the min `block_size` is 32.
  2.  Mistakenly delete code.

Tests
- Unit test
    test_pmem_allocator
    bench_allacator
- Integration test
- No code

Side effects
   No
