### PR TITLE
Bugfix: Expire negative TTL

### DIFF
--- a/engine/kv_engine.cpp
+++ b/engine/kv_engine.cpp
@@ -1420,8 +1420,8 @@ Status KVEngine::Expire(const StringView str, TTLType ttl_time) {
                                   version_controller_.GetCurrentTimestamp(),
                                   hint.spin});
       }
-      return Status::NotFound;
     }
+    return Status::NotFound;
   }
 
   if (res.s == Status::Ok) {

--- a/engine/kv_engine.cpp
+++ b/engine/kv_engine.cpp
@@ -1458,9 +1458,11 @@ Status KVEngine::Expire(const StringView str, TTLType ttl_time) {
       }
     }
     // Update hash entry status to TTL
-    hash_table_->UpdateEntryStatus(res.entry_ptr, expired_time == kPersistTime
-                                                      ? HashEntryStatus::Persist
+    if (res.s == Status::Ok) {
+      hash_table_->UpdateEntryStatus(
+          res.entry_ptr, expired_time == kPersistTime ? HashEntryStatus::Persist
                                                       : HashEntryStatus::TTL);
+    }
   }
   return res.s;
 }


### PR DESCRIPTION
<!--
Thank you for contributing to KVDK.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Problem Summary:

While expire a key with negative ttl, it is not persisted to PMem in current impl, so a expired key may comeback in recovery

### What is changed and how it works?

What's Changed:

Persist it on PMem in Expire

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- No code

Side effects

No
