### PR TITLE
Fix batchwrite locking

### DIFF
--- a/engine/hash_table.hpp
+++ b/engine/hash_table.hpp
@@ -228,6 +228,22 @@ class HashTable {
     return guard;
   }
 
+  std::vector<std::unique_lock<SpinMutex>> RangeLock(
+      std::vector<std::string> const& keys) {
+    std::vector<SpinMutex*> spins;
+    for (auto const& key : keys) {
+      spins.push_back(GetHint(key).spin);
+    }
+    std::sort(spins.begin(), spins.end());
+    auto end = std::unique(spins.begin(), spins.end());
+
+    std::vector<std::unique_lock<SpinMutex>> guard;
+    for (auto iter = spins.begin(); iter != end; ++iter) {
+      guard.emplace_back(**iter);
+    }
+    return guard;
+  }
+
   HashTableIterator GetIterator();
 
  private:

--- a/engine/hash_table.hpp
+++ b/engine/hash_table.hpp
@@ -212,24 +212,10 @@ class HashTable {
     return std::unique_lock<SpinMutex>{*GetHint(key).spin};
   }
 
+  // StringAlike is std::string or StringView
+  template <typename StringAlike>
   std::vector<std::unique_lock<SpinMutex>> RangeLock(
-      std::vector<StringView> const& keys) {
-    std::vector<SpinMutex*> spins;
-    for (auto const& key : keys) {
-      spins.push_back(GetHint(key).spin);
-    }
-    std::sort(spins.begin(), spins.end());
-    auto end = std::unique(spins.begin(), spins.end());
-
-    std::vector<std::unique_lock<SpinMutex>> guard;
-    for (auto iter = spins.begin(); iter != end; ++iter) {
-      guard.emplace_back(**iter);
-    }
-    return guard;
-  }
-
-  std::vector<std::unique_lock<SpinMutex>> RangeLock(
-      std::vector<std::string> const& keys) {
+      std::vector<StringAlike> const& keys) {
     std::vector<SpinMutex*> spins;
     for (auto const& key : keys) {
       spins.push_back(GetHint(key).spin);

--- a/engine/kv_engine.cpp
+++ b/engine/kv_engine.cpp
@@ -773,7 +773,7 @@ Status KVEngine::batchWriteImpl(WriteBatchImpl const& batch) {
   }
 
   // Keys/internal keys to be locked on HashTable
-  std::vector<StringView> keys_to_lock;
+  std::vector<std::string> keys_to_lock;
   for (auto const& string_op : batch.StringOps()) {
     keys_to_lock.push_back(string_op.key);
   }

--- a/engine/kv_engine.cpp
+++ b/engine/kv_engine.cpp
@@ -871,6 +871,7 @@ Status KVEngine::batchWriteImpl(WriteBatchImpl const& batch) {
   }
 
   // Prepare for Hash Elements
+  i = 0;
   for (auto const& hash_op : batch.HashOps()) {
     HashList* hlist = hashlists_found[i++];
     if (hlist == nullptr) {

--- a/engine/kv_engine.cpp
+++ b/engine/kv_engine.cpp
@@ -846,6 +846,7 @@ Status KVEngine::batchWriteImpl(WriteBatchImpl const& batch) {
     Skiplist* slist = skiplists_found[i++];
     if (slist == nullptr) {
       // Delete from non-existing Skiplist, skip;
+      kvdk_assert(sorted_op.op == WriteBatchImpl::Op::Delete, "");
       continue;
     }
     SortedWriteArgs args;
@@ -874,6 +875,7 @@ Status KVEngine::batchWriteImpl(WriteBatchImpl const& batch) {
     HashList* hlist = hashlists_found[i++];
     if (hlist == nullptr) {
       // Delete from non-existing HashList, skip;
+      kvdk_assert(hash_op.op == WriteBatchImpl::Op::Delete, "");
       continue;
     }
     HashWriteArgs args;

--- a/engine/write_batch_impl.hpp
+++ b/engine/write_batch_impl.hpp
@@ -106,6 +106,7 @@ struct SortedWriteArgs {
   StringView field;
   StringView value;
   WriteBatchImpl::Op op;
+  Skiplist* skiplist;
   SpaceEntry space;
   TimeStampType ts;
   HashTable::LookupResult res;
@@ -124,9 +125,11 @@ struct HashWriteArgs {
   StringView field;
   StringView value;
   WriteBatchImpl::Op op;
+  HashList* hlist;
   SpaceEntry space;
   TimeStampType ts;
   HashTable::LookupResult res;
+  // returned by write, used by publish
   DLRecord* new_rec;
 
   void Assign(WriteBatchImpl::HashOp const& hash_op) {

--- a/engine/write_batch_impl.hpp
+++ b/engine/write_batch_impl.hpp
@@ -193,12 +193,13 @@ class BatchWriteLog {
     sorted_logs.emplace_back(SortedLogEntry{Op::Delete, offset});
   }
 
-  void HashPut(PMemOffsetType offset) {
-    hash_logs.emplace_back(HashLogEntry{Op::Put, offset});
+  void HashPut(PMemOffsetType new_offset, PMemOffsetType old_offset) {
+    hash_logs.emplace_back(HashLogEntry{Op::Put, new_offset, old_offset});
   }
 
-  void HashDelete(PMemOffsetType offset) {
-    hash_logs.emplace_back(HashLogEntry{Op::Delete, offset});
+  void HashDelete(PMemOffsetType old_offset) {
+    hash_logs.emplace_back(
+        HashLogEntry{Op::Delete, kNullPMemOffset, old_offset});
   }
 
   void Clear() {

--- a/engine/write_batch_impl.hpp
+++ b/engine/write_batch_impl.hpp
@@ -168,7 +168,8 @@ class BatchWriteLog {
 
   struct HashLogEntry {
     Op op;
-    PMemOffsetType offset;
+    PMemOffsetType new_offset;
+    PMemOffsetType old_offset;
   };
 
   explicit BatchWriteLog() {}
@@ -210,10 +211,10 @@ class BatchWriteLog {
   static size_t Capacity() { return (1UL << 20); }
 
   static size_t MaxBytes() {
-    static_assert(sizeof(StringLog) == sizeof(SortedLog), "");
-    static_assert(sizeof(StringLog) == sizeof(HashLog), "");
+    static_assert(sizeof(HashLogEntry) >= sizeof(StringLogEntry), "");
+    static_assert(sizeof(HashLogEntry) >= sizeof(SortedLogEntry), "");
     return sizeof(size_t) + sizeof(TimeStampType) + sizeof(Stage) +
-           sizeof(size_t) + Capacity() * sizeof(StringLog);
+           sizeof(size_t) + Capacity() * sizeof(HashLogEntry);
   }
 
   // Format of the BatchWriteLog

--- a/engine/write_batch_impl.hpp
+++ b/engine/write_batch_impl.hpp
@@ -218,8 +218,10 @@ class BatchWriteLog {
   }
 
   // Format of the BatchWriteLog
-  // total_bytes | Stage | timestamp | N | StringLogEntry*N | M |
-  // SortedLogEntry*M | K | HashLogEntry*K
+  // total_bytes | timestamp | stage |
+  // N | StringLogEntry*N |
+  // M | SortedLogEntry*M
+  // K | HashLogEntry*K
   // dst is expected to have capacity of MaxBytes().
   void EncodeTo(char* dst);
 

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -771,6 +771,8 @@ TEST_F(EngineBasicTest, TestBatchWrite) {
         batch->StringDelete(keys[tid][i]);
       }
       if ((i + 1) % batch_size == 0) {
+        // Delete a non-existing key
+        batch->StringDelete("asdf");
         ASSERT_EQ(engine->BatchWrite(batch), Status::Ok);
         batch->Clear();
       }
@@ -2027,6 +2029,8 @@ TEST_F(EngineBasicTest, BatchWriteRollBack) {
         batch->StringPut(keys[tid][i], GetRandomString(120));
       } else {
         batch->StringDelete(keys[tid][i]);
+        // Delete a non-existing key
+        batch->StringDelete("asdf");
       }
       ASSERT_THROW(engine->BatchWrite(batch), SyncPoint::CrashPoint);
     }


### PR DESCRIPTION
Signed-off-by: ZiyanShi <ziyan.shi@intel.com>

<!--
Thank you for contributing to KVDK.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Fix locking mechanism for batchwrite. Batchwrite should lock internal keys, which consists of id and field, instead of just field.

Tests <!-- At least one of them must be included. -->

- Unit test
