### PR TITLE
Fix snapshot of sorted iterator 

### DIFF
--- a/engine/kv_engine_sorted.cpp
+++ b/engine/kv_engine_sorted.cpp
@@ -215,13 +215,15 @@ Iterator* KVEngine::NewSortedIterator(const StringView collection,
   auto res = lookupKey<false>(collection, SortedHeader);
   if (res.s == Status::Ok) {
     skiplist = res.entry_ptr->GetIndex().skiplist;
+    return new SortedIterator(skiplist, pmem_allocator_.get(),
+                              static_cast<SnapshotImpl*>(snapshot),
+                              create_snapshot);
+  } else {
+    if (create_snapshot) {
+      ReleaseSnapshot(snapshot);
+    }
+    return nullptr;
   }
-
-  return res.s == Status::Ok
-             ? new SortedIterator(skiplist, pmem_allocator_.get(),
-                                  static_cast<SnapshotImpl*>(snapshot),
-                                  create_snapshot)
-             : nullptr;
 }
 
 void KVEngine::ReleaseSortedIterator(Iterator* sorted_iterator) {

--- a/engine/kv_engine_sorted.cpp
+++ b/engine/kv_engine_sorted.cpp
@@ -207,15 +207,14 @@ Status KVEngine::SortedDelete(const StringView collection,
 Iterator* KVEngine::NewSortedIterator(const StringView collection,
                                       Snapshot* snapshot) {
   Skiplist* skiplist;
+  bool create_snapshot = snapshot == nullptr;
+  if (create_snapshot) {
+    snapshot = GetSnapshot(false);
+  }
   // find collection
   auto res = lookupKey<false>(collection, SortedHeader);
   if (res.s == Status::Ok) {
     skiplist = res.entry_ptr->GetIndex().skiplist;
-  }
-
-  bool create_snapshot = snapshot == nullptr;
-  if (create_snapshot) {
-    snapshot = GetSnapshot(false);
   }
 
   return res.s == Status::Ok


### PR DESCRIPTION
<!--
Thank you for contributing to KVDK.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Snapshot of SortedIterator created after search the sorted collection, so the collection may be destroyed before the iterator created

### What is changed and how it works?

What's Changed:

Hold snapshot before search collection

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

Side effects

- No