### PR TITLE
Bug fix: skiplist destroy

### DIFF
--- a/engine/sorted_collection/skiplist.cpp
+++ b/engine/sorted_collection/skiplist.cpp
@@ -872,13 +872,10 @@ void Skiplist::destroyRecords() {
   std::vector<SpaceEntry> to_free;
   if (header_) {
     DLRecord* header_record = header_->record;
-    DLRecord* next_destroy =
-        pmem_allocator_->offset2addr_checked<DLRecord>(header_record->next);
     DLRecord* to_destroy = nullptr;
     do {
-      to_destroy = next_destroy;
-      next_destroy =
-          pmem_allocator_->offset2addr_checked<DLRecord>(to_destroy->next);
+      to_destroy =
+          pmem_allocator_->offset2addr_checked<DLRecord>(header_record->next);
       StringView key = to_destroy->Key();
       auto ul = hash_table_->AcquireLock(key);
       // We need to purge destroyed records one by one in case engine crashed


### PR DESCRIPTION
### What is changed and how it works?

In skiplist destroy, the destroying record may be freed by cleaner thread, so we can not follow its pointer.

In this patch, we always unlink and destroy header->next, as the header won't be modified.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

Side effects

- No
