### PR TITLE
Bug fix: deadlock in background hashtable iterator, and skiplist linkage check

### DIFF
--- a/engine/data_record.cpp
+++ b/engine/data_record.cpp
@@ -11,8 +11,8 @@ static constexpr int kDataBufferSize = 1024 * 1024;
 
 StringRecord* StringRecord::PersistStringRecord(
     void* addr, uint32_t record_size, TimeStampType timestamp, RecordType type,
-    PMemOffsetType older_version_record, const StringView& key,
-    const StringView& value, ExpireTimeType expired_time) {
+    PMemOffsetType old_version, const StringView& key, const StringView& value,
+    ExpireTimeType expired_time) {
   void* data_cpy_target;
   auto write_size = key.size() + value.size() + sizeof(StringRecord);
   bool with_buffer = write_size <= kDataBufferSize;
@@ -25,7 +25,7 @@ StringRecord* StringRecord::PersistStringRecord(
     data_cpy_target = addr;
   }
   StringRecord::ConstructStringRecord(data_cpy_target, record_size, timestamp,
-                                      type, older_version_record, key, value,
+                                      type, old_version, key, value,
                                       expired_time);
   if (with_buffer) {
     pmem_memcpy(addr, data_cpy_target, write_size, PMEM_F_MEM_NONTEMPORAL);
@@ -39,7 +39,7 @@ StringRecord* StringRecord::PersistStringRecord(
 
 DLRecord* DLRecord::PersistDLRecord(void* addr, uint32_t record_size,
                                     TimeStampType timestamp, RecordType type,
-                                    PMemOffsetType older_version_record,
+                                    PMemOffsetType old_version,
                                     PMemOffsetType prev, PMemOffsetType next,
                                     const StringView& key,
                                     const StringView& value,
@@ -56,7 +56,7 @@ DLRecord* DLRecord::PersistDLRecord(void* addr, uint32_t record_size,
     data_cpy_target = addr;
   }
   DLRecord::ConstructDLRecord(data_cpy_target, record_size, timestamp, type,
-                              older_version_record, prev, next, key, value,
+                              old_version, prev, next, key, value,
                               expired_time);
   if (with_buffer) {
     pmem_memcpy(addr, data_cpy_target, write_size, PMEM_F_MEM_NONTEMPORAL);

--- a/engine/data_record.hpp
+++ b/engine/data_record.hpp
@@ -209,7 +209,7 @@ struct StringRecord {
 struct DLRecord {
  public:
   DataEntry entry;
-  PMemOffsetType older_version_offset;
+  PMemOffsetType older_version_record;
   PMemOffsetType prev;
   PMemOffsetType next;
   ExpireTimeType expired_time;
@@ -313,7 +313,7 @@ struct DLRecord {
            const StringView& _value, ExpireTimeType _expired_time)
       : entry(0, _record_size, _timestamp, _record_type, _key.size(),
               _value.size()),
-        older_version_offset(_older_version_record),
+        older_version_record(_older_version_record),
         prev(_prev),
         next(_next),
         expired_time(_expired_time) {

--- a/engine/data_record.hpp
+++ b/engine/data_record.hpp
@@ -98,7 +98,7 @@ static_assert(sizeof(DataEntry) <= kMinPMemBlockSize);
 struct StringRecord {
  public:
   DataEntry entry;
-  PMemOffsetType older_version_record;
+  PMemOffsetType old_version;
   ExpireTimeType expired_time;
   char data[0];
 
@@ -109,21 +109,20 @@ struct StringRecord {
   // should larger than sizeof(StringRecord) + key size + value size
   static StringRecord* ConstructStringRecord(
       void* target_address, uint32_t _record_size, TimeStampType _timestamp,
-      RecordType _record_type, PMemOffsetType _older_version_record,
+      RecordType _record_type, PMemOffsetType _old_version,
       const StringView& _key, const StringView& _value,
       ExpireTimeType _expired_time) {
     StringRecord* record = new (target_address)
-        StringRecord(_record_size, _timestamp, _record_type,
-                     _older_version_record, _key, _value, _expired_time);
+        StringRecord(_record_size, _timestamp, _record_type, _old_version, _key,
+                     _value, _expired_time);
     return record;
   }
 
   // Construct and persist a string record at pmem address "addr"
   static StringRecord* PersistStringRecord(
       void* addr, uint32_t record_size, TimeStampType timestamp,
-      RecordType type, PMemOffsetType older_version_record,
-      const StringView& key, const StringView& value,
-      ExpireTimeType expired_time = kPersistTime);
+      RecordType type, PMemOffsetType old_version, const StringView& key,
+      const StringView& value, ExpireTimeType expired_time = kPersistTime);
 
   void Destroy() { entry.Destroy(); }
 
@@ -175,12 +174,12 @@ struct StringRecord {
 
  private:
   StringRecord(uint32_t _record_size, TimeStampType _timestamp,
-               RecordType _record_type, PMemOffsetType _older_version_record,
+               RecordType _record_type, PMemOffsetType _old_version,
                const StringView& _key, const StringView& _value,
                ExpireTimeType _expired_time)
       : entry(0, _record_size, _timestamp, _record_type, _key.size(),
               _value.size()),
-        older_version_record(_older_version_record),
+        old_version(_old_version),
         expired_time(_expired_time) {
     assert(_record_type == StringDataRecord ||
            _record_type == StringDeleteRecord);
@@ -209,7 +208,7 @@ struct StringRecord {
 struct DLRecord {
  public:
   DataEntry entry;
-  PMemOffsetType older_version_record;
+  PMemOffsetType old_version;
   PMemOffsetType prev;
   PMemOffsetType next;
   ExpireTimeType expired_time;
@@ -221,14 +220,16 @@ struct DLRecord {
   //
   // target_address: pre-allocated space to store constructed record, it
   // should no smaller than sizeof(DLRecord) + key size + value size
-  static DLRecord* ConstructDLRecord(
-      void* target_address, uint32_t record_size, TimeStampType timestamp,
-      RecordType record_type, PMemOffsetType older_version_record,
-      uint64_t prev, uint64_t next, const StringView& key,
-      const StringView& value, ExpireTimeType expired_time) {
+  static DLRecord* ConstructDLRecord(void* target_address, uint32_t record_size,
+                                     TimeStampType timestamp,
+                                     RecordType record_type,
+                                     PMemOffsetType old_version, uint64_t prev,
+                                     uint64_t next, const StringView& key,
+                                     const StringView& value,
+                                     ExpireTimeType expired_time) {
     DLRecord* record = new (target_address)
-        DLRecord(record_size, timestamp, record_type, older_version_record,
-                 prev, next, key, value, expired_time);
+        DLRecord(record_size, timestamp, record_type, old_version, prev, next,
+                 key, value, expired_time);
     return record;
   }
 
@@ -298,7 +299,7 @@ struct DLRecord {
   // Construct and persist a dl record to PMem address "addr"
   static DLRecord* PersistDLRecord(void* addr, uint32_t record_size,
                                    TimeStampType timestamp, RecordType type,
-                                   PMemOffsetType older_version_record,
+                                   PMemOffsetType old_version,
                                    PMemOffsetType prev, PMemOffsetType next,
                                    const StringView& key,
                                    const StringView& value,
@@ -308,12 +309,12 @@ struct DLRecord {
 
  private:
   DLRecord(uint32_t _record_size, TimeStampType _timestamp,
-           RecordType _record_type, PMemOffsetType _older_version_record,
+           RecordType _record_type, PMemOffsetType _old_version,
            PMemOffsetType _prev, PMemOffsetType _next, const StringView& _key,
            const StringView& _value, ExpireTimeType _expired_time)
       : entry(0, _record_size, _timestamp, _record_type, _key.size(),
               _value.size()),
-        older_version_record(_older_version_record),
+        old_version(_old_version),
         prev(_prev),
         next(_next),
         expired_time(_expired_time) {

--- a/engine/kv_engine.cpp
+++ b/engine/kv_engine.cpp
@@ -1537,7 +1537,8 @@ Status KVEngine::StringDeleteImpl(const StringView& key) {
                               new_ts, hint.spin));
   }
 
-  return ret.s == Status::NotFound ? Status::Ok : ret.s;
+  return (ret.s == Status::NotFound || ret.s == Status::Outdated) ? Status::Ok
+                                                                  : ret.s;
 }
 
 Status KVEngine::StringSetImpl(const StringView& key, const StringView& value,

--- a/engine/kv_engine.cpp
+++ b/engine/kv_engine.cpp
@@ -1469,7 +1469,7 @@ Status KVEngine::Expire(const StringView str, TTLType ttl_time) {
         ul.unlock();
         res.s = Modify(
             str,
-            [](const StringView& key, const std::string* old_val,
+            [](const StringView&, const std::string* old_val,
                std::string* new_val, void*) {
               new_val->assign(*old_val);
               return ModifyOperation::Write;

--- a/engine/sorted_collection/iterator.hpp
+++ b/engine/sorted_collection/iterator.hpp
@@ -82,7 +82,7 @@ class SortedIterator : public Iterator {
     DLRecord* curr = pmem_record;
     TimeStampType ts = snapshot_->GetTimestamp();
     while (curr != nullptr && curr->entry.meta.timestamp > ts) {
-      curr = pmem_allocator_->offset2addr<DLRecord>(curr->older_version_offset);
+      curr = pmem_allocator_->offset2addr<DLRecord>(curr->older_version_record);
       kvdk_assert(curr == nullptr || curr->Validate(),
                   "Broken checkpoint: invalid older version sorted record");
       kvdk_assert(

--- a/engine/sorted_collection/iterator.hpp
+++ b/engine/sorted_collection/iterator.hpp
@@ -82,7 +82,7 @@ class SortedIterator : public Iterator {
     DLRecord* curr = pmem_record;
     TimeStampType ts = snapshot_->GetTimestamp();
     while (curr != nullptr && curr->entry.meta.timestamp > ts) {
-      curr = pmem_allocator_->offset2addr<DLRecord>(curr->older_version_record);
+      curr = pmem_allocator_->offset2addr<DLRecord>(curr->old_version);
       kvdk_assert(curr == nullptr || curr->Validate(),
                   "Broken checkpoint: invalid older version sorted record");
       kvdk_assert(

--- a/engine/sorted_collection/rebuilder.cpp
+++ b/engine/sorted_collection/rebuilder.cpp
@@ -608,8 +608,8 @@ DLRecord* SortedCollectionRebuilder::findValidVersion(DLRecord* pmem_record,
   DLRecord* curr = pmem_record;
   while (curr != nullptr &&
          curr->entry.meta.timestamp > checkpoint_.CheckpointTS()) {
-    curr = kv_engine_->pmem_allocator_->offset2addr<DLRecord>(
-        curr->older_version_record);
+    curr =
+        kv_engine_->pmem_allocator_->offset2addr<DLRecord>(curr->old_version);
     kvdk_assert(curr == nullptr || curr->Validate(),
                 "Broken checkpoint: invalid older version sorted record");
     kvdk_assert(

--- a/engine/sorted_collection/rebuilder.cpp
+++ b/engine/sorted_collection/rebuilder.cpp
@@ -501,18 +501,24 @@ bool SortedCollectionRebuilder::checkRecordLinkage(DLRecord* record) {
 
 bool SortedCollectionRebuilder::checkAndRepairRecordLinkage(DLRecord* record) {
   PMEMAllocator* pmem_allocator = kv_engine_->pmem_allocator_.get();
-  uint64_t offset = pmem_allocator->addr2offset_checked(record);
-  DLRecord* prev = pmem_allocator->offset2addr_checked<DLRecord>(record->prev);
-  DLRecord* next = pmem_allocator->offset2addr_checked<DLRecord>(record->next);
-  if (prev->next != offset && next->prev != offset) {
-    return false;
+
+  // The next linkage is correct. If the prev linkage is correct too, the record
+  // linkage is ok. If the prev linkage is not correct, it will be repaired by
+  // the correct prodecessor soon, so directly return true here.
+  if (Skiplist::CheckReocrdNextLinkage(record, pmem_allocator)) {
+    return true;
   }
-  // Repair un-finished write
-  if (next->prev != offset) {
-    next->prev = offset;
-    pmem_persist(&next->prev, 8);
+
+  // If only prev linkage is correct, then repair the next linkage
+  if (Skiplist::CheckRecordPrevLinkage(record, pmem_allocator)) {
+    DLRecord* next =
+        pmem_allocator->offset2addr_checked<DLRecord>(record->next);
+    next->prev = pmem_allocator->addr2offset_checked(record);
+    pmem_persist(&next->prev, sizeof(PMemOffsetType));
+    return true;
   }
-  return true;
+
+  return false;
 }
 
 void SortedCollectionRebuilder::cleanInvalidRecords() {
@@ -521,7 +527,8 @@ void SortedCollectionRebuilder::cleanInvalidRecords() {
   // clean unlinked records
   for (auto& thread_cache : rebuilder_thread_cache_) {
     for (DLRecord* pmem_record : thread_cache.unlinked_records) {
-      if (!checkRecordLinkage(pmem_record)) {
+      if (!Skiplist::IsSkiplistRecord(pmem_record) ||
+          !checkRecordLinkage(pmem_record)) {
         pmem_record->Destroy();
         to_free.emplace_back(
             kv_engine_->pmem_allocator_->addr2offset_checked(pmem_record),
@@ -602,7 +609,7 @@ DLRecord* SortedCollectionRebuilder::findValidVersion(DLRecord* pmem_record,
   while (curr != nullptr &&
          curr->entry.meta.timestamp > checkpoint_.CheckpointTS()) {
     curr = kv_engine_->pmem_allocator_->offset2addr<DLRecord>(
-        curr->older_version_offset);
+        curr->older_version_record);
     kvdk_assert(curr == nullptr || curr->Validate(),
                 "Broken checkpoint: invalid older version sorted record");
     kvdk_assert(

--- a/engine/sorted_collection/skiplist.cpp
+++ b/engine/sorted_collection/skiplist.cpp
@@ -193,15 +193,23 @@ Status Skiplist::CheckIndex() {
                                             next_record->entry.meta.type,
                                             &entry_ptr, &hash_entry, nullptr);
       if (s != Status::Ok) {
+        GlobalLogger.Error(
+            "Check skiplist index error: record not exist in hash table\n");
         return Status::Abort;
       }
 
       if (hash_entry.GetIndexType() == PointerType::SkiplistNode) {
         if (hash_entry.GetIndex().skiplist_node != next_node) {
+          GlobalLogger.Error(
+              "Check skiplist index error: Dram node miss-match with hash "
+              "table\n");
           return Status::Abort;
         }
       } else {
         if (hash_entry.GetIndex().dl_record != next_record) {
+          GlobalLogger.Error(
+              "Check skiplist index error: Dlrecord miss-match with hash "
+              "table\n");
           return Status::Abort;
         }
       }
@@ -211,6 +219,8 @@ Status Skiplist::CheckIndex() {
     if (next_node && next_node->record == next_record) {
       for (uint8_t i = 1; i <= next_node->Height(); i++) {
         if (splice.prevs[i]->RelaxedNext(i).RawPointer() != next_node) {
+          GlobalLogger.Error(
+              "Check skiplist index error: node linkage error\n");
           return Status::Abort;
         }
         splice.prevs[i] = next_node;

--- a/engine/sorted_collection/skiplist.hpp
+++ b/engine/sorted_collection/skiplist.hpp
@@ -235,8 +235,8 @@ class Skiplist : public Collection {
 
   static bool IsSkiplistRecord(DLRecord* record) {
     return record->entry.meta.type == SortedHeaderRecord ||
-           record->entry.meta.type == SortedHeaderRecord ||
-           record->entry.meta.type == SortedHeaderRecord;
+           record->entry.meta.type == SortedDataRecord ||
+           record->entry.meta.type == SortedDeleteRecord;
   }
 
   // Check if record correctly linked on list

--- a/engine/sorted_collection/skiplist.hpp
+++ b/engine/sorted_collection/skiplist.hpp
@@ -234,9 +234,9 @@ class Skiplist : public Collection {
   void CleanObsoletedNodes();
 
   static bool IsSkiplistRecord(DLRecord* record) {
-    return record->entry.meta.type == SortedHeaderRecord ||
-           record->entry.meta.type == SortedDataRecord ||
-           record->entry.meta.type == SortedDeleteRecord;
+    auto type = record->entry.meta.type;
+    return type == SortedDataRecord || type == SortedDeleteRecord ||
+           type == SortedHeaderRecord;
   }
 
   // Check if record correctly linked on list

--- a/engine/sorted_collection/skiplist.hpp
+++ b/engine/sorted_collection/skiplist.hpp
@@ -233,23 +233,59 @@ class Skiplist : public Collection {
 
   void CleanObsoletedNodes();
 
+  static bool IsSkiplistRecord(DLRecord* record) {
+    return record->entry.meta.type == SortedHeaderRecord ||
+           record->entry.meta.type == SortedHeaderRecord ||
+           record->entry.meta.type == SortedHeaderRecord;
+  }
+
   // Check if record correctly linked on list
   static bool CheckRecordLinkage(DLRecord* record,
                                  PMEMAllocator* pmem_allocator) {
-    uint64_t offset = pmem_allocator->addr2offset_checked(record);
-    DLRecord* prev =
-        pmem_allocator->offset2addr_checked<DLRecord>(record->prev);
-    DLRecord* next =
-        pmem_allocator->offset2addr_checked<DLRecord>(record->next);
-    return prev->next == offset && next->prev == offset;
+    return CheckRecordPrevLinkage(record, pmem_allocator) &&
+           CheckReocrdNextLinkage(record, pmem_allocator);
   }
 
   static bool CheckReocrdNextLinkage(DLRecord* record,
                                      PMEMAllocator* pmem_allocator) {
+    kvdk_assert(IsSkiplistRecord(record),
+                "check linkage of a non skiplist rececord");
+
     uint64_t offset = pmem_allocator->addr2offset_checked(record);
     DLRecord* next =
         pmem_allocator->offset2addr_checked<DLRecord>(record->next);
-    return next->prev == offset;
+
+    auto check_linkage = [&]() { return next->prev == offset; };
+
+    auto check_type = [&]() { return IsSkiplistRecord(next); };
+
+    auto check_id = [&]() {
+      auto next_id = Skiplist::SkiplistID(next);
+      auto record_id = Skiplist::SkiplistID(record);
+      return record_id == next_id;
+    };
+
+    return check_linkage() && check_type() && check_id();
+  }
+
+  static bool CheckRecordPrevLinkage(DLRecord* record,
+                                     PMEMAllocator* pmem_allocator) {
+    kvdk_assert(IsSkiplistRecord(record),
+                "check linkage of a non skiplist rececord");
+    uint64_t offset = pmem_allocator->addr2offset_checked(record);
+    DLRecord* prev =
+        pmem_allocator->offset2addr_checked<DLRecord>(record->prev);
+    auto check_linkage = [&]() { return prev->next == offset; };
+
+    auto check_type = [&]() { return IsSkiplistRecord(prev); };
+
+    auto check_id = [&]() {
+      auto prev_id = Skiplist::SkiplistID(prev);
+      auto record_id = Skiplist::SkiplistID(record);
+      return record_id == prev_id;
+    };
+
+    return check_linkage() && check_type() && check_id();
   }
 
   // Purge a dl record from its skiplist by remove it from linkage
@@ -321,8 +357,9 @@ class Skiplist : public Collection {
       case RecordType::SortedHeaderRecord:
         return DecodeID(record->Value());
       default:
+        GlobalLogger.Error("Wrong record type %d in SkiplistID",
+                           record->entry.meta.type);
         kvdk_assert(false, "Wrong type in SkiplistID");
-        GlobalLogger.Error("Wrong type in SkiplistID");
     }
     return 0;
   }

--- a/engine/version/old_records_cleaner.cpp
+++ b/engine/version/old_records_cleaner.cpp
@@ -245,65 +245,61 @@ SpaceEntry OldRecordsCleaner::purgeOldDeleteRecord(
     }
     case SortedDeleteRecord: {
     handle_sorted_delete_record : {
-      std::lock_guard<SpinMutex> lg(*old_delete_record.key_lock);
-      auto delete_record_index_type =
-          old_delete_record.record_index.skiplist_node.GetTag();
-      SkiplistNode* dram_node = nullptr;
-      HashEntry* hash_entry_ref = nullptr;
-      bool need_purge = false;
-      switch (delete_record_index_type) {
-        case PointerType::HashEntry: {
-          DLRecord* hash_indexed_pmem_record{};
-          hash_entry_ref = static_cast<HashEntry*>(
-              old_delete_record.record_index.hash_entry.RawPointer());
-          auto hash_index_type = hash_entry_ref->GetIndexType();
-          if (hash_index_type == PointerType::DLRecord) {
-            if (hash_entry_ref->GetIndex().dl_record ==
-                old_delete_record.pmem_delete_record) {
-              hash_indexed_pmem_record = hash_entry_ref->GetIndex().dl_record;
+      std::unique_lock<SpinMutex> ul(*old_delete_record.key_lock);
+      // We check linkage to determine if the delete record already been
+      // unlinked by updates. We only check the next linkage, as the record is
+      // already been locked, its next record will not be changed.
+      bool record_on_list = Skiplist::CheckReocrdNextLinkage(
+          static_cast<DLRecord*>(old_delete_record.pmem_delete_record),
+          kv_engine_->pmem_allocator_.get());
+      if (record_on_list) {
+        // record still on list, we clear its index and unlink it from list
+        auto delete_record_index_type =
+            old_delete_record.record_index.skiplist_node.GetTag();
+        SkiplistNode* dram_node = nullptr;
+        HashEntry* hash_entry_ref = nullptr;
+        switch (delete_record_index_type) {
+          case PointerType::HashEntry: {
+            hash_entry_ref = static_cast<HashEntry*>(
+                old_delete_record.record_index.hash_entry.RawPointer());
+            auto hash_index_type = hash_entry_ref->GetIndexType();
+            if (hash_index_type == PointerType::SkiplistNode) {
+              dram_node = hash_entry_ref->GetIndex().skiplist_node;
+              kvdk_assert(
+                  dram_node->record == old_delete_record.pmem_delete_record,
+                  "On-list old delete record of skiplist no pointed by its "
+                  "dram node");
+            } else {
+              kvdk_assert(hash_index_type == PointerType::DLRecord,
+                          "Wrong hash index type in cleaner");
+              kvdk_assert(
+                  hash_entry_ref->GetIndex().dl_record ==
+                      old_delete_record.pmem_delete_record,
+                  "On-list old delete record of skiplist no pointed by its "
+                  "hash entry")
             }
-          } else if (hash_index_type == PointerType::SkiplistNode) {
-            dram_node = hash_entry_ref->GetIndex().skiplist_node;
-            hash_indexed_pmem_record = dram_node->record;
-          } else {
-            // Hash entry of this key already been cleaned. This happens if
-            // another delete record of this key inserted in hash table and
-            // cleaned before this record
             break;
           }
 
-          if (hash_indexed_pmem_record ==
-              old_delete_record.pmem_delete_record) {
-            need_purge = true;
+          case PointerType::SkiplistNode: {
+            dram_node = static_cast<SkiplistNode*>(
+                old_delete_record.record_index.skiplist_node.RawPointer());
+            kvdk_assert(
+                dram_node->record == old_delete_record.pmem_delete_record,
+                "On-list old delete record of skiplist no pointed by its dram "
+                "node");
+            break;
           }
-          break;
-        }
-        case PointerType::SkiplistNode: {
-          dram_node = static_cast<SkiplistNode*>(
-              old_delete_record.record_index.skiplist_node.RawPointer());
-          if (dram_node->record == old_delete_record.pmem_delete_record) {
-            need_purge = true;
+
+          case PointerType::Empty: {
+            break;  // nothing to do
           }
-          break;
-        }
-        case PointerType::Empty: {
-          // This record is not indexed by hash table and skiplist node, so we
-          // check linkage to determine if its already been purged
-          //
-          // We only check the next linkage, as the delete record is already
-          // been locked, its next linkage will not be changed by other threads.
-          if (Skiplist::CheckReocrdNextLinkage(
-                  static_cast<DLRecord*>(old_delete_record.pmem_delete_record),
-                  kv_engine_->pmem_allocator_.get())) {
-            need_purge = true;
+
+          default: {
+            kvdk_assert(false, "never should reach");
           }
-          break;
         }
-        default: {
-          kvdk_assert(false, "never should reach");
-        }
-      }
-      if (need_purge) {
+
         if (!Skiplist::Purge(
                 static_cast<DLRecord*>(old_delete_record.pmem_delete_record),
                 old_delete_record.key_lock, dram_node,
@@ -316,8 +312,9 @@ SpaceEntry OldRecordsCleaner::purgeOldDeleteRecord(
           kv_engine_->hash_table_->Erase(hash_entry_ref);
         }
       }
-      return SpaceEntry(kv_engine_->pmem_allocator_->addr2offset(data_entry),
-                        data_entry->header.record_size);
+      return SpaceEntry(
+          kv_engine_->pmem_allocator_->addr2offset_checked(data_entry),
+          data_entry->header.record_size);
     }
     }
     default: {

--- a/engine/version/old_records_cleaner.hpp
+++ b/engine/version/old_records_cleaner.hpp
@@ -102,7 +102,11 @@ class OldRecordsCleaner {
   const uint64_t kLimitCachedDeleteRecords = 1000000;
 
   void maybeUpdateOldestSnapshot();
+  // Purge a old data record and free space
   SpaceEntry purgeOldDataRecord(const OldDataRecord& old_data_record);
+  // Purge a old delete record and free space
+  // Notice: this function will acquire slot lock in hash table, so deadlock may
+  // occur if call this function while holding other locks
   SpaceEntry purgeOldDeleteRecord(OldDeleteRecord& old_delete_record);
 
   KVEngine* kv_engine_;

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -716,7 +716,7 @@ TEST_F(EngineBasicTest, TestStringModify) {
     size_t incr_by;
     size_t result;
   };
-  auto IncN = [](const StringView& key, const std::string* old_val,
+  auto IncN = [](const StringView&, const std::string* old_val,
                  std::string* new_value, void* modify_args) {
     assert(modify_args);
     IncNArgs* args = static_cast<IncNArgs*>(modify_args);
@@ -2452,7 +2452,7 @@ TEST_F(EngineBasicTest, TestHashTableRangeIter) {
     auto hash_table = test_kvengine->GetHashTable();
     auto slot_iter = hash_table->GetSlotIterator();
     while (slot_iter.Valid()) {
-      slot_iter.LockSlot();
+      auto slot_lock = slot_iter.AcquireSlotLock();
       auto bucket_iter = slot_iter.Begin();
       auto end_bucket_iter = slot_iter.End();
       while (bucket_iter != end_bucket_iter) {

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -2452,6 +2452,7 @@ TEST_F(EngineBasicTest, TestHashTableRangeIter) {
     auto hash_table = test_kvengine->GetHashTable();
     auto slot_iter = hash_table->GetSlotIterator();
     while (slot_iter.Valid()) {
+      slot_iter.LockSlot();
       auto bucket_iter = slot_iter.Begin();
       auto end_bucket_iter = slot_iter.End();
       while (bucket_iter != end_bucket_iter) {


### PR DESCRIPTION
Signed-off-by: Jiayu Wu <jiayu.wu@intel.com>

<!--
Thank you for contributing to KVDK.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Problem Summary:

1. Background thread that clean outdated data may deadlock as it holds lock in hashtable iterator while cleaning old records clean, which also acquire lock
2. Skiplist linkage check only check pointers, which may treat a non-skiplist record as a linked record if the data on pointer position coincidently be a valid record address.
3. Cleaner check skiplist linkage by check dram node if exist, which may access a freed dram node

### What is changed and how it works?

What's Changed:

1. Release lock in hash table iterator while cleaning old record
2. Check linkage, record type and collection id during skiplist linkage check
4. Verify skiplit linkage only by checking next/prev pointers of pmem record in cleaner, to avoid access a invalid dram index

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

Side effects

No
