### PR TITLE
Manage record locks with LockTable in Skiplist

### DIFF
--- a/engine/hash_table.cpp
+++ b/engine/hash_table.cpp
@@ -10,11 +10,11 @@
 #include "thread_manager.hpp"
 
 namespace KVDK_NAMESPACE {
-HashTable* HashTable::NewHashTable(
-    uint64_t hash_bucket_num, uint32_t hash_bucket_size,
-    uint32_t num_buckets_per_slot,
-    std::shared_ptr<PMEMAllocator> pmem_allocator,
-    uint32_t max_access_threads) {
+HashTable* HashTable::NewHashTable(uint64_t hash_bucket_num,
+                                   uint32_t hash_bucket_size,
+                                   uint32_t num_buckets_per_slot,
+                                   const PMEMAllocator* pmem_allocator,
+                                   uint32_t max_access_threads) {
   HashTable* table = new (std::nothrow)
       HashTable(hash_bucket_num, hash_bucket_size, num_buckets_per_slot,
                 pmem_allocator, max_access_threads);

--- a/engine/hash_table.hpp
+++ b/engine/hash_table.hpp
@@ -119,7 +119,7 @@ class HashTable {
   static HashTable* NewHashTable(uint64_t hash_bucket_num,
                                  uint32_t hash_bucket_size,
                                  uint32_t num_buckets_per_slot,
-                                 std::shared_ptr<PMEMAllocator> pmem_allocator,
+                                 const PMEMAllocator* pmem_allocator,
                                  uint32_t max_access_threads);
 
   KeyHashHint GetHint(const StringView& key) {
@@ -181,8 +181,7 @@ class HashTable {
 
  private:
   HashTable(uint64_t hash_bucket_num, uint32_t hash_bucket_size,
-            uint32_t num_buckets_per_slot,
-            std::shared_ptr<PMEMAllocator> pmem_allocator,
+            uint32_t num_buckets_per_slot, const PMEMAllocator* pmem_allocator,
             uint32_t max_access_threads)
       : hash_bucket_num_(hash_bucket_num),
         num_buckets_per_slot_(num_buckets_per_slot),
@@ -205,8 +204,8 @@ class HashTable {
   const uint64_t hash_bucket_num_;
   const uint32_t num_buckets_per_slot_;
   const uint32_t hash_bucket_size_;
+  const PMEMAllocator* pmem_allocator_;
   ChunkBasedAllocator dram_allocator_;
-  std::shared_ptr<PMEMAllocator> pmem_allocator_;
   const uint64_t num_entries_per_bucket_;
   Array<Slot> slots_;
   std::vector<uint64_t> hash_bucket_entries_;

--- a/engine/hash_table.hpp
+++ b/engine/hash_table.hpp
@@ -186,8 +186,8 @@ class HashTable {
       : hash_bucket_num_(hash_bucket_num),
         num_buckets_per_slot_(num_buckets_per_slot),
         hash_bucket_size_(hash_bucket_size),
-        dram_allocator_(max_access_threads),
         pmem_allocator_(pmem_allocator),
+        dram_allocator_(max_access_threads),
         num_entries_per_bucket_((hash_bucket_size_ - 8 /* next pointer */) /
                                 sizeof(HashEntry)),
         slots_(hash_bucket_num / num_buckets_per_slot),

--- a/engine/kv_engine.cpp
+++ b/engine/kv_engine.cpp
@@ -161,7 +161,7 @@ Status KVEngine::Init(const std::string& name, const Configs& configs) {
                             ThreadManager(configs_.max_access_threads));
   hash_table_.reset(HashTable::NewHashTable(
       configs_.hash_bucket_num, configs_.hash_bucket_size,
-      configs_.num_buckets_per_slot, pmem_allocator_,
+      configs_.num_buckets_per_slot, pmem_allocator_.get(),
       configs_.max_access_threads));
   if (pmem_allocator_ == nullptr || hash_table_ == nullptr ||
       thread_manager_ == nullptr) {

--- a/engine/kv_engine.cpp
+++ b/engine/kv_engine.cpp
@@ -593,6 +593,7 @@ Status KVEngine::Recovery() {
     return s;
   }
 
+  skiplist_locks_.reset(new LockTable{1UL << 20});
   sorted_rebuilder_.reset(new SortedCollectionRebuilder(
       this, configs_.opt_large_sorted_collection_recovery,
       configs_.max_access_threads, *persist_checkpoint_));
@@ -960,7 +961,7 @@ start_expire : {
       case PointerType::Skiplist: {
         auto new_ts = snapshot_holder.Timestamp();
         auto ret = res.entry_ptr->GetIndex().skiplist->SetExpireTime(
-            expired_time, new_ts, hint.spin);
+            expired_time, new_ts);
         if (ret.s == Status::Fail) {
           goto start_expire;
         }

--- a/engine/kv_engine.cpp
+++ b/engine/kv_engine.cpp
@@ -919,7 +919,6 @@ Status KVEngine::Expire(const StringView str, TTLType ttl_time) {
   }
 
   ExpireTimeType expired_time = TimeUtils::TTLToExpireTime(ttl_time, base_time);
-start_expire : {
   HashTable::KeyHashHint hint = hash_table_->GetHint(str);
   std::unique_lock<SpinMutex> ul(*hint.spin);
   auto snapshot_holder = version_controller_.GetLocalSnapshotHolder();
@@ -962,9 +961,6 @@ start_expire : {
         auto new_ts = snapshot_holder.Timestamp();
         auto ret = res.entry_ptr->GetIndex().skiplist->SetExpireTime(
             expired_time, new_ts);
-        if (ret.s == Status::Fail) {
-          goto start_expire;
-        }
 
         if (ret.s == Status::Ok) {
           delayFree(OldDataRecord{ret.existing_record, new_ts});
@@ -1000,7 +996,6 @@ start_expire : {
     }
   }
   return res.s;
-}
 }
 }  // namespace KVDK_NAMESPACE
 

--- a/engine/kv_engine.hpp
+++ b/engine/kv_engine.hpp
@@ -273,11 +273,10 @@ class KVEngine : public Engine {
                   "Invalid type!");
     return std::is_same<CollectionType, Skiplist>::value
                ? RecordType::SortedHeader
-               : std::is_same<CollectionType, List>::value
-                     ? RecordType::ListRecord
-                     : std::is_same<CollectionType, HashList>::value
-                           ? RecordType::HashRecord
-                           : RecordType::Empty;
+           : std::is_same<CollectionType, List>::value ? RecordType::ListRecord
+           : std::is_same<CollectionType, HashList>::value
+               ? RecordType::HashRecord
+               : RecordType::Empty;
   }
 
   static PointerType pointerType(RecordType rtype) {
@@ -584,6 +583,7 @@ class KVEngine : public Engine {
   std::set<HashList*, Collection::TTLCmp> hash_lists_;
   std::unique_ptr<HashListBuilder> hash_list_builder_;
   std::unique_ptr<LockTable> hash_list_locks_;
+  std::unique_ptr<LockTable> skiplist_locks_;
 
   std::mutex skiplists_mu_;
   std::mutex lists_mu_;

--- a/engine/kv_engine.hpp
+++ b/engine/kv_engine.hpp
@@ -273,10 +273,11 @@ class KVEngine : public Engine {
                   "Invalid type!");
     return std::is_same<CollectionType, Skiplist>::value
                ? RecordType::SortedHeader
-           : std::is_same<CollectionType, List>::value ? RecordType::ListRecord
-           : std::is_same<CollectionType, HashList>::value
-               ? RecordType::HashRecord
-               : RecordType::Empty;
+               : std::is_same<CollectionType, List>::value
+                     ? RecordType::ListRecord
+                     : std::is_same<CollectionType, HashList>::value
+                           ? RecordType::HashRecord
+                           : RecordType::Empty;
   }
 
   static PointerType pointerType(RecordType rtype) {

--- a/engine/kv_engine.hpp
+++ b/engine/kv_engine.hpp
@@ -109,7 +109,7 @@ class KVEngine : public Engine {
   };
 
   // Used by test case.
-  const std::shared_ptr<HashTable>& GetHashTable() { return hash_table_; }
+  HashTable* GetHashTable() { return hash_table_.get(); }
 
   void CleanOutDated();
 
@@ -573,7 +573,7 @@ class KVEngine : public Engine {
   std::atomic<uint64_t> restored_{0};
   std::atomic<CollectionIDType> list_id_{0};
 
-  std::shared_ptr<HashTable> hash_table_;
+  std::unique_ptr<HashTable> hash_table_;
 
   std::unordered_map<CollectionIDType, std::shared_ptr<Skiplist>> skiplists_;
 
@@ -593,7 +593,7 @@ class KVEngine : public Engine {
   std::string pending_batch_dir_;
   std::string db_file_;
   std::shared_ptr<ThreadManager> thread_manager_;
-  std::shared_ptr<PMEMAllocator> pmem_allocator_;
+  std::unique_ptr<PMEMAllocator> pmem_allocator_;
   Configs configs_;
   bool closing_{false};
   std::vector<std::thread> bg_threads_;

--- a/engine/kv_engine_sorted.cpp
+++ b/engine/kv_engine_sorted.cpp
@@ -55,7 +55,7 @@ Status KVEngine::CreateSortedCollection(
 
     auto skiplist = std::make_shared<Skiplist>(
         pmem_record, string_view_2_string(collection_name), id, comparator,
-        pmem_allocator_, hash_table_, skiplist_locks_.get(),
+        pmem_allocator_.get(), hash_table_.get(), skiplist_locks_.get(),
         s_configs.index_with_hashtable);
     addSkiplistToMap(skiplist);
     hash_table_->Insert(hint, ret.entry_ptr, SortedHeader, skiplist.get(),

--- a/engine/kv_engine_sorted.cpp
+++ b/engine/kv_engine_sorted.cpp
@@ -198,7 +198,7 @@ Iterator* KVEngine::NewSortedIterator(const StringView collection,
   }
 
   return res.s == Status::Ok
-             ? new SortedIterator(skiplist, pmem_allocator_,
+             ? new SortedIterator(skiplist, pmem_allocator_.get(),
                                   static_cast<SnapshotImpl*>(snapshot),
                                   create_snapshot)
              : nullptr;

--- a/engine/kv_engine_sorted.cpp
+++ b/engine/kv_engine_sorted.cpp
@@ -98,8 +98,7 @@ Status KVEngine::DestroySortedCollection(const StringView collection_name) {
         pmem_allocator_->addr2offset_checked(header), header->prev,
         header->next, collection_name, value);
     Skiplist::Replace(header, pmem_record, skiplist->HeaderNode(),
-                      pmem_allocator_.get(), hash_table_.get(),
-                      skiplist_locks_.get());
+                      pmem_allocator_.get(), skiplist_locks_.get());
     hash_table_->Insert(hint, ret.entry_ptr, SortedHeaderDelete, skiplist,
                         PointerType::Skiplist);
     ul.unlock();

--- a/engine/lock_table.hpp
+++ b/engine/lock_table.hpp
@@ -20,6 +20,10 @@ class LockTable {
  public:
   LockTable(size_t n) : mutexes{n} {}
 
+  std::unique_lock<MutexType> AcquireLock(HashType hash) {
+    return std::unique_lock<MutexType>(*Mutex(hash));
+  }
+
   void Lock(HashType hash) { Mutex(hash)->lock(); }
 
   void Unlock(HashType hash) { Mutex(hash)->unlock(); }

--- a/engine/pmem_allocator/pmem_allocator.hpp
+++ b/engine/pmem_allocator/pmem_allocator.hpp
@@ -45,12 +45,12 @@ class PMEMAllocator : public Allocator {
   void Free(const SpaceEntry& entry) override;
 
   // translate block_offset of allocated space to address
-  inline void* offset2addr_checked(PMemOffsetType offset) {
+  inline void* offset2addr_checked(PMemOffsetType offset) const {
     assert(validate_offset(offset) && "Trying to access invalid offset");
     return pmem_ + offset;
   }
 
-  inline void* offset2addr(PMemOffsetType offset) {
+  inline void* offset2addr(PMemOffsetType offset) const {
     if (validate_offset(offset)) {
       return pmem_ + offset;
     }
@@ -58,24 +58,24 @@ class PMEMAllocator : public Allocator {
   }
 
   template <typename T>
-  inline T* offset2addr_checked(PMemOffsetType offset) {
+  inline T* offset2addr_checked(PMemOffsetType offset) const {
     return static_cast<T*>(offset2addr_checked(offset));
   }
 
   template <typename T>
-  inline T* offset2addr(PMemOffsetType block_offset) {
+  inline T* offset2addr(PMemOffsetType block_offset) const {
     return static_cast<T*>(offset2addr(block_offset));
   }
 
   // translate address of allocated space to block_offset
-  inline PMemOffsetType addr2offset_checked(const void* addr) {
+  inline PMemOffsetType addr2offset_checked(const void* addr) const {
     assert((char*)addr >= pmem_);
     PMemOffsetType offset = (char*)addr - pmem_;
     assert(validate_offset(offset) && "Trying to create invalid offset");
     return offset;
   }
 
-  inline PMemOffsetType addr2offset(const void* addr) {
+  inline PMemOffsetType addr2offset(const void* addr) const {
     if (addr) {
       PMemOffsetType offset = (char*)addr - pmem_;
       if (validate_offset(offset)) {
@@ -85,7 +85,7 @@ class PMEMAllocator : public Allocator {
     return kNullPMemOffset;
   }
 
-  inline bool validate_offset(uint64_t offset) {
+  inline bool validate_offset(uint64_t offset) const {
     return offset < pmem_size_ && offset != kNullPMemOffset;
   }
 

--- a/engine/sorted_collection/iterator.hpp
+++ b/engine/sorted_collection/iterator.hpp
@@ -13,8 +13,7 @@ class KVEngine;
 
 class SortedIterator : public Iterator {
  public:
-  SortedIterator(Skiplist* skiplist,
-                 std::shared_ptr<PMEMAllocator> pmem_allocator,
+  SortedIterator(Skiplist* skiplist, const PMEMAllocator* pmem_allocator,
                  SnapshotImpl* snapshot, bool own_snapshot)
       : skiplist_(skiplist),
         pmem_allocator_(pmem_allocator),
@@ -111,7 +110,7 @@ class SortedIterator : public Iterator {
   }
 
   Skiplist* skiplist_;
-  std::shared_ptr<PMEMAllocator> pmem_allocator_;
+  const PMEMAllocator* pmem_allocator_;
   DLRecord* current_;
   SnapshotImpl* snapshot_;
   bool own_snapshot_;

--- a/engine/sorted_collection/rebuilder.cpp
+++ b/engine/sorted_collection/rebuilder.cpp
@@ -136,8 +136,9 @@ Status SortedCollectionRebuilder::initRebuildLists() {
       skiplist =
           std::
               make_shared<Skiplist>(header_record, collection_name, id,
-                                    comparator, kv_engine_->pmem_allocator_,
-                                    kv_engine_->hash_table_,
+                                    comparator,
+                                    kv_engine_->pmem_allocator_.get(),
+                                    kv_engine_->hash_table_.get(),
                                     kv_engine_->skiplist_locks_.get(), false /* we do not build hash index for a invalid skiplist as it will be destroyed soon */);
       {
         std::lock_guard<SpinMutex> lg(lock_);
@@ -162,7 +163,7 @@ Status SortedCollectionRebuilder::initRebuildLists() {
       if (outdated) {
         skiplist = std::make_shared<Skiplist>(
             valid_version_record, collection_name, id, comparator,
-            kv_engine_->pmem_allocator_, kv_engine_->hash_table_,
+            kv_engine_->pmem_allocator_.get(), kv_engine_->hash_table_.get(),
             kv_engine_->skiplist_locks_.get(), false);
         {
           std::lock_guard<SpinMutex> lg(lock_);
@@ -171,7 +172,7 @@ Status SortedCollectionRebuilder::initRebuildLists() {
       } else {
         skiplist = std::make_shared<Skiplist>(
             valid_version_record, collection_name, id, comparator,
-            kv_engine_->pmem_allocator_, kv_engine_->hash_table_,
+            kv_engine_->pmem_allocator_.get(), kv_engine_->hash_table_.get(),
             kv_engine_->skiplist_locks_.get(), s_configs.index_with_hashtable);
         {
           std::lock_guard<SpinMutex> lg(lock_);

--- a/engine/sorted_collection/rebuilder.cpp
+++ b/engine/sorted_collection/rebuilder.cpp
@@ -151,7 +151,6 @@ Status SortedCollectionRebuilder::initRebuildLists() {
       if (valid_version_record != header_record) {
         Skiplist::Replace(header_record, valid_version_record, nullptr,
                           kv_engine_->pmem_allocator_.get(),
-                          kv_engine_->hash_table_.get(),
                           kv_engine_->skiplist_locks_.get());
         addUnlinkedRecord(header_record);
       }
@@ -314,14 +313,12 @@ Status SortedCollectionRebuilder::rebuildSegmentIndex(SkiplistNode* start_node,
       DLRecord* valid_version_record = findValidVersion(next_record, nullptr);
       if (valid_version_record == nullptr) {
         Skiplist::Purge(next_record, nullptr, kv_engine_->pmem_allocator_.get(),
-                        kv_engine_->hash_table_.get(),
                         kv_engine_->skiplist_locks_.get());
         addUnlinkedRecord(next_record);
       } else {
         if (valid_version_record != next_record) {
           Skiplist::Replace(next_record, valid_version_record, nullptr,
                             kv_engine_->pmem_allocator_.get(),
-                            kv_engine_->hash_table_.get(),
                             kv_engine_->skiplist_locks_.get());
           addUnlinkedRecord(next_record);
         }
@@ -465,7 +462,6 @@ Status SortedCollectionRebuilder::rebuildSkiplistIndex(Skiplist* skiplist) {
     if (valid_version_record == nullptr) {
       // purge invalid version record from list
       Skiplist::Purge(next_record, nullptr, kv_engine_->pmem_allocator_.get(),
-                      kv_engine_->hash_table_.get(),
                       kv_engine_->skiplist_locks_.get());
       addUnlinkedRecord(next_record);
     } else {
@@ -473,7 +469,6 @@ Status SortedCollectionRebuilder::rebuildSkiplistIndex(Skiplist* skiplist) {
         // repair linkage of checkpoint version
         Skiplist::Replace(next_record, valid_version_record, nullptr,
                           kv_engine_->pmem_allocator_.get(),
-                          kv_engine_->hash_table_.get(),
                           kv_engine_->skiplist_locks_.get());
         addUnlinkedRecord(next_record);
       }

--- a/engine/sorted_collection/skiplist.cpp
+++ b/engine/sorted_collection/skiplist.cpp
@@ -34,9 +34,8 @@ Skiplist::~Skiplist() {
 }
 
 Skiplist::Skiplist(DLRecord* h, const std::string& name, CollectionIDType id,
-                   Comparator comparator,
-                   std::shared_ptr<PMEMAllocator> pmem_allocator,
-                   std::shared_ptr<HashTable> hash_table, LockTable* lock_table,
+                   Comparator comparator, PMEMAllocator* pmem_allocator,
+                   HashTable* hash_table, LockTable* lock_table,
                    bool index_with_hashtable)
     : Collection(name, id),
       comparator_(comparator),
@@ -73,8 +72,8 @@ Skiplist::WriteResult Skiplist::SetExpireTime(ExpireTimeType expired_time,
       space_entry.size, timestamp, SortedHeader,
       pmem_allocator_->addr2offset_checked(header), header->prev, header->next,
       header->Key(), header->Value(), expired_time);
-  Skiplist::Replace(header, pmem_record, HeaderNode(), pmem_allocator_.get(),
-                    hash_table_.get(), record_locks_);
+  Skiplist::Replace(header, pmem_record, HeaderNode(), pmem_allocator_,
+                    hash_table_, record_locks_);
   ret.existing_record = header;
   ret.dram_node = HeaderNode();
   ret.write_record = pmem_record;
@@ -873,8 +872,8 @@ void Skiplist::destroyRecords() {
       std::lock_guard<SpinMutex> lg(*hash_hint.spin);
       // We need to purge destroyed records one by one in case engine crashed
       // during destroy
-      Skiplist::Purge(to_destroy, nullptr, pmem_allocator_.get(),
-                      hash_table_.get(), record_locks_);
+      Skiplist::Purge(to_destroy, nullptr, pmem_allocator_, hash_table_,
+                      record_locks_);
 
       if (IndexWithHashtable()) {
         HashEntry* entry_ptr = nullptr;

--- a/engine/sorted_collection/skiplist.cpp
+++ b/engine/sorted_collection/skiplist.cpp
@@ -274,8 +274,7 @@ LockTable::GuardType Skiplist::lockRecordPosition(const DLRecord* record,
     DLRecord* prev = pmem_allocator->offset2addr_checked<DLRecord>(prev_offset);
     DLRecord* next = pmem_allocator->offset2addr<DLRecord>(next_offset);
 
-    auto guard =
-        lock_table->MultiGuard({lockIndex(prev), lockIndex(next)});
+    auto guard = lock_table->MultiGuard({recordHash(prev), recordHash(next)});
 
     // Check if the list has changed before we successfully acquire lock.
     if (record->prev != prev_offset || prev->next != record_offset ||
@@ -299,7 +298,7 @@ bool Skiplist::lockInsertPosition(const StringView& inserting_key,
       pmem_allocator_->addr2offset_checked(prev_record);
   PMemOffsetType next_offset =
       pmem_allocator_->addr2offset_checked(next_record);
-  *prev_record_lock = record_locks_->AcquireLock(lockIndex(prev_record));
+  *prev_record_lock = record_locks_->AcquireLock(recordHash(prev_record));
 
   // Check if the linkage has changed before we successfully acquire lock.
   auto check_linkage = [&]() {

--- a/engine/sorted_collection/skiplist.cpp
+++ b/engine/sorted_collection/skiplist.cpp
@@ -269,12 +269,11 @@ LockTable::GuardType Skiplist::lockRecordPosition(const DLRecord* record,
                                                   HashTable* hash_table,
                                                   LockTable* lock_table) {
   while (1) {
-    DLRecord* prev =
-        pmem_allocator->offset2addr_checked<DLRecord>(record->prev);
-    DLRecord* next = pmem_allocator->offset2addr<DLRecord>(record->next);
     PMemOffsetType record_offset = pmem_allocator->addr2offset_checked(record);
-    PMemOffsetType prev_offset = pmem_allocator->addr2offset_checked(prev);
-    PMemOffsetType next_offset = pmem_allocator->addr2offset_checked(next);
+    PMemOffsetType prev_offset = record->prev;
+    PMemOffsetType next_offset = record->next;
+    DLRecord* prev = pmem_allocator->offset2addr_checked<DLRecord>(prev_offset);
+    DLRecord* next = pmem_allocator->offset2addr<DLRecord>(next_offset);
 
     auto guard = lock_table->MultiGuard({prev_offset, record_offset});
 

--- a/engine/sorted_collection/skiplist.cpp
+++ b/engine/sorted_collection/skiplist.cpp
@@ -36,12 +36,13 @@ Skiplist::~Skiplist() {
 Skiplist::Skiplist(DLRecord* h, const std::string& name, CollectionIDType id,
                    Comparator comparator,
                    std::shared_ptr<PMEMAllocator> pmem_allocator,
-                   std::shared_ptr<HashTable> hash_table,
+                   std::shared_ptr<HashTable> hash_table, LockTable* lock_table,
                    bool index_with_hashtable)
     : Collection(name, id),
       comparator_(comparator),
       pmem_allocator_(pmem_allocator),
       hash_table_(hash_table),
+      record_locks_(lock_table),
       index_with_hashtable_(index_with_hashtable),
       deleted_(false) {
   header_ = SkiplistNode::NewNode(name, h, kMaxHeight);
@@ -57,8 +58,7 @@ Status Skiplist::SetExpireTime(ExpireTimeType expired_time) {
 }
 
 Skiplist::WriteResult Skiplist::SetExpireTime(ExpireTimeType expired_time,
-                                              TimeStampType timestamp,
-                                              SpinMutex* locked_header_lock) {
+                                              TimeStampType timestamp) {
   WriteResult ret;
   DLRecord* header = HeaderRecord();
   auto request_size =
@@ -73,8 +73,9 @@ Skiplist::WriteResult Skiplist::SetExpireTime(ExpireTimeType expired_time,
       space_entry.size, timestamp, SortedHeader,
       pmem_allocator_->addr2offset_checked(header), header->prev, header->next,
       header->Key(), header->Value(), expired_time);
-  if (!Skiplist::Replace(header, pmem_record, locked_header_lock, HeaderNode(),
-                         pmem_allocator_.get(), hash_table_.get())) {
+  if (!Skiplist::Replace(header, pmem_record, HeaderNode(),
+                         pmem_allocator_.get(), hash_table_.get(),
+                         record_locks_)) {
     ret.s = Status::Fail;
     return ret;
   }
@@ -268,32 +269,24 @@ Status Skiplist::CheckIndex() {
   return Status::Ok;
 }
 
-bool Skiplist::lockRecordPosition(const DLRecord* record,
-                                  const SpinMutex* record_key_lock,
-                                  std::unique_lock<SpinMutex>* prev_record_lock,
-                                  PMEMAllocator* pmem_allocator,
-                                  HashTable* hash_table) {
+LockTable::GuardType Skiplist::lockRecordPosition(const DLRecord* record,
+                                                  PMEMAllocator* pmem_allocator,
+                                                  HashTable* hash_table,
+                                                  LockTable* lock_table) {
   while (1) {
     DLRecord* prev =
         pmem_allocator->offset2addr_checked<DLRecord>(record->prev);
     DLRecord* next = pmem_allocator->offset2addr<DLRecord>(record->next);
+    PMemOffsetType record_offset = pmem_allocator->addr2offset_checked(record);
     PMemOffsetType prev_offset = pmem_allocator->addr2offset_checked(prev);
     PMemOffsetType next_offset = pmem_allocator->addr2offset_checked(next);
 
-    SpinMutex* prev_lock = hash_table->GetHint(prev->Key()).spin;
-    if (prev_lock != record_key_lock) {
-      if (!prev_lock->try_lock()) {
-        return false;
-      }
-      *prev_record_lock =
-          std::unique_lock<SpinMutex>(*prev_lock, std::adopt_lock);
-    }
+    auto guard = lock_table->MultiGuard({prev_offset, record_offset});
 
     // Check if the list has changed before we successfully acquire lock.
     // As the record is already locked, so we don't need to check its next
     if (record->prev != prev_offset ||
         prev->next != pmem_allocator->addr2offset(record)) {
-      *prev_record_lock = std::unique_lock<SpinMutex>();
       continue;
     }
 
@@ -301,24 +294,16 @@ bool Skiplist::lockRecordPosition(const DLRecord* record,
     kvdk_assert(record->next == next_offset, "");
     kvdk_assert(next->prev == pmem_allocator->addr2offset(record), "");
 
-    return true;
+    return guard;
   }
 }
 
-bool Skiplist::lockInsertPosition(
-    const StringView& inserting_key, DLRecord* prev_record,
-    DLRecord* next_record, const SpinMutex* inserting_key_lock,
-    std::unique_lock<SpinMutex>* prev_record_lock) {
+bool Skiplist::lockInsertPosition(const StringView& inserting_key,
+                                  DLRecord* prev_record, DLRecord* next_record,
+                                  LockTable::ULockType* prev_record_lock) {
   PMemOffsetType prev_offset =
       pmem_allocator_->addr2offset_checked(prev_record);
-  auto prev_hint = hash_table_->GetHint(prev_record->Key());
-  if (prev_hint.spin != inserting_key_lock) {
-    if (!prev_hint.spin->try_lock()) {
-      return false;
-    }
-    *prev_record_lock =
-        std::unique_lock<SpinMutex>(*prev_hint.spin, std::adopt_lock);
-  }
+  *prev_record_lock = record_locks_->AcquireLock(prev_offset);
 
   PMemOffsetType next_offset =
       pmem_allocator_->addr2offset_checked(next_record);
@@ -373,35 +358,29 @@ bool Skiplist::lockInsertPosition(
 }
 
 Skiplist::WriteResult Skiplist::Delete(const StringView& key,
-                                       const HashTable::KeyHashHint& hash_hint,
                                        TimeStampType timestamp) {
   if (IndexWithHashtable()) {
-    return deleteImplWithHash(key, hash_hint, timestamp);
+    return deleteImplWithHash(key, timestamp);
   } else {
-    return deleteImplNoHash(key, hash_hint.spin, timestamp);
+    return deleteImplNoHash(key, timestamp);
   }
 }
 
 Skiplist::WriteResult Skiplist::Set(const StringView& key,
                                     const StringView& value,
-                                    const HashTable::KeyHashHint& hash_hint,
                                     TimeStampType timestamp) {
   if (IndexWithHashtable()) {
-    return setImplWithHash(key, value, hash_hint, timestamp);
+    return setImplWithHash(key, value, timestamp);
   } else {
-    return setImplNoHash(key, value, hash_hint.spin, timestamp);
+    return setImplNoHash(key, value, timestamp);
   }
 }
 
 bool Skiplist::Replace(DLRecord* old_record, DLRecord* new_record,
-                       const SpinMutex* old_record_lock,
                        SkiplistNode* dram_node, PMEMAllocator* pmem_allocator,
-                       HashTable* hash_table) {
-  std::unique_lock<SpinMutex> prev_record_lock;
-  if (!lockRecordPosition(old_record, old_record_lock, &prev_record_lock,
-                          pmem_allocator, hash_table)) {
-    return false;
-  }
+                       HashTable* hash_table, LockTable* lock_table) {
+  auto guard =
+      lockRecordPosition(old_record, pmem_allocator, hash_table, lock_table);
   PMemOffsetType prev_offset = old_record->prev;
   PMemOffsetType next_offset = old_record->next;
   DLRecord* prev = pmem_allocator->offset2addr_checked<DLRecord>(prev_offset);
@@ -424,15 +403,11 @@ bool Skiplist::Replace(DLRecord* old_record, DLRecord* new_record,
   return true;
 }
 
-bool Skiplist::Purge(DLRecord* purging_record,
-                     const SpinMutex* purging_record_lock,
-                     SkiplistNode* dram_node, PMEMAllocator* pmem_allocator,
-                     HashTable* hash_table) {
-  std::unique_lock<SpinMutex> prev_record_lock;
-  if (!lockRecordPosition(purging_record, purging_record_lock,
-                          &prev_record_lock, pmem_allocator, hash_table)) {
-    return false;
-  }
+bool Skiplist::Purge(DLRecord* purging_record, SkiplistNode* dram_node,
+                     PMEMAllocator* pmem_allocator, HashTable* hash_table,
+                     LockTable* lock_table) {
+  auto guard = lockRecordPosition(purging_record, pmem_allocator, hash_table,
+                                  lock_table);
 
   // Modify linkage to drop deleted record
   PMemOffsetType purging_offset = pmem_allocator->addr2offset(purging_record);
@@ -549,9 +524,8 @@ Status Skiplist::Get(const StringView& key, std::string* value) {
   }
 }
 
-Skiplist::WriteResult Skiplist::deleteImplNoHash(
-    const StringView& key, const SpinMutex* locked_key_lock,
-    TimeStampType timestamp) {
+Skiplist::WriteResult Skiplist::deleteImplNoHash(const StringView& key,
+                                                 TimeStampType timestamp) {
   WriteResult ret;
   std::string internal_key(InternalKey(key));
   Splice splice(this);
@@ -574,12 +548,7 @@ Skiplist::WriteResult Skiplist::deleteImplNoHash(
   }
 
   // try to write delete record
-  std::unique_lock<SpinMutex> prev_record_lock;
-  if (!lockRecordPosition(ret.existing_record, locked_key_lock,
-                          &prev_record_lock)) {
-    ret.s = Status::Fail;
-    return ret;
-  }
+  auto guard = lockRecordPosition(ret.existing_record);
 
   auto request_size = internal_key.size() + sizeof(DLRecord);
   auto space_to_write = pmem_allocator_->Allocate(request_size);
@@ -616,17 +585,15 @@ Skiplist::WriteResult Skiplist::deleteImplNoHash(
   return ret;
 }
 
-Skiplist::WriteResult Skiplist::deleteImplWithHash(
-    const StringView& key, const HashTable::KeyHashHint& locked_hash_hint,
-    TimeStampType timestamp) {
+Skiplist::WriteResult Skiplist::deleteImplWithHash(const StringView& key,
+                                                   TimeStampType timestamp) {
   WriteResult ret;
   assert(IndexWithHashtable());
   std::string internal_key(InternalKey(key));
-  SpinMutex* deleting_key_lock = locked_hash_hint.spin;
   HashEntry* entry_ptr = nullptr;
   HashEntry hash_entry;
-  std::unique_lock<SpinMutex> prev_record_lock;
-  ret.s = hash_table_->SearchForRead(locked_hash_hint, internal_key,
+  auto hint = hash_table_->GetHint(internal_key);
+  ret.s = hash_table_->SearchForRead(hint, internal_key,
                                      SortedElem | SortedElemDelete, &entry_ptr,
                                      &hash_entry, nullptr);
 
@@ -651,11 +618,7 @@ Skiplist::WriteResult Skiplist::deleteImplWithHash(
       assert(timestamp > ret.existing_record->entry.meta.timestamp);
 
       // Try to write delete record
-      if (!lockRecordPosition(ret.existing_record, deleting_key_lock,
-                              &prev_record_lock)) {
-        ret.s = Status::Fail;
-        return ret;
-      }
+      auto guard = lockRecordPosition(ret.existing_record);
 
       auto space_to_write =
           pmem_allocator_->Allocate(internal_key.size() + sizeof(DLRecord));
@@ -689,27 +652,27 @@ Skiplist::WriteResult Skiplist::deleteImplWithHash(
   // until here, new record is already inserted to list
   assert(ret.write_record != nullptr);
   if (ret.dram_node == nullptr) {
-    hash_table_->Insert(locked_hash_hint, entry_ptr, SortedElemDelete,
-                        ret.write_record, PointerType::DLRecord);
+    hash_table_->Insert(hint, entry_ptr, SortedElemDelete, ret.write_record,
+                        PointerType::DLRecord);
   } else {
     ret.dram_node->record = ret.write_record;
-    hash_table_->Insert(locked_hash_hint, entry_ptr, SortedElemDelete,
-                        ret.dram_node, PointerType::SkiplistNode);
+    hash_table_->Insert(hint, entry_ptr, SortedElemDelete, ret.dram_node,
+                        PointerType::SkiplistNode);
   }
 
   return ret;
 }
 
-Skiplist::WriteResult Skiplist::setImplWithHash(
-    const StringView& key, const StringView& value,
-    const HashTable::KeyHashHint& locked_hash_hint, TimeStampType timestamp) {
+Skiplist::WriteResult Skiplist::setImplWithHash(const StringView& key,
+                                                const StringView& value,
+                                                TimeStampType timestamp) {
   WriteResult ret;
   assert(IndexWithHashtable());
   std::string internal_key(InternalKey(key));
+  auto hint = hash_table_->GetHint(internal_key);
   HashEntry* entry_ptr = nullptr;
   HashEntry hash_entry;
-  std::unique_lock<SpinMutex> prev_record_lock;
-  ret.s = hash_table_->SearchForWrite(locked_hash_hint, internal_key,
+  ret.s = hash_table_->SearchForWrite(hint, internal_key,
                                       SortedElem | SortedElemDelete, &entry_ptr,
                                       &hash_entry, nullptr);
 
@@ -726,11 +689,7 @@ Skiplist::WriteResult Skiplist::setImplWithHash(
       assert(timestamp > ret.existing_record->entry.meta.timestamp);
 
       // Try to write delete record
-      if (!lockRecordPosition(ret.existing_record, locked_hash_hint.spin,
-                              &prev_record_lock)) {
-        ret.s = Status::Fail;
-        return ret;
-      }
+      auto guard = lockRecordPosition(ret.existing_record);
 
       auto request_size = internal_key.size() + value.size() + sizeof(DLRecord);
       auto space_to_write = pmem_allocator_->Allocate(request_size);
@@ -758,7 +717,7 @@ Skiplist::WriteResult Skiplist::setImplWithHash(
       break;
     }
     case Status::NotFound: {
-      ret = setImplNoHash(key, value, locked_hash_hint.spin, timestamp);
+      ret = setImplNoHash(key, value, timestamp);
       if (ret.s != Status::Ok) {
         return ret;
       }
@@ -775,24 +734,26 @@ Skiplist::WriteResult Skiplist::setImplWithHash(
   // until here, new record is already inserted to list
   assert(ret.write_record != nullptr);
   if (ret.dram_node == nullptr) {
-    hash_table_->Insert(locked_hash_hint, entry_ptr, SortedElem,
-                        ret.write_record, PointerType::DLRecord);
+    hash_table_->Insert(hint, entry_ptr, SortedElem, ret.write_record,
+                        PointerType::DLRecord);
   } else {
     ret.dram_node->record = ret.write_record;
-    hash_table_->Insert(locked_hash_hint, entry_ptr, SortedElem, ret.dram_node,
+    hash_table_->Insert(hint, entry_ptr, SortedElem, ret.dram_node,
                         PointerType::SkiplistNode);
   }
 
   return ret;
 }
 
-Skiplist::WriteResult Skiplist::setImplNoHash(
-    const StringView& key, const StringView& value,
-    const SpinMutex* inserting_key_lock, TimeStampType timestamp) {
+Skiplist::WriteResult Skiplist::setImplNoHash(const StringView& key,
+                                              const StringView& value,
+                                              TimeStampType timestamp) {
   WriteResult ret;
   std::string internal_key(InternalKey(key));
   Splice splice(this);
   Seek(key, &splice);
+  LockTable::ULockType insert_guard;
+  LockTable::GuardType update_guard;
 
   bool exist = !IndexWithHashtable() /* a hash indexed skiplist call this
                                         function only if key not exist */
@@ -802,17 +763,13 @@ Skiplist::WriteResult Skiplist::setImplNoHash(
 
   DLRecord* prev_record;
   DLRecord* next_record;
-  std::unique_lock<SpinMutex> prev_record_lock;
   if (exist) {
     ret.existing_record = splice.next_pmem_record;
     if (splice.nexts[1] && splice.nexts[1]->record == ret.existing_record) {
       ret.dram_node = splice.nexts[1];
     }
-    if (!lockRecordPosition(ret.existing_record, inserting_key_lock,
-                            &prev_record_lock)) {
-      ret.s = Status::Fail;
-      return ret;
-    }
+
+    update_guard = lockRecordPosition(ret.existing_record);
     prev_record = pmem_allocator_->offset2addr_checked<DLRecord>(
         ret.existing_record->prev);
     next_record = pmem_allocator_->offset2addr_checked<DLRecord>(
@@ -820,8 +777,7 @@ Skiplist::WriteResult Skiplist::setImplNoHash(
   } else {
     ret.existing_record = nullptr;
     if (!lockInsertPosition(key, splice.prev_pmem_record,
-                            splice.next_pmem_record, inserting_key_lock,
-                            &prev_record_lock)) {
+                            splice.next_pmem_record, &insert_guard)) {
       ret.s = Status::Fail;
       return ret;
     }
@@ -920,8 +876,8 @@ void Skiplist::destroyRecords() {
         std::lock_guard<SpinMutex> lg(*hash_hint.spin);
         // We need to purge destroyed records one by one in case engine crashed
         // during destroy
-        if (!Skiplist::Purge(to_destroy, hash_hint.spin, nullptr,
-                             pmem_allocator_.get(), hash_table_.get())) {
+        if (!Skiplist::Purge(to_destroy, nullptr, pmem_allocator_.get(),
+                             hash_table_.get(), record_locks_)) {
           GlobalLogger.Debug("Purge failed in destroy skiplist records\n");
           continue;
         }

--- a/engine/sorted_collection/skiplist.hpp
+++ b/engine/sorted_collection/skiplist.hpp
@@ -444,6 +444,11 @@ class Skiplist : public Collection {
 
   void destroyNodes();
 
+  static LockTable::HashType lockIndex(DLRecord* record) {
+    kvdk_assert(record != nullptr, "");
+    return XXH3_64bits(record, sizeof(DLRecord*));
+  }
+
   Comparator comparator_ = compare_string_view;
   PMEMAllocator* pmem_allocator_;
   // TODO: use specified hash table for each skiplist

--- a/engine/sorted_collection/skiplist.hpp
+++ b/engine/sorted_collection/skiplist.hpp
@@ -309,8 +309,7 @@ class Skiplist : public Collection {
   //
   // Notice: key of the purging record should already been locked by engine
   static bool Purge(DLRecord* purging_record, SkiplistNode* dram_node,
-                    PMEMAllocator* pmem_allocator, HashTable* hash_table,
-                    LockTable* lock_table);
+                    PMEMAllocator* pmem_allocator, LockTable* lock_table);
 
   // Replace "old_record" from its skiplist with "replacing_record", please make
   // sure the key order is correct after replace
@@ -325,7 +324,7 @@ class Skiplist : public Collection {
   // Notice: key of the replacing record should already been locked by engine
   static bool Replace(DLRecord* old_record, DLRecord* new_record,
                       SkiplistNode* dram_node, PMEMAllocator* pmem_allocator,
-                      HashTable* hash_table, LockTable* lock_table);
+                      LockTable* lock_table);
 
   // Build a skiplist node for "pmem_record"
   static SkiplistNode* NewNodeBuild(DLRecord* pmem_record);
@@ -408,12 +407,10 @@ class Skiplist : public Collection {
   // record itself
   static LockTable::GuardType lockRecordPosition(const DLRecord* record,
                                                  PMEMAllocator* pmem_allocator,
-                                                 HashTable* hash_table,
                                                  LockTable* lock_table);
 
   LockTable::GuardType lockRecordPosition(const DLRecord* record) {
-    return lockRecordPosition(record, pmem_allocator_, hash_table_,
-                              record_locks_);
+    return lockRecordPosition(record, pmem_allocator_, record_locks_);
   }
 
   bool validateDLRecord(const DLRecord* record) {

--- a/engine/sorted_collection/skiplist.hpp
+++ b/engine/sorted_collection/skiplist.hpp
@@ -444,7 +444,7 @@ class Skiplist : public Collection {
 
   void destroyNodes();
 
-  static LockTable::HashType lockIndex(DLRecord* record) {
+  static LockTable::HashType recordHash(DLRecord* record) {
     kvdk_assert(record != nullptr, "");
     return XXH3_64bits(record, sizeof(DLRecord*));
   }

--- a/engine/version/old_records_cleaner.cpp
+++ b/engine/version/old_records_cleaner.cpp
@@ -337,7 +337,6 @@ SpaceEntry OldRecordsCleaner::purgeOldDeleteRecord(
                         data_entry->header.record_size);
     }
     case SortedElemDelete: {
-    handle_sorted_delete_record : {
       std::unique_lock<SpinMutex> ul(*old_delete_record.key_lock);
       // We check linkage to determine if the delete record already been
       // unlinked by updates. We only check the next linkage, as the record is
@@ -393,14 +392,12 @@ SpaceEntry OldRecordsCleaner::purgeOldDeleteRecord(
           }
         }
 
-        if (!Skiplist::Purge(
-                static_cast<DLRecord*>(old_delete_record.pmem_delete_record),
-                dram_node, kv_engine_->pmem_allocator_.get(),
-                kv_engine_->hash_table_.get(),
-                kv_engine_->skiplist_locks_.get())) {
-          // lock conflict, retry
-          goto handle_sorted_delete_record;
-        } else if (hash_entry_ref) {
+        Skiplist::Purge(
+            static_cast<DLRecord*>(old_delete_record.pmem_delete_record),
+            dram_node, kv_engine_->pmem_allocator_.get(),
+            kv_engine_->hash_table_.get(), kv_engine_->skiplist_locks_.get());
+
+        if (hash_entry_ref) {
           // Erase hash entry after successfully purge record
           kv_engine_->hash_table_->Erase(hash_entry_ref);
         }
@@ -408,7 +405,6 @@ SpaceEntry OldRecordsCleaner::purgeOldDeleteRecord(
       return SpaceEntry(
           kv_engine_->pmem_allocator_->addr2offset_checked(data_entry),
           data_entry->header.record_size);
-    }
     }
     default: {
       std::abort();

--- a/engine/version/old_records_cleaner.cpp
+++ b/engine/version/old_records_cleaner.cpp
@@ -395,9 +395,9 @@ SpaceEntry OldRecordsCleaner::purgeOldDeleteRecord(
 
         if (!Skiplist::Purge(
                 static_cast<DLRecord*>(old_delete_record.pmem_delete_record),
-                old_delete_record.key_lock, dram_node,
-                kv_engine_->pmem_allocator_.get(),
-                kv_engine_->hash_table_.get())) {
+                dram_node, kv_engine_->pmem_allocator_.get(),
+                kv_engine_->hash_table_.get(),
+                kv_engine_->skiplist_locks_.get())) {
           // lock conflict, retry
           goto handle_sorted_delete_record;
         } else if (hash_entry_ref) {

--- a/engine/version/old_records_cleaner.cpp
+++ b/engine/version/old_records_cleaner.cpp
@@ -395,7 +395,7 @@ SpaceEntry OldRecordsCleaner::purgeOldDeleteRecord(
         Skiplist::Purge(
             static_cast<DLRecord*>(old_delete_record.pmem_delete_record),
             dram_node, kv_engine_->pmem_allocator_.get(),
-            kv_engine_->hash_table_.get(), kv_engine_->skiplist_locks_.get());
+            kv_engine_->skiplist_locks_.get());
 
         if (hash_entry_ref) {
           // Erase hash entry after successfully purge record


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:

Deadlock avoidance strategy in current Skiplist impl is too complex

### What is changed and how it works?

What's Changed:

Use LockTable to manage locks of skiplist records in write operations to avoid deadlock from occur

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

Side effects

Testing
