### PR TITLE
Dirty read fix

### DIFF
--- a/engine/generic_list.hpp
+++ b/engine/generic_list.hpp
@@ -923,7 +923,7 @@ class GenericListBuilder final {
       } else {
         // Interrupted Replace/Emplace(newer),
         // repair newer record into List
-        addressOf(elem->next)->PersistNextNT(offsetOf(elem));
+        addressOf(elem->next)->PersistPrevNT(offsetOf(elem));
         return false;
       }
     } else {

--- a/engine/generic_list.hpp
+++ b/engine/generic_list.hpp
@@ -924,7 +924,7 @@ class GenericListBuilder final {
         // Interrupted Replace/Emplace(newer),
         // repair newer record into List
         addressOf(elem->next)->PersistPrevNT(offsetOf(elem));
-        return false;
+        return true;
       }
     } else {
       if (offsetOf(elem) == addressOf(elem->next)->prev) {


### PR DESCRIPTION
<!--
Thank you for contributing to KVDK.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Fix potential dirty read.
When a node is half inserted into List, it is accessible to iterator. If a crash happens, this node would be discarded in previous logic, causing a dirty read.
We should ensure everything newly inserted will be recovered once it is visible to other threads.

Tests <!-- At least one of them must be included. -->

- Unit test

