### PR TITLE
Fix checkpoint recovery of skiplist

### DIFF
--- a/engine/sorted_collection/rebuilder.cpp
+++ b/engine/sorted_collection/rebuilder.cpp
@@ -173,10 +173,6 @@ Status SortedCollectionRebuilder::initRebuildLists() {
         Skiplist::SkiplistID(valid_version_record) != id) {
       // No valid version, or valid version header belong to another linked
       // skiplist with same name
-      kvdk_assert(valid_version_record == nullptr ||
-                      Skiplist::CheckRecordLinkage(valid_version_record,
-                                                   pmem_allocator),
-                  "");
       skiplist =
           std::
               make_shared<Skiplist>(header_record, collection_name, id,

--- a/engine/sorted_collection/rebuilder.cpp
+++ b/engine/sorted_collection/rebuilder.cpp
@@ -171,7 +171,7 @@ Status SortedCollectionRebuilder::initRebuildLists() {
     std::shared_ptr<Skiplist> skiplist;
     if (valid_version_record == nullptr ||
         Skiplist::SkiplistID(valid_version_record) != id) {
-      // No valid version, or valid version header belong to another linked
+      // No valid version, or valid version header belongs to another linked
       // skiplist with same name
       skiplist =
           std::


### PR DESCRIPTION
Signed-off-by: Jiayu Wu <jiayu.wu@intel.com>

<!--
Thank you for contributing to KVDK.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Version chain of skiplist links headers with same name, while a skiplist is outdated and re-created, the outdated version may be destroyed twice if there is a checkpoint on it during recovery

### What is changed and how it works?

Check skiplist ID in version check

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

Side effects

- No
