### PR TITLE
Bug fix: lock record position in skiplist

### DIFF
--- a/engine/sorted_collection/skiplist.cpp
+++ b/engine/sorted_collection/skiplist.cpp
@@ -274,7 +274,7 @@ LockTable::GuardType Skiplist::lockRecordPosition(const DLRecord* record,
     DLRecord* prev = pmem_allocator->offset2addr_checked<DLRecord>(prev_offset);
     DLRecord* next = pmem_allocator->offset2addr<DLRecord>(next_offset);
 
-    auto guard = lock_table->MultiGuard({recordHash(prev), recordHash(next)});
+    auto guard = lock_table->MultiGuard({recordHash(prev), recordHash(record)});
 
     // Check if the list has changed before we successfully acquire lock.
     if (record->prev != prev_offset || prev->next != record_offset ||

--- a/engine/sorted_collection/skiplist.hpp
+++ b/engine/sorted_collection/skiplist.hpp
@@ -444,9 +444,9 @@ class Skiplist : public Collection {
 
   void destroyNodes();
 
-  static LockTable::HashType recordHash(DLRecord* record) {
+  static LockTable::HashType recordHash(const DLRecord* record) {
     kvdk_assert(record != nullptr, "");
-    return XXH3_64bits(record, sizeof(DLRecord*));
+    return XXH3_64bits(record, sizeof(const DLRecord*));
   }
 
   Comparator comparator_ = compare_string_view;


### PR DESCRIPTION
### What problem does this PR solve?

Skiplist::lockRecordPosition locked wrong record

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

Side effects

- No
