### PR TITLE
fix batchwrite log

### DIFF
--- a/engine/write_batch_impl.hpp
+++ b/engine/write_batch_impl.hpp
@@ -232,14 +232,14 @@ class BatchWriteLog {
   void DecodeFrom(char const* src);
 
   static void MarkProcessing(char* dst) {
-    dst = &dst[sizeof(size_t)];
-    *reinterpret_cast<Stage*>(dst) = Stage::Processing;
+    dst = &dst[sizeof(size_t) + sizeof(TimeStampType)];
+    *reinterpret_cast<Stage*>(dst + sizeof(size_t)) = Stage::Processing;
     _mm_clflush(dst);
     _mm_mfence();
   }
 
   static void MarkCommitted(char* dst) {
-    dst = &dst[sizeof(size_t)];
+    dst = &dst[sizeof(size_t) + sizeof(TimeStampType)];
     *reinterpret_cast<Stage*>(dst) = Stage::Committed;
     _mm_clflush(dst);
     _mm_mfence();
@@ -247,7 +247,7 @@ class BatchWriteLog {
 
   // For rollback
   static void MarkInitializing(char* dst) {
-    dst = &dst[sizeof(size_t)];
+    dst = &dst[sizeof(size_t) + sizeof(TimeStampType)];
     *reinterpret_cast<Stage*>(dst) = Stage::Initializing;
     _mm_clflush(dst);
     _mm_mfence();


### PR DESCRIPTION
Signed-off-by: ZiyanShi <ziyan.shi@intel.com>

<!--
Thank you for contributing to KVDK.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

When persisting the Stage of batchwrite, the timestamp field is mistakenly overwritten by stage field.

Tests <!-- At least one of them must be included. -->

- Unit test
