### PR TITLE
Add delay_free function pointer to listDestroy() and hashListDestroy() API

### DIFF
--- a/engine/data_record.hpp
+++ b/engine/data_record.hpp
@@ -24,12 +24,14 @@ enum RecordType : uint16_t {
   SortedHeaderRecord = (1 << 4),
 
   HashRecord = (1 << 5),
-  HashElem = (1 << 6),
-  HashDirtyElem = (1 << 7),
+  HashDirtyRecord = (1 << 6),
+  HashElem = (1 << 7),
+  HashDirtyElem = (1 << 8),
 
   ListRecord = (1 << 9),
-  ListElem = (1 << 10),
-  ListDirtyElem = (1 << 11),
+  ListDirtyRecord = (1 << 10),
+  ListElem = (1 << 11),
+  ListDirtyElem = (1 << 12),
 
   Padding = (1 << 15),
 };

--- a/engine/generic_list.hpp
+++ b/engine/generic_list.hpp
@@ -212,6 +212,7 @@ class GenericList final : public Collection {
     kvdk_assert(Size() == 0 && list_record != nullptr && first == nullptr &&
                     last == nullptr,
                 "Only initialized empty List can be destroyed!");
+    markAsDirty(list_record);
     list_deleter(list_record);
     list_record = nullptr;
     alloc = nullptr;
@@ -548,6 +549,14 @@ class GenericList final : public Collection {
       }
       case RecordType::HashElem: {
         entry.meta.type = RecordType::HashDirtyElem;
+        break;
+      }
+      case RecordType::ListRecord: {
+        entry.meta.type = RecordType::ListDirtyRecord;
+        break;
+      }
+      case RecordType::HashRecord: {
+        entry.meta.type = RecordType::HashDirtyRecord;
         break;
       }
       default: {

--- a/engine/kv_engine.cpp
+++ b/engine/kv_engine.cpp
@@ -327,6 +327,8 @@ Status KVEngine::RestoreData() {
       }
       case RecordType::ListDirtyElem:
       case RecordType::HashDirtyElem:
+      case RecordType::ListDirtyRecord:
+      case RecordType::HashDirtyRecord:
       case RecordType::Padding:
       case RecordType::Empty: {
         data_entry_cached.meta.type = RecordType::Padding;
@@ -2031,12 +2033,26 @@ Status KVEngine::listRegisterRecovered() {
   return Status::Ok;
 }
 
-Status KVEngine::listDestroy(List* list) {
+template <typename DelayFree>
+Status KVEngine::listDestroy(List* list, DelayFree delay_free) {
+  // Currently, every list operation locks the whole list
+  // and delay_free is not necessary.
+  // We use delay_free here so that we can enable some lockless
+  // operations in the future.
   while (list->Size() > 0) {
-    list->PopFront([&](DLRecord* elem) { purgeAndFree(elem); });
+    auto token = version_controller_.GetLocalSnapshotHolder();
+    list->PopFront(
+        [&](DLRecord* elem) { delay_free(elem, token.Timestamp()); });
   }
-  list->Destroy([&](DLRecord* lrec) { purgeAndFree(lrec); });
+  auto token = version_controller_.GetLocalSnapshotHolder();
+  list->Destroy([&](DLRecord* lrec) { delay_free(lrec, token.Timestamp()); });
   return Status::Ok;
+}
+
+Status KVEngine::listDestroy(List* list) {
+  // Lambda to help resolve symbol
+  return listDestroy(
+      list, [this](void* addr, TimeStampType ts) { delayFree(addr, ts); });
 }
 
 Status KVEngine::listFind(StringView key, List** list, bool init_nx,

--- a/engine/kv_engine.hpp
+++ b/engine/kv_engine.hpp
@@ -407,6 +407,9 @@ class KVEngine : public Engine {
 
   Status listRegisterRecovered();
 
+  template <typename DelayFree>
+  Status listDestroy(List* list, DelayFree delay_free);
+
   Status listDestroy(List* list);
 
   /// Hash helper funtions
@@ -417,6 +420,9 @@ class KVEngine : public Engine {
   Status hashListRestoreList(DLRecord* rec);
 
   Status hashListRegisterRecovered();
+
+  template <typename DelayFree>
+  Status hashListDestroy(HashList* list, DelayFree delay_free);
 
   Status hashListDestroy(HashList* list);
 

--- a/engine/version/old_records_cleaner.cpp
+++ b/engine/version/old_records_cleaner.cpp
@@ -10,9 +10,10 @@
 namespace KVDK_NAMESPACE {
 
 void OldRecordsCleaner::PushToPendingFree(void* addr, TimeStampType ts) {
-  kvdk_assert(static_cast<DLRecord*>(addr)->entry.meta.type &
-                  (ListDirtyElem | HashDirtyElem),
-              "");
+  kvdk_assert(
+      static_cast<DLRecord*>(addr)->entry.meta.type &
+          (ListDirtyElem | ListDirtyRecord | HashDirtyElem | HashDirtyRecord),
+      "");
   kvdk_assert(access_thread.id >= 0, "");
   auto& tc = cleaner_thread_cache_[access_thread.id];
   std::lock_guard<SpinMutex> guard{tc.old_records_lock};


### PR DESCRIPTION
Signed-off-by: ZiyanShi <ziyan.shi@intel.com>

<!--
Thank you for contributing to KVDK.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Add delay_free as a function parameter in istDestroy() and hashListDestroy() so that functions related to expire can use custom delay_free() function.

Tests <!-- At least one of them must be included. -->

- Unit test

