### PR TITLE
Bugfix: replace header of a empty skiplist

### DIFF
--- a/engine/sorted_collection/rebuilder.cpp
+++ b/engine/sorted_collection/rebuilder.cpp
@@ -118,11 +118,12 @@ Status SortedCollectionRebuilder::initRebuildLists() {
 
   for (size_t i = 0; i < linked_headers_.size(); i++) {
     DLRecord* header_record = linked_headers_[i];
-    // If there are newer version of this header, it indicates system crashed
-    // while updating header of a empty skiplist in previous run
     if (i + 1 < linked_headers_.size() &&
         equal_string_view(linked_headers_[i + 1]->Key(),
                           header_record->Key())) {
+      // There are newer version of this header, it indicates system crashed
+      // while updating header of a empty skiplist in previous run before break
+      // header linkage.
       kvdk_assert(
           header_record->prev == header_record->next &&
               header_record->prev == pmem_allocator->addr2offset(header_record),

--- a/engine/sorted_collection/skiplist.cpp
+++ b/engine/sorted_collection/skiplist.cpp
@@ -387,11 +387,17 @@ bool Skiplist::Replace(DLRecord* old_record, DLRecord* new_record,
   auto old_record_offset = pmem_allocator->addr2offset(old_record);
   if (prev_offset == old_record_offset && next_offset == old_record_offset) {
     // old record is the only record (the header) in the skiplist, so we make
-    // new record point to itself
+    // new record point to itself and break linkage of the old one for recovery
     kvdk_assert((new_record->entry.meta.type & SortedHeaderType) &&
                     (old_record->entry.meta.type & SortedHeaderType),
                 "Non-header record shouldn't be the only record in a skiplist");
     Skiplist::linkDLRecord(new_record, new_record, new_record, pmem_allocator);
+    auto new_record_offset = pmem_allocator->addr2offset(new_record);
+    old_record->PersistPrevNT(new_record_offset);
+    kvdk_assert(
+        !Skiplist::CheckRecordPrevLinkage(old_record, pmem_allocator) &&
+            !Skiplist::CheckReocrdNextLinkage(old_record, pmem_allocator),
+        "");
   } else {
     DLRecord* prev = pmem_allocator->offset2addr_checked<DLRecord>(prev_offset);
     DLRecord* next = pmem_allocator->offset2addr_checked<DLRecord>(next_offset);

--- a/engine/sorted_collection/skiplist.cpp
+++ b/engine/sorted_collection/skiplist.cpp
@@ -384,18 +384,28 @@ bool Skiplist::Replace(DLRecord* old_record, DLRecord* new_record,
   auto guard = lockRecordPosition(old_record, pmem_allocator, lock_table);
   PMemOffsetType prev_offset = old_record->prev;
   PMemOffsetType next_offset = old_record->next;
-  DLRecord* prev = pmem_allocator->offset2addr_checked<DLRecord>(prev_offset);
-  DLRecord* next = pmem_allocator->offset2addr_checked<DLRecord>(next_offset);
+  auto old_record_offset = pmem_allocator->addr2offset(old_record);
+  if (prev_offset == old_record_offset && next_offset == old_record_offset) {
+    // old record is the only record (the header) in the skiplist, so we make
+    // new record point to itself
+    kvdk_assert((new_record->entry.meta.type & SortedHeaderType) &&
+                    (old_record->entry.meta.type & SortedHeaderType),
+                "Non-header record shouldn't be the only record in a skiplist");
+    Skiplist::linkDLRecord(new_record, new_record, new_record, pmem_allocator);
+  } else {
+    DLRecord* prev = pmem_allocator->offset2addr_checked<DLRecord>(prev_offset);
+    DLRecord* next = pmem_allocator->offset2addr_checked<DLRecord>(next_offset);
 
-  kvdk_assert(prev->next == pmem_allocator->addr2offset(old_record),
-              "Bad prev linkage in Skiplist::Replace");
-  kvdk_assert(next->prev == pmem_allocator->addr2offset(old_record),
-              "Bad next linkage in Skiplist::Replace");
-  new_record->prev = prev_offset;
-  pmem_persist(&new_record->prev, sizeof(PMemOffsetType));
-  new_record->next = next_offset;
-  pmem_persist(&new_record->next, sizeof(PMemOffsetType));
-  Skiplist::linkDLRecord(prev, next, new_record, pmem_allocator);
+    kvdk_assert(prev->next == old_record_offset,
+                "Bad prev linkage in Skiplist::Replace");
+    kvdk_assert(next->prev == old_record_offset,
+                "Bad next linkage in Skiplist::Replace");
+    new_record->prev = prev_offset;
+    pmem_persist(&new_record->prev, sizeof(PMemOffsetType));
+    new_record->next = next_offset;
+    pmem_persist(&new_record->next, sizeof(PMemOffsetType));
+    Skiplist::linkDLRecord(prev, next, new_record, pmem_allocator);
+  }
   if (dram_node != nullptr) {
     kvdk_assert(dram_node->record == old_record,
                 "Dram node not belong to old record in Skiplist::Replace");

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -965,6 +965,17 @@ TEST_F(EngineBasicTest, TestSortedRestore) {
       s_configs.index_with_hashtable = index_with_hashtable;
       ASSERT_EQ(Engine::Open(db_path.c_str(), &engine, configs, stdout),
                 Status::Ok);
+      // Test destroy a collction
+      std::string empty_skiplist("empty_skiplist");
+      size_t empty_skiplist_size;
+      ASSERT_EQ(engine->CreateSortedCollection(empty_skiplist, s_configs),
+                Status::Ok);
+      ASSERT_EQ(engine->SortedSize(empty_skiplist, &empty_skiplist_size),
+                Status::Ok);
+      ASSERT_EQ(empty_skiplist_size, 0);
+      ASSERT_EQ(engine->DestroySortedCollection(empty_skiplist), Status::Ok);
+      ASSERT_EQ(engine->SortedSize(empty_skiplist, &empty_skiplist_size),
+                Status::NotFound);
       // insert and delete some keys, then re-insert some deleted keys
       int count = 100;
       std::string global_skiplist =
@@ -1014,6 +1025,8 @@ TEST_F(EngineBasicTest, TestSortedRestore) {
       // reopen and restore engine and try gets
       ASSERT_EQ(Engine::Open(db_path.c_str(), &engine, configs, stdout),
                 Status::Ok);
+      ASSERT_EQ(engine->SortedSize(empty_skiplist, &empty_skiplist_size),
+                Status::NotFound);
       for (size_t id = 0; id < num_threads; id++) {
         std::string t_skiplist(thread_skiplist + std::to_string(id));
         std::string key_prefix(id, 'a');


### PR DESCRIPTION
Signed-off-by: Jiayu Wu <jiayu.wu@intel.com>

<!--
Thank you for contributing to KVDK.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

While replacing header of a empty skiplist, the new header and old header will point to each other

### What is changed and how it works?

- Make new header point to itself and break the linkage of old one in this circumstance. 
- Detect duplicate skiplist headers in recovery and destroy the older one

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

Side effects

- No
