### PR TITLE
Prevent duplicate key from WriteBatch

### DIFF
--- a/engine/kv_engine.cpp
+++ b/engine/kv_engine.cpp
@@ -825,18 +825,20 @@ Status KVEngine::batchWriteImpl(WriteBatchImpl const& batch) {
   // Prevent collection and nodes in double linked lists from being deleted
   auto access_token = version_controller_.GetLocalSnapshotHolder();
 
-  std::vector<StringWriteArgs> string_args(batch.StringOps().size());
-  std::vector<SortedWriteArgs> sorted_args(batch.SortedOps().size());
-  std::vector<HashWriteArgs> hash_args(batch.HashOps().size());
+  std::vector<StringWriteArgs> string_args;
+  string_args.reserve(batch.StringOps().size());
+  std::vector<SortedWriteArgs> sorted_args;
+  sorted_args.reserve(batch.SortedOps().size());
+  std::vector<HashWriteArgs> hash_args;
+  hash_args.reserve(batch.HashOps().size());
 
-  for (size_t i = 0; i < batch.StringOps().size(); i++) {
-    auto const& string_op = batch.StringOps()[i];
-    string_args[i].Assign(string_op);
+  for (auto const& string_op : batch.StringOps()) {
+    string_args.emplace_back();
+    string_args.back().Assign(string_op);
   }
 
   // Lookup Skiplists and Hashes for further operations
-  for (size_t i = 0; i < batch.SortedOps().size(); i++) {
-    auto const& sorted_op = batch.SortedOps()[i];
+  for (auto const& sorted_op : batch.SortedOps()) {
     auto res = lookupKey<false>(sorted_op.key, SortedHeaderType);
     /// TODO: this is a temporary work-around
     /// We cannot lock both key and field, which may trigger deadlock.
@@ -849,19 +851,20 @@ Status KVEngine::batchWriteImpl(WriteBatchImpl const& batch) {
     if (res.s != Status::Ok) {
       return res.s;
     }
-    sorted_args[i].Assign(sorted_op);
-    sorted_args[i].skiplist = res.entry.GetIndex().skiplist;
+    sorted_args.emplace_back();
+    sorted_args.back().Assign(sorted_op);
+    sorted_args.back().skiplist = res.entry.GetIndex().skiplist;
   }
 
-  for (size_t i = 0; i < batch.HashOps().size(); i++) {
-    auto const& hash_op = batch.HashOps()[i];
+  for (auto const& hash_op : batch.HashOps()) {
     HashList* hlist;
     Status s = hashListFind(hash_op.key, &hlist);
     if (s != Status::Ok) {
       return s;
     }
-    hash_args[i].Assign(hash_op);
-    hash_args[i].hlist = hlist;
+    hash_args.emplace_back();
+    hash_args.back().Assign(hash_op);
+    hash_args.back().hlist = hlist;
   }
 
   // Keys/internal keys to be locked on HashTable

--- a/engine/utils/utils.hpp
+++ b/engine/utils/utils.hpp
@@ -58,9 +58,8 @@ inline uint64_t hash_str(const char* str, uint64_t size) {
   return XXH3_64bits(str, size);
 }
 
-template <typename T>
-inline uint64_t xxh_hash(T const& val) {
-  return XXH3_64bits(&val, sizeof(T));
+inline uint64_t xxh_hash(std::string const& val) {
+  return XXH3_64bits(val.data(), val.size());
 }
 
 inline uint64_t get_checksum(const void* data, uint64_t size) {

--- a/engine/utils/utils.hpp
+++ b/engine/utils/utils.hpp
@@ -58,6 +58,11 @@ inline uint64_t hash_str(const char* str, uint64_t size) {
   return XXH3_64bits(str, size);
 }
 
+template <typename T>
+inline uint64_t xxh_hash(T const& val) {
+  return XXH3_64bits(&val, sizeof(T));
+}
+
 inline uint64_t get_checksum(const void* data, uint64_t size) {
   return XXH3_64bits(data, size);
 }

--- a/engine/write_batch_impl.hpp
+++ b/engine/write_batch_impl.hpp
@@ -112,7 +112,7 @@ class WriteBatchImpl final : public WriteBatch {
     hash_ops.clear();
   }
 
-  size_t Size() const {
+  size_t Size() const final {
     return string_ops.size() + sorted_ops.size() + hash_ops.size();
   }
 

--- a/include/kvdk/write_batch.hpp
+++ b/include/kvdk/write_batch.hpp
@@ -26,6 +26,8 @@ class WriteBatch {
 
   virtual void Clear() = 0;
 
+  virtual size_t Size() const = 0;
+
   virtual ~WriteBatch() = default;
 };
 

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -740,6 +740,8 @@ TEST_F(EngineBasicTest, TestBatchWrite) {
     for (size_t i = 0; i < count; i++) {
       if (i % 2 == 0) {
         values[tid][i] = GetRandomString(120);
+        // The first Put is overwritten by the second Put.
+        batch->StringPut(keys[tid][i], GetRandomString(120));
         batch->StringPut(keys[tid][i], values[tid][i]);
       } else {
         values[tid][i].clear();

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -746,6 +746,7 @@ TEST_F(EngineBasicTest, TestBatchWrite) {
       } else {
         values[tid][i].clear();
         batch->StringDelete(keys[tid][i]);
+        batch->StringDelete(keys[tid][i]);
       }
       if ((i + 1) % batch_size == 0) {
         // Delete a non-existing key

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -750,6 +750,7 @@ TEST_F(EngineBasicTest, TestBatchWrite) {
       if ((i + 1) % batch_size == 0) {
         // Delete a non-existing key
         batch->StringDelete("asdf");
+        ASSERT_EQ(batch->Size(), batch_size + 1);
         ASSERT_EQ(engine->BatchWrite(batch), Status::Ok);
         batch->Clear();
       }


### PR DESCRIPTION
<!--
Thank you for contributing to KVDK.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

During BatchWrite, the new key-value pair will not be published to HashTable until all KVs in the batch is persisted to PMem. If a duplicate key exists in the write batch, the key is written twice, while the second write has no clue about the first write, leading to errors.
Thus, WriteBatch automatically removes the old KV in the batch. This has no visible effect to user.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test