### PR TITLE
fix expire API:  remove ttl_time <=0 check.

### DIFF
--- a/engine/kv_engine_string.cpp
+++ b/engine/kv_engine_string.cpp
@@ -10,8 +10,7 @@ namespace KVDK_NAMESPACE {
 Status KVEngine::Modify(const StringView key, ModifyFunc modify_func,
                         void* modify_args, const WriteOptions& write_options) {
   int64_t base_time = TimeUtils::millisecond_time();
-  if (write_options.ttl_time <= 0 ||
-      !TimeUtils::CheckTTL(write_options.ttl_time, base_time)) {
+  if (!TimeUtils::CheckTTL(write_options.ttl_time, base_time)) {
     return Status::InvalidArgument;
   }
 
@@ -202,8 +201,7 @@ Status KVEngine::StringDeleteImpl(const StringView& key) {
 Status KVEngine::StringSetImpl(const StringView& key, const StringView& value,
                                const WriteOptions& write_options) {
   int64_t base_time = TimeUtils::millisecond_time();
-  if (write_options.ttl_time <= 0 ||
-      !TimeUtils::CheckTTL(write_options.ttl_time, base_time)) {
+  if (!TimeUtils::CheckTTL(write_options.ttl_time, base_time)) {
     return Status::InvalidArgument;
   }
 

--- a/examples/tutorial/c_api_tutorial.c
+++ b/examples/tutorial/c_api_tutorial.c
@@ -462,6 +462,12 @@ void ExpireExample(KVDKEngine* kvdk_engine) {
     sleep(1);
     s = KVDKGet(kvdk_engine, key, strlen(key), &val_len, &got_val);
     assert(s == NotFound);
+    // case: ttl time is negative or 0
+    KVDKWriteOptionsSetTTLTime(write_option, 0);
+    s = KVDKSet(kvdk_engine, key, strlen(key), val, strlen(val), write_option);
+    assert(s == Ok);
+    s = KVDKGet(kvdk_engine, key, strlen(key), &val_len, &got_val);
+    assert(s == NotFound);
     // No need to free(got_val)
     printf("Successfully expire string\n");
 
@@ -478,6 +484,7 @@ void ExpireExample(KVDKEngine* kvdk_engine) {
         KVDKCreateSortedCollectionConfigs();
     s = KVDKCreateSortedCollection(kvdk_engine, sorted_collection,
                                    strlen(sorted_collection), s_configs);
+    assert(s == Ok);
     s = KVDKGetTTL(kvdk_engine, sorted_collection, strlen(sorted_collection),
                    &ttl_time);
     assert(s == Ok);

--- a/examples/tutorial/cpp_api_tutorial.cpp
+++ b/examples/tutorial/cpp_api_tutorial.cpp
@@ -334,6 +334,13 @@ static void test_expire() {
     sleep(1);
     s = engine->Get(key, &got_val);
     assert(s == kvdk::Status::NotFound);
+    // case: ttl time is negative.
+    s = engine->Set(key, "Updatedval");
+    assert(s == kvdk::Status::Ok);
+    s = engine->Expire(key, -1);
+    assert(s == kvdk::Status::Ok);
+    s = engine->GetTTL(key, &ttl_time);
+    assert(s == kvdk::Status::NotFound);
     printf("Successfully expire string\n");
   }
 

--- a/include/kvdk/configs.hpp
+++ b/include/kvdk/configs.hpp
@@ -137,7 +137,7 @@ struct WriteOptions {
   WriteOptions(TTLType _ttl_time = kPersistTTL) : ttl_time(_ttl_time) {}
 
   // expired time in milliseconod, should be kPersistTime for no expiration
-  // data, or >= 0 as the ttl
+  // data, or a certain interge which be in the range [INT64_MIN , INT64_MAX].
   TTLType ttl_time;
 };
 

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -1816,6 +1816,15 @@ TEST_F(EngineBasicTest, TestExpireAPI) {
 
     // reset expired time for string record.
     ASSERT_EQ(engine->Expire(key, normal_ttl_time), Status::Ok);
+
+    // set negative ttl time.
+    std::string expire_key = "expired_key1";
+    std::string expire_val = "expired_val1";
+    ASSERT_EQ(engine->Set(expire_key, expire_val, WriteOptions{}), Status::Ok);
+    ASSERT_EQ(engine->GetTTL(expire_key, &ttl_time), Status::Ok);
+    ASSERT_EQ(ttl_time, kPersistTime);
+    ASSERT_EQ(engine->Expire(expire_key, -30), Status::Ok);
+    ASSERT_EQ(engine->GetTTL(expire_key, &ttl_time), Status::NotFound);
   }
 
   // For sorte collection
@@ -1839,6 +1848,14 @@ TEST_F(EngineBasicTest, TestExpireAPI) {
     sleep(2);
     ASSERT_EQ(engine->SortedGet(sorted_collection, "sorted" + key, &got_val),
               Status::NotFound);
+    ASSERT_EQ(engine->GetTTL(sorted_collection, &ttl_time), Status::NotFound);
+    ASSERT_EQ(ttl_time, kInvalidTTL);
+
+    // set negative or 0 ttl time.
+    ASSERT_EQ(engine->CreateSortedCollection(sorted_collection), Status::Ok);
+    ASSERT_EQ(engine->GetTTL(sorted_collection, &ttl_time), Status::Ok);
+    ASSERT_EQ(ttl_time, kPersistTime);
+    ASSERT_EQ(engine->Expire(sorted_collection, 0), Status::Ok);
     ASSERT_EQ(engine->GetTTL(sorted_collection, &ttl_time), Status::NotFound);
     ASSERT_EQ(ttl_time, kInvalidTTL);
   }
@@ -1885,17 +1902,21 @@ TEST_F(EngineBasicTest, TestExpireAPI) {
   delete engine;
   ASSERT_EQ(Engine::Open(db_path.c_str(), &engine, configs, stdout),
             Status::Ok);
-  // Get string record expired time
-  ASSERT_EQ(engine->GetTTL(key, &ttl_time), Status::Ok);
+  // // Get string record expired time
+  // ASSERT_EQ(engine->GetTTL(key, &ttl_time), Status::Ok);
 
   // Get sorted record expired time
   ASSERT_EQ(engine->GetTTL(sorted_collection, &ttl_time), Status::NotFound);
 
-  // Get hashes record expired time
-  ASSERT_EQ(engine->GetTTL(hashes_collection, &ttl_time), Status::Ok);
+  // // Get hashes record expired time
+  // ASSERT_EQ(engine->GetTTL(hashes_collection, &ttl_time), Status::Ok);
+  // ASSERT_EQ(engine->Expire(hashes_collection, INT64_MIN), Status::Ok);
+  // ASSERT_EQ(engine->GetTTL(sorted_collection, &ttl_time), Status::NotFound);
 
-  // Get list record expired time
-  ASSERT_EQ(engine->GetTTL(list_collection, &ttl_time), Status::Ok);
+  // // Get list record expired time
+  // ASSERT_EQ(engine->GetTTL(list_collection, &ttl_time), Status::Ok);
+  // ASSERT_EQ(engine->Expire(hashes_collection, -100), Status::Ok);
+  // ASSERT_EQ(engine->GetTTL(sorted_collection, &ttl_time), Status::NotFound);
   delete engine;
 }
 


### PR DESCRIPTION
### What problem does this PR solve?
1. Remove ttl_time <= check
2.  Enhance expire example and test cases

- Unit test
    ExpireAPI test case doesn't pass.  Since skiplist recovery has bug. 
- Integration test
- No code

Side effects
   No
