### PR TITLE
Fix old version reset in sorted collection recovery

### DIFF
--- a/engine/sorted_collection/rebuilder.cpp
+++ b/engine/sorted_collection/rebuilder.cpp
@@ -88,7 +88,6 @@ Status SortedCollectionRebuilder::AddElement(DLRecord* record) {
             0 &&
         findCheckpointVersion(record) == record &&
         record->entry.meta.type == SortedElem) {
-      record->PersistOldVersion(kNullPMemOffset);
       SkiplistNode* start_node = nullptr;
       while (start_node == nullptr) {
         // Always build dram node for a recovery segment start record
@@ -333,6 +332,9 @@ Status SortedCollectionRebuilder::rebuildSegmentIndex(SkiplistNode* start_node,
       }
     }
   }
+  kvdk_assert(findCheckpointVersion(start_node->record) == start_node->record,
+              "start node of a recovery segment must be valid verion");
+  start_node->record->PersistOldVersion(kNullPMemOffset);
 
   SkiplistNode* cur_node = start_node;
   DLRecord* cur_record = cur_node->record;

--- a/engine/sorted_collection/rebuilder.cpp
+++ b/engine/sorted_collection/rebuilder.cpp
@@ -88,6 +88,7 @@ Status SortedCollectionRebuilder::AddElement(DLRecord* record) {
             0 &&
         findCheckpointVersion(record) == record &&
         record->entry.meta.type == SortedElem) {
+      record->PersistOldVersion(kNullPMemOffset);
       SkiplistNode* start_node = nullptr;
       while (start_node == nullptr) {
         // Always build dram node for a recovery segment start record

--- a/engine/sorted_collection/skiplist.cpp
+++ b/engine/sorted_collection/skiplist.cpp
@@ -649,7 +649,8 @@ Skiplist::WriteResult Skiplist::putImplWithHash(const StringView& key,
     ret.s = Status::PmemOverflow;
     return ret;
   }
-  auto lookup_result = hash_table_->Lookup<true>(internal_key, SortedElem);
+  auto lookup_result =
+      hash_table_->Lookup<true>(internal_key, SortedElem | SortedElemDelete);
   return putPreparedWithHash(lookup_result, key, value, timestamp, space);
 }
 
@@ -913,6 +914,7 @@ seek_write_position:
     ret.existing_record = nullptr;
     if (!lockInsertPosition(key, seek_result.prev_pmem_record,
                             seek_result.next_pmem_record, &insert_guard)) {
+      seek_result = Splice(this);
       Seek(key, &seek_result);
       goto seek_write_position;
     }

--- a/engine/sorted_collection/skiplist.cpp
+++ b/engine/sorted_collection/skiplist.cpp
@@ -649,8 +649,7 @@ Skiplist::WriteResult Skiplist::putImplWithHash(const StringView& key,
     ret.s = Status::PmemOverflow;
     return ret;
   }
-  auto lookup_result =
-      hash_table_->Lookup<true>(internal_key, SortedElem | SortedElemDelete);
+  auto lookup_result = hash_table_->Lookup<true>(internal_key, SortedElemType);
   return putPreparedWithHash(lookup_result, key, value, timestamp, space);
 }
 

--- a/engine/sorted_collection/skiplist.hpp
+++ b/engine/sorted_collection/skiplist.hpp
@@ -481,7 +481,10 @@ class Skiplist : public Collection {
       auto guard = lockRecordPosition(record, pmem_allocator_, record_locks_);
       DLRecord* prev =
           pmem_allocator_->offset2addr_checked<DLRecord>(record->prev);
-      if (prev->next == pmem_allocator_->addr2offset_checked(record)) {
+      DLRecord* next =
+          pmem_allocator_->offset2addr_checked<DLRecord>(record->next);
+      if (prev->next == pmem_allocator_->addr2offset_checked(record) &&
+          next->prev == pmem_allocator_->addr2offset_checked(record)) {
         return guard;
       }
     }

--- a/engine/sorted_collection/skiplist.hpp
+++ b/engine/sorted_collection/skiplist.hpp
@@ -481,10 +481,7 @@ class Skiplist : public Collection {
       auto guard = lockRecordPosition(record, pmem_allocator_, record_locks_);
       DLRecord* prev =
           pmem_allocator_->offset2addr_checked<DLRecord>(record->prev);
-      DLRecord* next =
-          pmem_allocator_->offset2addr_checked<DLRecord>(record->next);
-      if (prev->next == pmem_allocator_->addr2offset_checked(record) &&
-          next->prev == pmem_allocator_->addr2offset_checked(record)) {
+      if (prev->next == pmem_allocator_->addr2offset_checked(record)) {
         return guard;
       }
     }


### PR DESCRIPTION
<!--
Thank you for contributing to KVDK.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Issue Number: close #xxx <!-- REMOVE this line if no issue to close -->

Problem Summary:

Old version list of recovery segment start record in sorted collection rebuild not been reset, so its older version record may be free twice (in recovery and in background cleaner)

Also, there are some un-safe codes fixed in this patch.

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test