### PR TITLE
Fix segfault when popping an empty list

### DIFF
--- a/engine/kv_engine.cpp
+++ b/engine/kv_engine.cpp
@@ -1482,8 +1482,10 @@ Status KVEngine::ListPopFront(StringView key, std::string* elem) {
   if (s != Status::Ok) {
     return s;
   }
+  if (list->Size() == 0) {
+    return Status::NotFound;
+  }
 
-  kvdk_assert(list->Size() != 0, "");
   StringView sw = list->Front()->Value();
   elem->assign(sw.data(), sw.size());
   list->PopFront([&](DLRecord* rec) { delayFree(rec); });
@@ -1504,8 +1506,10 @@ Status KVEngine::ListPopBack(StringView key, std::string* elem) {
   if (s != Status::Ok) {
     return s;
   }
+  if (list->Size() == 0) {
+    return Status::NotFound;
+  }
 
-  kvdk_assert(list->Size() != 0, "");
   StringView sw = list->Back()->Value();
   elem->assign(sw.data(), sw.size());
   list->PopBack([&](DLRecord* rec) { delayFree(rec); });

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -1237,13 +1237,15 @@ TEST_F(EngineBasicTest, TestList) {
     std::string value_got;
     size_t sz;
     for (size_t j = 0; j < count; j++) {
+      if (list_copy.empty()) {
+        ASSERT_EQ(engine->ListPopFront(key, &value_got), Status::NotFound);
+        break;
+      }
       ASSERT_EQ(engine->ListPopFront(key, &value_got), Status::Ok);
       ASSERT_EQ(list_copy.front(), value_got);
       list_copy.pop_front();
-      // Empty list is deleted!
-      ASSERT_TRUE((engine->ListLength(key, &sz) == Status::NotFound &&
-                   list_copy.empty()) ||
-                  sz == list_copy.size());
+      ASSERT_EQ(engine->ListLength(key, &sz), Status::Ok);
+      ASSERT_EQ(sz, list_copy.size());
     }
   };
 
@@ -1253,12 +1255,15 @@ TEST_F(EngineBasicTest, TestList) {
     std::string value_got;
     size_t sz;
     for (size_t j = 0; j < count; j++) {
+      if (list_copy.empty()) {
+        ASSERT_EQ(engine->ListPopFront(key, &value_got), Status::NotFound);
+        break;
+      }
       ASSERT_EQ(engine->ListPopBack(key, &value_got), Status::Ok);
       ASSERT_EQ(list_copy.back(), value_got);
       list_copy.pop_back();
-      ASSERT_TRUE((engine->ListLength(key, &sz) == Status::NotFound &&
-                   list_copy.empty()) ||
-                  sz == list_copy.size());
+      ASSERT_EQ(engine->ListLength(key, &sz), Status::Ok);
+      ASSERT_EQ(sz, list_copy.size());
     }
   };
 
@@ -1329,6 +1334,8 @@ TEST_F(EngineBasicTest, TestList) {
   };
 
   for (size_t i = 0; i < 3; i++) {
+    LaunchNThreads(num_threads, LPop);
+    LaunchNThreads(num_threads, RPop);
     LaunchNThreads(num_threads, LPush);
     LaunchNThreads(num_threads, ListIterate);
     LaunchNThreads(num_threads, RPush);


### PR DESCRIPTION
Signed-off-by: ZiyanShi <ziyan.shi@intel.com>

<!--
Thank you for contributing to KVDK.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

When callling `ListPopFront()` or `ListPopBack()`, empty list was not checked and segfault may occur.
Now popping an empty list will return `Status::NotFound`.

Tests <!-- At least one of them must be included. -->

- Unit test

