### PR TITLE
Chaining old versions of List and HashSet

### DIFF
--- a/engine/generic_list.hpp
+++ b/engine/generic_list.hpp
@@ -49,6 +49,7 @@ class GenericList final : public Collection {
   // Lock table to lock individual elements
   // Redis List don't use lock_table, Redis Hash does.
   LockTable* lock_table{nullptr};
+  GenericList* old_list{nullptr};
 
  public:
   // Deletion of a node in GenericList takes two steps.
@@ -201,6 +202,8 @@ class GenericList final : public Collection {
   GenericList& operator=(GenericList const&) = delete;
   GenericList& operator=(GenericList&&) = delete;
   ~GenericList() {
+    delete old_list;
+    old_list = nullptr;
     list_record = nullptr;
     alloc = nullptr;
   }
@@ -223,6 +226,7 @@ class GenericList final : public Collection {
   void Destroy(DelayFree delay_free) {
     kvdk_assert(list_record != nullptr, "Destroy() uninitialized.");
     kvdk_assert(Size() == 0, "Only empty list can be Destroy()ed");
+    kvdk_assert(old_list == nullptr, "");
     kvdk_assert(!isRecordDirty(list_record), "double Destroy()!");
     markRecordAsDirty(list_record);
     delay_free(list_record);
@@ -302,6 +306,22 @@ class GenericList final : public Collection {
       }
       return iter;
     }
+  }
+
+  GenericList* OldVersion() const { return old_list; }
+
+  void AddOldVersion(GenericList* old) {
+    kvdk_assert(old_list == nullptr, "");
+    kvdk_assert(old_list->ID() < ID(), "");
+    kvdk_assert(
+        old_list->list_record->GetTimestamp() < list_record->GetTimestamp(),
+        "");
+    old_list = old;
+  }
+
+  void RemoveOldVersion() {
+    kvdk_assert(old_list != nullptr, "");
+    old_list = nullptr;
   }
 
   template <typename DelayFree>
@@ -821,6 +841,7 @@ class GenericListBuilder final {
   }
 
   void RebuildLists() {
+    std::unordered_map<StringView, List*> temp;
     countListElems();
     for (auto const& primer : primers) {
       if (primer.list_record == nullptr) {
@@ -832,7 +853,14 @@ class GenericListBuilder final {
       List* list = new List{};
       list->Restore(alloc, primer.list_record, primer.first, primer.last,
                     primer.size.load(), lock_table);
-      rebuilded_lists->emplace(list);
+      List* old_list = temp[list->Name()];
+      if (old_list != nullptr) {
+        list->AddOldVersion(old_list);
+      }
+      temp[list->Name()] = list;
+    }
+    for (auto const& pair : temp) {
+      rebuilded_lists->emplace(pair.second);
     }
   }
 

--- a/engine/generic_list.hpp
+++ b/engine/generic_list.hpp
@@ -312,11 +312,11 @@ class GenericList final : public Collection {
 
   void AddOldVersion(GenericList* old) {
     kvdk_assert(old_list == nullptr, "");
+    old_list = old;
     kvdk_assert(old_list->ID() < ID(), "");
     kvdk_assert(
         old_list->list_record->GetTimestamp() < list_record->GetTimestamp(),
         "");
-    old_list = old;
   }
 
   void RemoveOldVersion() {

--- a/engine/kv_engine_hash.cpp
+++ b/engine/kv_engine_hash.cpp
@@ -30,8 +30,16 @@ Status KVEngine::HashCreate(StringView key) {
   hlist->Init(pmem_allocator_.get(), space,
               version_controller_.GetCurrentTimestamp(), key,
               list_id_.fetch_add(1), hash_list_locks_.get());
+  HashList* old_hlist = nullptr;
+  if (result.s == Status::Outdated) {
+    old_hlist = result.entry.GetIndex().hlist;
+    hlist->AddOldVersion(old_hlist);
+  }
   {
     std::lock_guard<std::mutex> guard2{hlists_mu_};
+    if (old_hlist != nullptr) {
+      hash_lists_.erase(old_hlist);
+    }
     hash_lists_.emplace(hlist);
   }
   insertKeyOrElem(result, RecordType::HashRecord, hlist);
@@ -310,13 +318,17 @@ Status KVEngine::hashListRegisterRecovered() {
 
 Status KVEngine::hashListDestroy(HashList* hlist) {
   // Since hashListDestroy is only called after it's no longer visible,
-  // entries can be directly Free()d
+  // entries can be directly Free()-ed
   std::vector<SpaceEntry> entries;
   auto PushPending = [&](DLRecord* rec) {
     SpaceEntry space{pmem_allocator_->addr2offset_checked(rec),
                      rec->entry.header.record_size};
     entries.push_back(space);
   };
+  if (hlist->OldVersion() != nullptr) {
+    hlist->RemoveOldVersion();
+    hashListDestroy(hlist->OldVersion());
+  }
   while (hlist->Size() != 0) {
     StringView internal_key = hlist->Front()->Key();
     {

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -1359,6 +1359,8 @@ TEST_F(EngineBasicTest, TestList) {
   for (size_t i = 0; i < num_threads; i++) {
     key_vec[i] = "List_" + std::to_string(i);
     ASSERT_EQ(engine->ListCreate(key_vec[i]), Status::Ok);
+    ASSERT_EQ(engine->ListDestroy(key_vec[i]), Status::Ok);
+    ASSERT_EQ(engine->ListCreate(key_vec[i]), Status::Ok);
     for (size_t j = 0; j < count; j++) {
       elems_vec[i].push_back(std::to_string(i) + "_" + std::to_string(j));
     }
@@ -1524,6 +1526,8 @@ TEST_F(EngineBasicTest, TestHash) {
   ASSERT_EQ(Engine::Open(db_path.c_str(), &engine, configs, stdout),
             Status::Ok);
   std::string key{"Hash"};
+  ASSERT_EQ(engine->HashCreate(key), Status::Ok);
+  ASSERT_EQ(engine->HashDestroy(key), Status::Ok);
   ASSERT_EQ(engine->HashCreate(key), Status::Ok);
   using umap = std::unordered_map<std::string, std::string>;
   std::vector<umap> local_copies(num_threads);


### PR DESCRIPTION
Signed-off-by: ZiyanShi <ziyan.shi@intel.com>

<!--
Thank you for contributing to KVDK.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Chaining old versions of List and HashSet if an expired version is found on HashTable by ListCreate() or HashCreate() but yet destroyed by background cleaner.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
