### PR TITLE
Bugfix: Clean old delete reocrds for no-hash-indexed sorted collection

### DIFF
--- a/engine/sorted_collection/skiplist.hpp
+++ b/engine/sorted_collection/skiplist.hpp
@@ -244,6 +244,14 @@ class Skiplist : public Collection {
     return prev->next == offset && next->prev == offset;
   }
 
+  static bool CheckReocrdNextLinkage(DLRecord* record,
+                                     PMEMAllocator* pmem_allocator) {
+    uint64_t offset = pmem_allocator->addr2offset_checked(record);
+    DLRecord* next =
+        pmem_allocator->offset2addr_checked<DLRecord>(record->next);
+    return next->prev == offset;
+  }
+
   // Purge a dl record from its skiplist by remove it from linkage
   //
   // purged_record:existing record to purge

--- a/engine/version/old_records_cleaner.cpp
+++ b/engine/version/old_records_cleaner.cpp
@@ -289,7 +289,7 @@ SpaceEntry OldRecordsCleaner::purgeOldDeleteRecord(
         case PointerType::Empty: {
           // This record is not indexed by hash table and skiplist node, so we
           // check linkage to determine if its already been purged
-          if (Skiplist::CheckRecordLinkage(
+          if (Skiplist::CheckReocrdNextLinkage(
                   static_cast<DLRecord*>(old_delete_record.pmem_delete_record),
                   kv_engine_->pmem_allocator_.get())) {
             need_purge = true;

--- a/engine/version/old_records_cleaner.cpp
+++ b/engine/version/old_records_cleaner.cpp
@@ -289,6 +289,9 @@ SpaceEntry OldRecordsCleaner::purgeOldDeleteRecord(
         case PointerType::Empty: {
           // This record is not indexed by hash table and skiplist node, so we
           // check linkage to determine if its already been purged
+          //
+          // We only check the next linkage, as the delete record is already
+          // been locked, its next linkage will not be changed by other threads.
           if (Skiplist::CheckReocrdNextLinkage(
                   static_cast<DLRecord*>(old_delete_record.pmem_delete_record),
                   kv_engine_->pmem_allocator_.get())) {


### PR DESCRIPTION
Problem Summary:

In current implementation, in a no-hash-indexed sorted collection, while a delete record with no DRAM node  been handled by cleaner, the cleaner will check its linkage (prev and next) to determine if it's on list.

However, as the prev record is not locked, during the check, a new record may be inserted between the delete record and its prev record, so the check will fail even the delete record is linked.

What's Changed:

Only check next linkage of delete record. as the delete record is already been locked in cleaner, its next linkage will not be changed by other threads.

Side effects

No
