### PR TITLE
Fix snapshot of sorted iterator

### DIFF
--- a/engine/dram_allocator.hpp
+++ b/engine/dram_allocator.hpp
@@ -27,7 +27,7 @@ class ChunkBasedAllocator : Allocator {
   inline void* offset2addr(uint64_t offset) { return (void*)offset; }
   template <typename T>
   inline T* offset2addr(uint64_t offset) {
-    return static_cast<T*>(offset);
+    return static_cast<T*>(offset2addr(offset));
   }
   inline uint64_t addr2offset(void* addr) { return (uint64_t)addr; }
   ChunkBasedAllocator(uint32_t max_access_threads)

--- a/engine/hash_table.cpp
+++ b/engine/hash_table.cpp
@@ -15,25 +15,20 @@ HashTable* HashTable::NewHashTable(uint64_t hash_bucket_num,
                                    uint32_t num_buckets_per_slot,
                                    const PMEMAllocator* pmem_allocator,
                                    uint32_t max_access_threads) {
-  HashTable* table = new (std::nothrow)
-      HashTable(hash_bucket_num, hash_bucket_size, num_buckets_per_slot,
-                pmem_allocator, max_access_threads);
-  if (table) {
-    auto main_buckets_space =
-        table->dram_allocator_.Allocate(hash_bucket_size * hash_bucket_num);
-    if (main_buckets_space.size == 0) {
-      GlobalLogger.Error("No enough dram to create global hash table\n");
-      delete table;
-      table = nullptr;
-    } else {
-      table->main_buckets_ =
-          table->dram_allocator_.offset2addr(main_buckets_space.offset);
-      memset(table->main_buckets_, 0, hash_bucket_size * hash_bucket_num);
-      kvdk_assert((uint64_t)table->main_buckets_ % sizeof(HashEntry) == 0,
-                  "hash table bucket address should aligned to hash entry size "
-                  "in create new hash table");
-    }
+  HashTable* table;
+  // We catch exception here as we may need to allocate large memory for hash
+  // table here
+  try {
+    table =
+        new HashTable(hash_bucket_num, hash_bucket_size, num_buckets_per_slot,
+                      pmem_allocator, max_access_threads);
+    return table;
+  } catch (std::bad_alloc& b) {
+    GlobalLogger.Error("No enough dram to create global hash table: b\n",
+                       b.what());
+    table = nullptr;
   }
+
   return table;
 }
 
@@ -105,10 +100,9 @@ Status HashTable::SearchForWrite(const KeyHashHint& hint, const StringView& key,
   assert(entry_ptr);
   assert((*entry_ptr) == nullptr);
   HashEntry* reusable_entry = nullptr;
-  char* bucket_ptr =
-      (char*)main_buckets_ + (uint64_t)hint.bucket * hash_bucket_size_;
-  _mm_prefetch(bucket_ptr, _MM_HINT_T0);
 
+  HashBucket* bucket_ptr = &hash_buckets_[hint.bucket];
+  _mm_prefetch(bucket_ptr, _MM_HINT_T0);
   uint32_t key_hash_prefix = hint.key_hash_value >> 32;
   uint64_t entries = hash_bucket_entries_[hint.bucket];
   bool found = false;
@@ -119,66 +113,34 @@ Status HashTable::SearchForWrite(const KeyHashHint& hint, const StringView& key,
     atomic_load_16(hash_entry_snap, *entry_ptr);
     if (hash_entry_snap->Match(key, key_hash_prefix, type_mask,
                                data_entry_meta)) {
-      found = true;
+      return Status::Ok;
     }
   }
 
-  if (!found) {
-    // iterate hash entries
-    *entry_ptr = (HashEntry*)bucket_ptr;
-    uint64_t i = 0;
-    for (i = 0; i < entries; i++) {
-      if (i > 0 && i % num_entries_per_bucket_ == 0) {
-        // next bucket
-        memcpy_8(&bucket_ptr, bucket_ptr + hash_bucket_size_ - 8);
-        _mm_prefetch(bucket_ptr, _MM_HINT_T0);
-      }
-      *entry_ptr = (HashEntry*)bucket_ptr + (i % num_entries_per_bucket_);
-
-      atomic_load_16(hash_entry_snap, *entry_ptr);
-      if (hash_entry_snap->Match(key, key_hash_prefix, type_mask,
-                                 data_entry_meta)) {
-        slots_[hint.slot].hash_cache.entry_ptr = *entry_ptr;
-        found = true;
-        break;
-      }
-
-      if ((*entry_ptr)->Empty()) {
-        reusable_entry = *entry_ptr;
-      }
+  // iterate hash entrys in the bucket
+  BucketIterator iter(this, hint.bucket);
+  while (iter.Valid()) {
+    atomic_load_16(hash_entry_snap, &*iter);
+    if (hash_entry_snap->Match(key, key_hash_prefix, type_mask,
+                               data_entry_meta)) {
+      *entry_ptr = &*iter;
+      slots_[hint.slot].hash_cache.entry_ptr = *entry_ptr;
+      return Status::Ok;
     }
-
-    if (!found) {
-      // reach end of buckets, reuse entry or allocate a new bucket
-      if (i > 0 && i % num_entries_per_bucket_ == 0) {
-        if (reusable_entry != nullptr) {
-          *entry_ptr = reusable_entry;
-        } else {
-          auto space = dram_allocator_.Allocate(hash_bucket_size_);
-          if (space.size == 0) {
-            GlobalLogger.Error("Memory overflow!\n");
-            return Status::MemoryOverflow;
-          }
-          void* next_off = dram_allocator_.offset2addr(space.offset);
-          kvdk_assert((uint64_t)next_off % sizeof(HashEntry) == 0,
-                      "hash table bucket address should aligned to hash entry "
-                      "size in allocate new bucket");
-          memset(next_off, 0, space.size);
-          memcpy_8(bucket_ptr + hash_bucket_size_ - 8, &next_off);
-          *entry_ptr = (HashEntry*)next_off;
-        }
-      } else {
-        *entry_ptr = (HashEntry*)bucket_ptr + (i % num_entries_per_bucket_);
-      }
+    if (iter->Empty()) {
+      reusable_entry = &*iter;
     }
+    iter++;
   }
 
-  if (!found && (*entry_ptr) != reusable_entry) {
-    (*entry_ptr)->clear();
-    hash_bucket_entries_[hint.bucket]++;
+  if (reusable_entry == nullptr) {
+    allocate(iter);
+    *entry_ptr = &*iter;
+  } else {
+    *entry_ptr = reusable_entry;
   }
 
-  return found ? Status::Ok : Status::NotFound;
+  return Status::NotFound;
 }
 
 Status HashTable::SearchForRead(const KeyHashHint& hint, const StringView& key,
@@ -187,10 +149,9 @@ Status HashTable::SearchForRead(const KeyHashHint& hint, const StringView& key,
                                 DataEntry* data_entry_meta) {
   assert(entry_ptr);
   *entry_ptr = nullptr;
-  char* bucket_ptr =
-      (char*)main_buckets_ + (uint64_t)hint.bucket * hash_bucket_size_;
-  _mm_prefetch(bucket_ptr, _MM_HINT_T0);
 
+  HashBucket* bucket_ptr = &hash_buckets_[hint.bucket];
+  _mm_prefetch(bucket_ptr, _MM_HINT_T0);
   uint32_t key_hash_prefix = hint.key_hash_value >> 32;
   uint64_t entries = hash_bucket_entries_[hint.bucket];
 
@@ -204,29 +165,19 @@ Status HashTable::SearchForRead(const KeyHashHint& hint, const StringView& key,
     }
   }
 
-  // iterate hash entrys
-  for (uint64_t i = 0; i < entries; i++) {
-    if (i > 0 && i % num_entries_per_bucket_ == 0) {
-      // next bucket
-      memcpy_8(&bucket_ptr, bucket_ptr + hash_bucket_size_ - 8);
-      _mm_prefetch(bucket_ptr, _MM_HINT_T0);
+  // iterate hash entrys in the bucket
+  BucketIterator iter(this, hint.bucket);
+  while (iter.Valid()) {
+    *entry_ptr = &*iter;
+    atomic_load_16(hash_entry_snap, *entry_ptr);
+    if (hash_entry_snap->Match(key, key_hash_prefix, type_mask,
+                               data_entry_meta)) {
+      slots_[hint.slot].hash_cache.entry_ptr = *entry_ptr;
+      return Status::Ok;
     }
-    *entry_ptr = (HashEntry*)bucket_ptr + (i % num_entries_per_bucket_);
-    while (1) {
-      atomic_load_16(hash_entry_snap, *entry_ptr);
-      if (hash_entry_snap->Match(key, key_hash_prefix, type_mask,
-                                 data_entry_meta)) {
-        slots_[hint.slot].hash_cache.entry_ptr = *entry_ptr;
-        return Status::Ok;
-      } else {
-        // check if hash entry modified by another write thread during
-        // match hash entry
-        if (memcmp(hash_entry_snap, *(entry_ptr), sizeof(HashEntry)) == 0) {
-          break;
-        }
-      }
-    }
+    iter++;
   }
+
   return Status::NotFound;
 }
 
@@ -236,6 +187,27 @@ void HashTable::Insert(const KeyHashHint& hint, HashEntry* entry_ptr,
   HashEntry new_hash_entry(hint.key_hash_value >> 32, type, index, index_type,
                            entry_status);
   atomic_store_16(entry_ptr, &new_hash_entry);
+}
+
+Status HashTable::allocate(BucketIterator& bucket_iter) {
+  kvdk_assert(bucket_iter.hash_table_ == this &&
+                  bucket_iter.entry_idx_ ==
+                      hash_bucket_entries_[bucket_iter.bucket_idx_],
+              "Only allocate new hash entry at end of hash bucket");
+  if (hash_bucket_entries_[bucket_iter.bucket_idx_] % kNumEntryPerBucket == 0) {
+    auto space = dram_allocator_.Allocate(128);
+    if (space.size == 0) {
+      GlobalLogger.Error("MemoryOverflow!\n");
+      return Status::MemoryOverflow;
+    }
+    bucket_iter.bucket_ptr_->next =
+        dram_allocator_.offset2addr<HashBucket>(space.offset);
+    bucket_iter.bucket_ptr_ = bucket_iter.bucket_ptr_->next;
+  }
+  bucket_iter.entry_idx_ = hash_bucket_entries_[bucket_iter.bucket_idx_]++;
+  bucket_iter->clear();
+  kvdk_assert(bucket_iter.Valid(), "");
+  return Status::Ok;
 }
 
 SlotIterator HashTable::GetSlotIterator() { return SlotIterator{this}; }

--- a/engine/kv_engine.cpp
+++ b/engine/kv_engine.cpp
@@ -1324,6 +1324,7 @@ void KVEngine::backgroundDestroyCollections() {
 }
 
 void KVEngine::CleanOutDated() {
+  return;
   int64_t interval = static_cast<int64_t>(configs_.background_work_interval);
   std::deque<OldDeleteRecord> expired_record_queue;
   std::deque<OutdatedCollection> expired_collection_queue;

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -675,7 +675,7 @@ TEST_F(EngineBasicTest, TestBasicStringOperations) {
   ASSERT_EQ(Engine::Open(db_path.c_str(), &engine, configs, stdout),
             Status::Ok);
   do {
-    TestString(1);
+    TestString(configs.max_access_threads);
   } while (ChangeConfig());
   delete engine;
 }


### PR DESCRIPTION
<!--
Thank you for contributing to KVDK.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Snapshot of SortedIterator created after search the sorted collection, so the collection may be destroyed before the iterator created

### What is changed and how it works?

What's Changed:

Hold snapshot before search collection

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

Side effects

- No
