### PR TITLE
Purge delete record of skiplist in recovery

### DIFF
--- a/engine/sorted_collection/rebuilder.cpp
+++ b/engine/sorted_collection/rebuilder.cpp
@@ -86,7 +86,8 @@ Status SortedCollectionRebuilder::AddElement(DLRecord* record) {
                     .visited_skiplists[Skiplist::SkiplistID(record)] %
                 kRestoreSkiplistStride ==
             0 &&
-        findValidVersion(record, nullptr) == record) {
+        findCheckpointVersion(record) == record &&
+        record->entry.meta.type == SortedElem) {
       SkiplistNode* start_node = nullptr;
       while (start_node == nullptr) {
         // Always build dram node for a recovery segment start record
@@ -130,7 +131,7 @@ Status SortedCollectionRebuilder::initRebuildLists() {
     max_recovered_id_ = std::max(max_recovered_id_, id);
 
     // Check version and rebuild index
-    DLRecord* valid_version_record = findValidVersion(header_record, nullptr);
+    DLRecord* valid_version_record = findCheckpointVersion(header_record);
     std::shared_ptr<Skiplist> skiplist;
     if (valid_version_record == nullptr) {
       skiplist =
@@ -312,8 +313,9 @@ Status SortedCollectionRebuilder::rebuildSegmentIndex(SkiplistNode* start_node,
 
       auto hash_hint = kv_engine_->hash_table_->GetHint(internal_key);
       std::lock_guard<SpinMutex> lg(*hash_hint.spin);
-      DLRecord* valid_version_record = findValidVersion(next_record, nullptr);
-      if (valid_version_record == nullptr) {
+      DLRecord* valid_version_record = findCheckpointVersion(next_record);
+      if (valid_version_record == nullptr ||
+          valid_version_record->entry.meta.type == SortedElemDelete) {
         Skiplist::Purge(next_record, nullptr, kv_engine_->pmem_allocator_.get(),
                         kv_engine_->skiplist_locks_.get());
         addUnlinkedRecord(next_record);
@@ -466,8 +468,9 @@ Status SortedCollectionRebuilder::rebuildSkiplistIndex(Skiplist* skiplist) {
     StringView internal_key = next_record->Key();
     auto hash_hint = kv_engine_->hash_table_->GetHint(internal_key);
     std::lock_guard<SpinMutex> lg(*hash_hint.spin);
-    DLRecord* valid_version_record = findValidVersion(next_record, nullptr);
-    if (valid_version_record == nullptr) {
+    DLRecord* valid_version_record = findCheckpointVersion(next_record);
+    if (valid_version_record == nullptr ||
+        valid_version_record->entry.meta.type == SortedElemDelete) {
       // purge invalid version record from list
       Skiplist::Purge(next_record, nullptr, kv_engine_->pmem_allocator_.get(),
                       kv_engine_->skiplist_locks_.get());
@@ -650,8 +653,8 @@ Status SortedCollectionRebuilder::insertHashIndex(const StringView& key,
   return Status::Ok;
 }
 
-DLRecord* SortedCollectionRebuilder::findValidVersion(DLRecord* pmem_record,
-                                                      std::vector<DLRecord*>*) {
+DLRecord* SortedCollectionRebuilder::findCheckpointVersion(
+    DLRecord* pmem_record) {
   kvdk_assert(pmem_record != nullptr,
               "pass nullptr to SortedCollectionRebuilder::findValidVersion");
   if (!recoverToCheckpoint()) {

--- a/engine/sorted_collection/rebuilder.hpp
+++ b/engine/sorted_collection/rebuilder.hpp
@@ -61,8 +61,7 @@ class SortedCollectionRebuilder {
   // exist, otherwise return pmem_record itself. Return nullptr if no valid
   // version of pmem_record exist.
   // If invalid_version_records is not null, put all invalid versions into it.
-  DLRecord* findValidVersion(DLRecord* pmem_record,
-                             std::vector<DLRecord*>* invalid_version_records);
+  DLRecord* findCheckpointVersion(DLRecord* pmem_record);
 
   // Rebuild DRAM index based on skiplists, i.e., every recovery thread rebuilds
   // a whole skiplist one by one in parallel


### PR DESCRIPTION
### What problem this patch solve?

Un-purged delete record not been purged during recovery in current impl, so the space won't be freed

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

Side effects

- Release more PMEM in recovery
