### PR TITLE
Fix test cases with sync points

### DIFF
--- a/engine/utils/sync_impl.hpp
+++ b/engine/utils/sync_impl.hpp
@@ -138,6 +138,7 @@ struct SyncImpl {
     producers_.clear();
     callbacks_.clear();
     point_table_.clear();
+    crash_points_.clear();
     num_callbacks_running_ = 0;
   }
 

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -66,11 +66,6 @@ class EngineBasicTest : public testing::Test {
     int res __attribute__((unused)) = system(cmd);
     config_option = OptionConfig::Default;
     cnt = 500;
-
-#if KVDK_DEBUG_LEVEL > 0
-    SyncPoint::GetInstance()->DisableProcessing();
-    SyncPoint::GetInstance()->Reset();
-#endif
   }
 
   virtual void TearDown() {

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -66,9 +66,20 @@ class EngineBasicTest : public testing::Test {
     int res __attribute__((unused)) = system(cmd);
     config_option = OptionConfig::Default;
     cnt = 500;
+
+#if KVDK_DEBUG_LEVEL > 0
+    SyncPoint::GetInstance()->DisableProcessing();
+    SyncPoint::GetInstance()->Reset();
+#endif
   }
 
-  virtual void TearDown() { Destroy(); }
+  virtual void TearDown() {
+#if KVDK_DEBUG_LEVEL > 0
+    SyncPoint::GetInstance()->DisableProcessing();
+    SyncPoint::GetInstance()->Reset();
+#endif
+    Destroy();
+  }
 
   void AssignData(std::string& data, int len) {
     data.assign(str_pool.data() + (rand() % (str_pool_length - len)), len);


### PR DESCRIPTION
Signed-off-by: ZiyanShi <ziyan.shi@intel.com>

<!--
Thank you for contributing to KVDK.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Fix test throw an exception if use gtest_repeat option.
This patch disable and reset sync points for each test case on setup and teardown so that sync points will not live through test cases.

Tests <!-- At least one of them must be included. -->

- Unit test
