### PR TITLE
Parallel count list elements during recovery

### DIFF
--- a/engine/kv_engine.cpp
+++ b/engine/kv_engine.cpp
@@ -597,12 +597,13 @@ Status KVEngine::Recovery() {
       this, configs_.opt_large_sorted_collection_recovery,
       configs_.max_access_threads, *persist_checkpoint_));
 
-  list_builder_.reset(
-      new ListBuilder{pmem_allocator_.get(), &lists_, 1U, nullptr});
+  list_builder_.reset(new ListBuilder{pmem_allocator_.get(), &lists_,
+                                      configs_.max_access_threads, nullptr});
 
   hash_list_locks_.reset(new LockTable{1UL << 20});
-  hash_list_builder_.reset(new HashListBuilder{
-      pmem_allocator_.get(), &hash_lists_, 1U, hash_list_locks_.get()});
+  hash_list_builder_.reset(
+      new HashListBuilder{pmem_allocator_.get(), &hash_lists_,
+                          configs_.max_access_threads, hash_list_locks_.get()});
 
   std::vector<std::future<Status>> fs;
   GlobalLogger.Info("Start restore data\n");


### PR DESCRIPTION
Signed-off-by: ZiyanShi <ziyan.shi@intel.com>

### What problem does this PR solve?

Optimize recovery speed by parallel count List and Hash elements during recovery.

Tests <!-- At least one of them must be included. -->

- Unit test

Side effects

- Improve recovery speed for List and Hash by approximately 40%
