### PR TITLE
Fix latency calculation in benchmark

### DIFF
--- a/benchmark/bench.cpp
+++ b/benchmark/bench.cpp
@@ -108,14 +108,16 @@ std::atomic_uint64_t read_ops{0};
 std::atomic_uint64_t write_ops{0};
 std::atomic_uint64_t read_not_found{0};
 std::atomic_uint64_t read_cnt{UINT64_MAX};
-std::vector<std::vector<std::uint64_t>> read_latencies;
-std::vector<std::vector<std::uint64_t>> write_latencies;
 std::vector<std::string> collections;
 Engine* engine;
 std::string value_pool;
 size_t operations_per_thread;
 bool has_timed_out;
 std::vector<int> has_finished;  // std::vector<bool> is a trap!
+// Record operation latencies of access threads. Latencies of write threads
+// stored in first part of the vector, latencies of read threads stored in
+// second part
+std::vector<std::vector<std::uint64_t>> latencies;
 
 std::vector<PaddedEngine> random_engines;
 std::vector<PaddedRangeIterators> ranges;
@@ -220,7 +222,7 @@ void DBWrite(int tid) {
       if (lat / 100 >= MAX_LAT) {
         throw std::runtime_error{"Write latency overflow"};
       }
-      write_latencies[tid][lat / 100]++;
+      latencies[tid][lat / 100]++;
     }
 
     if (s != Status::Ok) {
@@ -356,7 +358,7 @@ void DBRead(int tid) {
         fprintf(stderr, "Read latency overflow: %ld us\n", lat / 100);
         std::abort();
       }
-      read_latencies[tid][lat / 100]++;
+      latencies[tid][lat / 100]++;
     }
 
     if (s != Status::Ok) {
@@ -495,9 +497,7 @@ int main(int argc, char** argv) {
 
   if (FLAGS_latency) {
     printf("calculate latencies\n");
-    read_latencies.resize(read_threads, std::vector<std::uint64_t>(MAX_LAT, 0));
-    write_latencies.resize(write_threads,
-                           std::vector<std::uint64_t>(MAX_LAT + 1, 0));
+    latencies.resize(FLAGS_threads, std::vector<std::uint64_t>(MAX_LAT, 0));
   }
 
   if (bench_data_type == DataType::Sorted) {
@@ -602,7 +602,7 @@ int main(int argc, char** argv) {
 
   if (FLAGS_latency) {
     auto ro = read_ops.load();
-    if (ro > 0 && read_latencies.size() > 0) {
+    if (ro > 0 && read_threads > 0) {
       double total = 0;
       double avg = 0;
       double cur = 0;
@@ -613,8 +613,8 @@ int main(int argc, char** argv) {
       double l9999 = 0;
       for (std::uint64_t i = 1; i <= MAX_LAT; i++) {
         for (auto j = 0; j < read_threads; j++) {
-          cur += read_latencies[j][i];
-          total += read_latencies[j][i] * i;
+          cur += latencies[write_threads + j][i];
+          total += latencies[write_threads + j][i] * i;
           if (l50 == 0 && (double)cur / ro > 0.5) {
             l50 = (double)i / 10;
           } else if (l99 == 0 && (double)cur / ro > 0.99) {
@@ -638,7 +638,7 @@ int main(int argc, char** argv) {
     }
 
     auto wo = write_ops.load();
-    if (wo > 0 && write_latencies.size() > 0) {
+    if (wo > 0 && write_threads > 0) {
       double total = 0;
       double avg = 0;
       double cur = 0;
@@ -649,8 +649,8 @@ int main(int argc, char** argv) {
       double l9999 = 0;
       for (std::uint64_t i = 1; i <= MAX_LAT; i++) {
         for (size_t j = 0; j < write_threads; j++) {
-          cur += write_latencies[j][i];
-          total += write_latencies[j][i] * i;
+          cur += latencies[j][i];
+          total += latencies[j][i] * i;
           if (l50 == 0 && (double)cur / wo > 0.5) {
             l50 = (double)i / 10;
           } else if (l99 == 0 && (double)cur / wo > 0.99) {

--- a/benchmark/bench.cpp
+++ b/benchmark/bench.cpp
@@ -575,7 +575,7 @@ int main(int argc, char** argv) {
   std::cout << "Benchmark finished." << std::endl;
   printf("finish bench\n");
 
-  for (size_t i = 0; i < FLAGS_threads; i++) {
+  for (size_t i = 0; i < ts.size(); i++) {
     ts[i].join();
   }
 


### PR DESCRIPTION
### What problem does this PR solve?

latency array overflow in read/write mixed benchmark

### What is changed and how it works?

What's Changed:

combine latencies of read/write threads in the same vector and access them with thread id

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Benchmark test

Side effects

- No
