### PR TITLE
Classified large free space entry with thread cache in pmem allocator

### DIFF
--- a/engine/allocator.hpp
+++ b/engine/allocator.hpp
@@ -8,6 +8,14 @@
 
 namespace KVDK_NAMESPACE {
 struct SpaceEntry {
+  class SpaceCmp {
+   public:
+    bool operator()(const SpaceEntry& s1, const SpaceEntry& s2) const {
+      if (s1.size > s2.size) return true;
+      if (s1.size == s2.size && s1.offset < s2.offset) return true;
+      return false;
+    }
+  };
   SpaceEntry() = default;
 
   SpaceEntry(uint64_t _offset, uint64_t _size) : offset(_offset), size(_size) {}

--- a/engine/pmem_allocator/free_list.cpp
+++ b/engine/pmem_allocator/free_list.cpp
@@ -120,41 +120,50 @@ uint64_t SpaceMap::TryMerge(uint64_t offset, uint64_t max_merge_length,
 }
 
 void Freelist::OrganizeFreeSpace() {
-  MoveCachedListsToPool();
+  MoveCachedEntriesToPool();
   MergeSpaceInPool();
 }
 
 void Freelist::MergeSpaceInPool() {
   std::vector<PMemOffsetType> merging_list;
-  std::vector<std::vector<PMemOffsetType>> merged_entry_list(
-      max_classified_b_size_);
+  std::vector<std::vector<PMemOffsetType>> merged_small_entry_offsets(
+      max_small_entry_block_size_);
+  std::vector<std::set<SpaceEntry, SpaceEntry::SpaceCmp>> merged_large_entries(
+      max_large_entry_size_index_);
 
-  for (uint32_t b_size = 1; b_size < max_classified_b_size_; b_size++) {
+  for (uint32_t b_size = 1; b_size < max_small_entry_block_size_; b_size++) {
     while (active_pool_.TryFetchEntryList(merging_list, b_size)) {
       for (PMemOffsetType& offset : merging_list) {
         assert(offset % block_size_ == 0);
         auto b_offset = offset / block_size_;
-        uint64_t merged_blocks = MergeSpace(
+        uint64_t merged_blocks_ = MergeSpace(
             b_offset, num_segment_blocks_ - b_offset % num_segment_blocks_,
             b_size);
 
-        if (merged_blocks > 0) {
+        if (merged_blocks_ > 0) {
           // Persist merged free entry on PMem
-          if (merged_blocks > b_size) {
+          if (merged_blocks_ > b_size) {
             pmem_allocator_->persistSpaceEntry(offset,
-                                               merged_blocks * block_size_);
+                                               merged_blocks_ * block_size_);
           }
 
           // large space entries
-          if (merged_blocks >= merged_entry_list.size()) {
-            std::lock_guard<SpinMutex> lg(large_entries_spin_);
-            large_entries_.emplace(offset, merged_blocks * block_size_);
-            // move merged entries to merging pool to avoid redundant merging
+          if (merged_blocks_ >= merged_small_entry_offsets.size()) {
+            size_t size_index = blockSizeIndex(merged_blocks_);
+            merged_large_entries[size_index].emplace(
+                offset, merged_blocks_ * block_size_);
+            if (merged_large_entries[size_index].size() >= kMinMovableEntries) {
+              // move merged entries to merging pool to avoid redundant merging
+              merged_pool_.MoveLargeEntrySet(merged_large_entries[size_index],
+                                             size_index);
+            }
           } else {
-            merged_entry_list[merged_blocks].emplace_back(offset);
-            if (merged_entry_list[merged_blocks].size() >= kMinMovableEntries) {
-              merged_pool_.MoveEntryList(merged_entry_list[merged_blocks],
-                                         merged_blocks);
+            merged_small_entry_offsets[merged_blocks_].emplace_back(offset);
+            if (merged_small_entry_offsets[merged_blocks_].size() >=
+                kMinMovableEntries) {
+              // move merged entries to merging pool to avoid redundant merging
+              merged_pool_.MoveEntryList(
+                  merged_small_entry_offsets[merged_blocks_], merged_blocks_);
             }
           }
         }
@@ -162,14 +171,27 @@ void Freelist::MergeSpaceInPool() {
     }
   }
 
-  std::vector<PMemOffsetType> merged_list;
-  for (uint32_t b_size = 1; b_size < max_classified_b_size_; b_size++) {
-    while (merged_pool_.TryFetchEntryList(merged_list, b_size)) {
-      active_pool_.MoveEntryList(merged_list, b_size);
+  for (uint32_t b_size = 1; b_size < merged_small_entry_offsets.size();
+       b_size++) {
+    if (merged_small_entry_offsets[b_size].size() > 0) {
+      active_pool_.MoveEntryList(merged_small_entry_offsets[b_size], b_size);
     }
+    while (merged_pool_.TryFetchEntryList(merged_small_entry_offsets[b_size],
+                                          b_size)) {
+      active_pool_.MoveEntryList(merged_small_entry_offsets[b_size], b_size);
+    }
+  }
 
-    if (merged_entry_list[b_size].size() > 0) {
-      active_pool_.MoveEntryList(merged_entry_list[b_size], b_size);
+  for (size_t size_index = 0; size_index < merged_large_entries.size();
+       size_index++) {
+    if (merged_large_entries[size_index].size() > 0) {
+      active_pool_.MoveLargeEntrySet(merged_large_entries[size_index],
+                                     size_index);
+    }
+    while (merged_pool_.TryFetchLargeEntrySet(merged_large_entries[size_index],
+                                              size_index)) {
+      active_pool_.MoveLargeEntrySet(merged_large_entries[size_index],
+                                     size_index);
     }
   }
 }
@@ -181,40 +203,57 @@ void Freelist::Push(const SpaceEntry& entry) {
   auto b_size = entry.size / block_size_;
   auto b_offset = entry.offset / block_size_;
   space_map_.Set(b_offset, b_size);
+
   auto& flist_thread_cache = flist_thread_cache_[access_thread.id];
-  if (b_size >= flist_thread_cache.active_entry_offsets.size()) {
-    std::lock_guard<SpinMutex> lg(large_entries_spin_);
-    large_entries_.emplace(entry);
+  if (b_size >= flist_thread_cache.small_entry_offsets.size()) {
+    size_t size_index = blockSizeIndex(b_size);
+    std::lock_guard<SpinMutex> lg(
+        flist_thread_cache.large_entry_spins[size_index]);
+    flist_thread_cache.large_entries[size_index].insert(entry);
   } else {
-    std::lock_guard<SpinMutex> lg(flist_thread_cache.spins[b_size]);
-    flist_thread_cache.active_entry_offsets[b_size].emplace_back(entry.offset);
+    std::lock_guard<SpinMutex> lg(flist_thread_cache.small_entry_spins[b_size]);
+    flist_thread_cache.small_entry_offsets[b_size].emplace_back(entry.offset);
   }
 }
 
 uint64_t Freelist::BatchPush(const std::vector<SpaceEntry>& entries) {
   uint64_t pushed_size = 0;
-  Array<std::vector<PMemOffsetType>> moving_list(max_classified_b_size_);
+  std::vector<std::vector<PMemOffsetType>> moving_small_entry_list(
+      max_small_entry_block_size_);
+  std::vector<std::set<SpaceEntry, SpaceEntry::SpaceCmp>>
+      moving_large_entry_set(max_large_entry_size_index_);
   for (const SpaceEntry& entry : entries) {
     kvdk_assert(entry.size % block_size_ == 0,
                 "batch freed entry size is not aligned to block size");
     uint32_t b_size = entry.size / block_size_;
     uint64_t b_offset = entry.offset / block_size_;
     space_map_.Set(b_offset, b_size);
-    if (b_size < max_classified_b_size_) {
-      moving_list[b_size].emplace_back(entry.offset);
-      if (moving_list[b_size].size() == kMinMovableEntries) {
-        active_pool_.MoveEntryList(moving_list[b_size], b_size);
+    if (b_size < max_small_entry_block_size_) {
+      moving_small_entry_list[b_size].emplace_back(entry.offset);
+      if (moving_small_entry_list[b_size].size() == kMinMovableEntries) {
+        active_pool_.MoveEntryList(moving_small_entry_list[b_size], b_size);
       }
     } else {
-      std::lock_guard<SpinMutex> lg(large_entries_spin_);
-      large_entries_.emplace(entry);
+      size_t size_index = blockSizeIndex(b_size);
+      moving_large_entry_set[size_index].insert(entry);
+      if (moving_large_entry_set[size_index].size() == kMinMovableEntries) {
+        active_pool_.MoveLargeEntrySet(moving_large_entry_set[size_index],
+                                       size_index);
+      }
     }
     pushed_size += entry.size;
   }
 
-  for (uint32_t b_size = 1; b_size < moving_list.size(); b_size++) {
-    if (moving_list[b_size].size() > 0) {
-      active_pool_.MoveEntryList(moving_list[b_size], b_size);
+  for (uint32_t b_size = 1; b_size < moving_small_entry_list.size(); b_size++) {
+    if (moving_small_entry_list[b_size].size() > 0) {
+      active_pool_.MoveEntryList(moving_small_entry_list[b_size], b_size);
+    }
+  }
+  for (uint32_t size_index = 0; size_index < moving_large_entry_set.size();
+       size_index++) {
+    if (moving_large_entry_set[size_index].size() > 0) {
+      active_pool_.MoveLargeEntrySet(moving_large_entry_set[size_index],
+                                     size_index);
     }
   }
   return pushed_size;
@@ -222,31 +261,64 @@ uint64_t Freelist::BatchPush(const std::vector<SpaceEntry>& entries) {
 
 bool Freelist::Get(uint32_t size, SpaceEntry* space_entry) {
   assert(size % block_size_ == 0);
-  auto b_size = size / block_size_;
-  auto& flist_thread_cache = flist_thread_cache_[access_thread.id];
-  for (uint32_t i = b_size; i < flist_thread_cache.active_entry_offsets.size();
-       i++) {
-    bool found = false;
-  search_entry : {
-    std::lock_guard<SpinMutex> lg(flist_thread_cache.spins[i]);
-    if (flist_thread_cache.active_entry_offsets[i].size() == 0) {
-      if (!active_pool_.TryFetchEntryList(
-              flist_thread_cache.active_entry_offsets[i], i) &&
-          !merged_pool_.TryFetchEntryList(
-              flist_thread_cache.active_entry_offsets[i], i)) {
-        // no usable b_size free space entry
-        continue;
+  if (getSmallEntry(size, space_entry)) {
+    return true;
+  }
+  return getLargeEntry(size, space_entry);
+}
+
+void Freelist::MoveCachedEntriesToPool() {
+  std::vector<PMemOffsetType> moving_small_entry_list;
+  std::set<SpaceEntry, SpaceEntry::SpaceCmp> moving_large_entry_set;
+  for (uint64_t i = 0; i < flist_thread_cache_.size(); i++) {
+    auto& tc = flist_thread_cache_[i];
+
+    for (size_t b_size = 1; b_size < tc.small_entry_offsets.size(); b_size++) {
+      moving_small_entry_list.clear();
+      {
+        std::lock_guard<SpinMutex> lg(tc.small_entry_spins[b_size]);
+        if (tc.small_entry_offsets[b_size].size() > 0) {
+          moving_small_entry_list.swap(tc.small_entry_offsets[b_size]);
+        }
       }
+
+      active_pool_.MoveEntryList(moving_small_entry_list, b_size);
     }
 
-    if (flist_thread_cache.active_entry_offsets[i].size() != 0) {
-      space_entry->offset = flist_thread_cache.active_entry_offsets[i].back();
-      flist_thread_cache.active_entry_offsets[i].pop_back();
-      found = true;
+    for (size_t size_index = 0; size_index < tc.large_entries.size();
+         size_index++) {
+      moving_large_entry_set.clear();
+      {
+        std::lock_guard<SpinMutex> lg(tc.large_entry_spins[size_index]);
+        if (tc.large_entries[size_index].size() > 0) {
+          moving_large_entry_set.swap(tc.large_entries[size_index]);
+        }
+      }
+
+      active_pool_.MoveLargeEntrySet(moving_large_entry_set, size_index);
     }
   }
+}
 
-    if (found) {
+bool Freelist::getSmallEntry(uint32_t size, SpaceEntry* space_entry) {
+  auto b_size = size / block_size_;
+  auto& flist_thread_cache = flist_thread_cache_[access_thread.id];
+  for (uint32_t i = b_size; i < flist_thread_cache.small_entry_offsets.size();
+       i++) {
+  search_entry:
+    std::lock_guard<SpinMutex> lg(flist_thread_cache.small_entry_spins[i]);
+    if (flist_thread_cache.small_entry_offsets[i].size() == 0 &&
+        !active_pool_.TryFetchEntryList(
+            flist_thread_cache.small_entry_offsets[i], i) &&
+        !merged_pool_.TryFetchEntryList(
+            flist_thread_cache.small_entry_offsets[i], i)) {
+      // no usable b_size free space entry
+      continue;
+    }
+
+    if (flist_thread_cache.small_entry_offsets[i].size() > 0) {
+      space_entry->offset = flist_thread_cache.small_entry_offsets[i].back();
+      flist_thread_cache.small_entry_offsets[i].pop_back();
       assert(space_entry->offset % block_size_ == 0);
       auto b_offset = space_entry->offset / block_size_;
       if (space_map_.TestAndUnset(b_offset, i) == i) {
@@ -256,76 +328,40 @@ bool Freelist::Get(uint32_t size, SpaceEntry* space_entry) {
       goto search_entry;
     }
   }
-
-  if (!large_entries_.empty()) {
-    std::lock_guard<SpinMutex> lg(large_entries_spin_);
-    while (!large_entries_.empty()) {
-      auto large_entry = large_entries_.begin();
-      auto entry_size = large_entry->size;
-      auto entry_offset = large_entry->offset;
-      assert(entry_size % block_size_ == 0);
-      assert(entry_offset % block_size_ == 0);
-      auto entry_b_size = entry_size / block_size_;
-      auto entry_b_offset = entry_offset / block_size_;
-      if (entry_b_size >= b_size) {
-        space_entry->offset = large_entry->offset;
-        large_entries_.erase(large_entry);
-        if (space_map_.TestAndUnset(entry_b_offset, entry_b_size) ==
-            entry_b_size) {
-          space_entry->size = entry_size;
-          return true;
-        }
-      } else {
-        break;
-      }
-    }
-  }
   return false;
 }
 
-void Freelist::MoveCachedListsToPool() {
-  std::vector<PMemOffsetType> moving_list;
-  for (uint64_t i = 0; i < flist_thread_cache_.size(); i++) {
-    auto& tc = flist_thread_cache_[i];
+bool Freelist::getLargeEntry(uint32_t size, SpaceEntry* space_entry) {
+  auto b_size = size / block_size_;
+  auto& flist_thread_cache = flist_thread_cache_[access_thread.id];
 
-    for (size_t b_size = 1; b_size < tc.active_entry_offsets.size(); b_size++) {
-      moving_list.clear();
-      {
-        std::lock_guard<SpinMutex> lg(tc.spins[b_size]);
-        if (tc.active_entry_offsets[b_size].size() > 0) {
-          moving_list.swap(tc.active_entry_offsets[b_size]);
-        }
-      }
-
-      if (moving_list.size() > 0) {
-        active_pool_.MoveEntryList(moving_list, b_size);
+  auto size_index = blockSizeIndex(b_size);
+  for (size_t i = size_index; i < flist_thread_cache.large_entries.size();
+       i++) {
+    std::lock_guard<SpinMutex> lg(flist_thread_cache.large_entry_spins[i]);
+    if (flist_thread_cache.large_entries[i].size() == 0) {
+      if (!active_pool_.TryFetchLargeEntrySet(
+              flist_thread_cache.large_entries[i], i) &&
+          !merged_pool_.TryFetchLargeEntrySet(
+              flist_thread_cache.large_entries[i], i)) {
+        // no suitable free space entry in this size
+        continue;
       }
     }
-  }
-}
 
-bool Freelist::MergeGet(uint32_t size, SpaceEntry* space_entry) {
-  assert(size % block_size_ == 0);
-  auto b_size = size / block_size_;
-  auto& cache_list = flist_thread_cache_[access_thread.id].active_entry_offsets;
-  for (uint32_t i = 1; i < max_classified_b_size_; i++) {
-    size_t j = 0;
-    while (j < cache_list[i].size()) {
-      assert(cache_list[i][j] % block_size_ == 0);
-      auto b_offset = cache_list[i][j] / block_size_;
-      uint64_t merged_blocks = MergeSpace(
-          b_offset, num_segment_blocks_ - b_offset % num_segment_blocks_,
-          b_size);
-      if (merged_blocks >= b_size) {
-        space_entry->offset = cache_list[i][j];
-        std::swap(cache_list[i][j], cache_list[i].back());
-        cache_list[i].pop_back();
-        if (space_map_.TestAndUnset(b_offset, merged_blocks) == merged_blocks) {
-          space_entry->size = merged_blocks * block_size_;
-          return true;
-        }
+    auto iter = flist_thread_cache.large_entries[i].begin();
+    while (iter != flist_thread_cache.large_entries[i].end()) {
+      if (iter->size < size) {
+        break;
+      }
+      auto b_offset = iter->offset / block_size_;
+      auto b_size = iter->size / block_size_;
+      if (space_map_.TestAndUnset(b_offset, b_size) == b_size) {
+        *space_entry = *iter;
+        iter = flist_thread_cache.large_entries[i].erase(iter);
+        return true;
       } else {
-        j++;
+        iter = flist_thread_cache.large_entries[i].erase(iter);
       }
     }
   }

--- a/engine/pmem_allocator/free_list.cpp
+++ b/engine/pmem_allocator/free_list.cpp
@@ -129,7 +129,7 @@ void Freelist::MergeSpaceInPool() {
   std::vector<std::vector<PMemOffsetType>> merged_small_entry_offsets(
       max_small_entry_block_size_);
   std::vector<std::set<SpaceEntry, SpaceEntry::SpaceCmp>> merged_large_entries(
-      max_large_entry_size_index_);
+      max_block_size_index_);
 
   for (uint32_t b_size = 1; b_size < max_small_entry_block_size_; b_size++) {
     while (active_pool_.TryFetchEntryList(merging_list, b_size)) {
@@ -221,7 +221,7 @@ uint64_t Freelist::BatchPush(const std::vector<SpaceEntry>& entries) {
   std::vector<std::vector<PMemOffsetType>> moving_small_entry_list(
       max_small_entry_block_size_);
   std::vector<std::set<SpaceEntry, SpaceEntry::SpaceCmp>>
-      moving_large_entry_set(max_large_entry_size_index_);
+      moving_large_entry_set(max_block_size_index_);
   for (const SpaceEntry& entry : entries) {
     kvdk_assert(entry.size % block_size_ == 0,
                 "batch freed entry size is not aligned to block size");

--- a/engine/pmem_allocator/free_list.hpp
+++ b/engine/pmem_allocator/free_list.hpp
@@ -164,12 +164,13 @@ class Freelist {
       : num_segment_blocks_(num_segment_blocks),
         block_size_(block_size),
         max_small_entry_block_size_(max_small_entry_b_size),
-        max_large_entry_size_index_(kMaxBlockSizeIndex),
-        active_pool_(max_small_entry_b_size, max_large_entry_size_index_),
-        merged_pool_(max_small_entry_b_size, max_large_entry_size_index_),
+        max_block_size_index_(std::min(
+            kMaxBlockSizeIndex, blockSizeIndex(num_segment_blocks_) + 1)),
+        active_pool_(max_small_entry_b_size, max_block_size_index_),
+        merged_pool_(max_small_entry_b_size, max_block_size_index_),
         space_map_(num_blocks),
         flist_thread_cache_(num_threads, max_small_entry_block_size_,
-                            max_large_entry_size_index_),
+                            max_block_size_index_),
         pmem_allocator_(allocator) {}
 
   Freelist(uint64_t num_segment_blocks, uint32_t block_size,
@@ -256,7 +257,7 @@ class Freelist {
                        ? 0
                        : (block_size - max_small_entry_block_size_) /
                              kBlockSizeIndexInterval;
-    return std::min(ret, max_large_entry_size_index_ - 1);
+    return std::min(ret, max_block_size_index_ - 1);
   }
 
   bool getSmallEntry(uint32_t size, SpaceEntry* space_entry);
@@ -266,7 +267,7 @@ class Freelist {
   const uint64_t num_segment_blocks_;
   const uint32_t block_size_;
   const uint32_t max_small_entry_block_size_;
-  const uint32_t max_large_entry_size_index_;
+  const uint32_t max_block_size_index_;
   SpaceEntryPool active_pool_;
   SpaceEntryPool merged_pool_;
   SpaceMap space_map_;

--- a/engine/pmem_allocator/free_list.hpp
+++ b/engine/pmem_allocator/free_list.hpp
@@ -13,7 +13,9 @@
 
 namespace KVDK_NAMESPACE {
 
-constexpr uint32_t kFreelistMaxClassifiedBlockSize = 255;
+constexpr uint32_t kMaxSmallBlockSize = 255;
+constexpr uint32_t kMaxBlockSizeIndex = 255;
+constexpr uint32_t kBlockSizeIndexInterval = 1024;
 constexpr uint32_t kSpaceMapLockGranularity = 64;
 
 class PMEMAllocator;
@@ -88,25 +90,56 @@ class SpaceMap {
 //                    |-----   list2
 class SpaceEntryPool {
  public:
-  SpaceEntryPool(uint32_t max_classified_b_size)
-      : pool_(max_classified_b_size), spins_(max_classified_b_size) {}
+  SpaceEntryPool(uint32_t max_small_entry_b_size,
+                 uint32_t max_large_entry_size_index)
+      : small_entry_pool_(max_small_entry_b_size),
+        large_entry_pool_(max_large_entry_size_index),
+        small_entry_spins_(max_small_entry_b_size),
+        large_entry_spins_(max_large_entry_size_index) {}
 
   // move a list of b_size free space entries to pool, "src" will be empty
   // after move
   void MoveEntryList(std::vector<PMemOffsetType>& src, uint32_t b_size) {
-    std::lock_guard<SpinMutex> lg(spins_[b_size]);
-    assert(b_size < pool_.size());
-    pool_[b_size].emplace_back();
-    pool_[b_size].back().swap(src);
+    if (src.size() > 0) {
+      std::lock_guard<SpinMutex> lg(small_entry_spins_[b_size]);
+      assert(b_size < small_entry_pool_.size());
+      small_entry_pool_[b_size].emplace_back();
+      small_entry_pool_[b_size].back().swap(src);
+    }
   }
 
   // try to fetch b_size free space entries from a entry list of pool to dst
   bool TryFetchEntryList(std::vector<PMemOffsetType>& dst, uint32_t b_size) {
-    if (pool_[b_size].size() != 0) {
-      std::lock_guard<SpinMutex> lg(spins_[b_size]);
-      if (pool_[b_size].size() != 0) {
-        dst.swap(pool_[b_size].back());
-        pool_[b_size].pop_back();
+    if (small_entry_pool_[b_size].size() != 0) {
+      std::lock_guard<SpinMutex> lg(small_entry_spins_[b_size]);
+      if (small_entry_pool_[b_size].size() != 0) {
+        dst.swap(small_entry_pool_[b_size].back());
+        small_entry_pool_[b_size].pop_back();
+        return true;
+      }
+    }
+    return false;
+  }
+
+  void MoveLargeEntrySet(std::set<SpaceEntry, SpaceEntry::SpaceCmp>& src,
+                         size_t size_index) {
+    if (src.size() > 0) {
+      kvdk_assert(size_index < large_entry_pool_.size(), "");
+      std::lock_guard<SpinMutex> lg(large_entry_spins_[size_index]);
+      large_entry_pool_[size_index].emplace_back();
+      large_entry_pool_[size_index].back().swap(src);
+    }
+  }
+
+  // Try to fetch large space entries set with size_index from pool to dst
+  bool TryFetchLargeEntrySet(std::set<SpaceEntry, SpaceEntry::SpaceCmp>& dst,
+                             size_t size_index) {
+    kvdk_assert(size_index < large_entry_pool_.size(), "");
+    if (large_entry_pool_[size_index].size() != 0) {
+      std::lock_guard<SpinMutex> lg(large_entry_spins_[size_index]);
+      if (large_entry_pool_[size_index].size() != 0) {
+        dst.swap(large_entry_pool_[size_index].back());
+        large_entry_pool_[size_index].pop_back();
         return true;
       }
     }
@@ -114,29 +147,35 @@ class SpaceEntryPool {
   }
 
  private:
-  std::vector<std::vector<std::vector<PMemOffsetType>>> pool_;
-  // Entry lists of a same block size share a spin lock
-  std::vector<SpinMutex> spins_;
+  std::vector<std::vector<std::vector<PMemOffsetType>>> small_entry_pool_;
+  std::vector<std::vector<std::set<SpaceEntry, SpaceEntry::SpaceCmp>>>
+      large_entry_pool_;
+  // Small entry lists of a same block size share a spin lock
+  std::vector<SpinMutex> small_entry_spins_;
+  // Large entry set of same size index share a spin lock
+  std::vector<SpinMutex> large_entry_spins_;
 };
 
 class Freelist {
  public:
-  Freelist(uint32_t max_classified_b_size, uint64_t num_segment_blocks,
+  Freelist(uint32_t max_small_entry_b_size, uint64_t num_segment_blocks,
            uint32_t block_size, uint32_t num_threads, uint64_t num_blocks,
            PMEMAllocator* allocator)
       : num_segment_blocks_(num_segment_blocks),
         block_size_(block_size),
-        max_classified_b_size_(max_classified_b_size),
-        active_pool_(max_classified_b_size),
-        merged_pool_(max_classified_b_size),
+        max_small_entry_block_size_(max_small_entry_b_size),
+        max_large_entry_size_index_(kMaxBlockSizeIndex),
+        active_pool_(max_small_entry_b_size, max_large_entry_size_index_),
+        merged_pool_(max_small_entry_b_size, max_large_entry_size_index_),
         space_map_(num_blocks),
-        flist_thread_cache_(num_threads, max_classified_b_size),
+        flist_thread_cache_(num_threads, max_small_entry_block_size_,
+                            max_large_entry_size_index_),
         pmem_allocator_(allocator) {}
 
   Freelist(uint64_t num_segment_blocks, uint32_t block_size,
            uint32_t num_threads, uint64_t num_blocks, PMEMAllocator* allocator)
-      : Freelist(kFreelistMaxClassifiedBlockSize, num_segment_blocks,
-                 block_size, num_threads, num_blocks, allocator) {}
+      : Freelist(kMaxSmallBlockSize, num_segment_blocks, block_size,
+                 num_threads, num_blocks, allocator) {}
 
   // Add a space entry
   void Push(const SpaceEntry& entry);
@@ -144,12 +183,8 @@ class Freelist {
   // Add a batch of space entry to free list entries pool, return pushed size
   uint64_t BatchPush(const std::vector<SpaceEntry>& entries);
 
-  // Request a at least "size" free space entry
+  // Request a free space entry that equal to or larger than "size"
   bool Get(uint32_t size, SpaceEntry* space_entry);
-
-  // Try to merge thread-cached free space entries to get a at least "size"
-  // entry
-  bool MergeGet(uint32_t size, SpaceEntry* space_entry);
 
   // Merge adjacent free spaces stored in the entry pool into larger one
   //
@@ -159,6 +194,7 @@ class Freelist {
   // active_pool_ for next run. Calculate the minimal timestamp of free entries
   // in the pool meantime
   // TODO: set a condition to decide if we need to do merging
+  // Notice: we do not merge large entries for performance
   void MergeSpaceInPool();
 
   // Move cached free space list to space entry pool to balance usable space
@@ -166,7 +202,7 @@ class Freelist {
   //
   // Iterate every active entry lists of thread caches, move the list to
   // active_pool_, and update minimal timestamp of free entries meantime
-  void MoveCachedListsToPool();
+  void MoveCachedEntriesToPool();
 
   // Origanize free space entries, including merging adjacent space and move
   // thread cached space entries to pool
@@ -178,28 +214,31 @@ class Freelist {
   // many entries cached by a thread, newly freed entries will be stored to
   // backup_entries and move to entry pool which shared by all threads.
   struct alignas(64) FlistThreadCache {
-    FlistThreadCache(uint32_t max_classified_b_size)
-        : active_entry_offsets(max_classified_b_size),
-          spins(max_classified_b_size) {}
+    FlistThreadCache(uint32_t max_small_entry_b_size,
+                     size_t max_large_entry_size_index)
+        : small_entry_offsets(max_small_entry_b_size),
+          large_entries(max_large_entry_size_index),
+          small_entry_spins(max_small_entry_b_size),
+          large_entry_spins(max_large_entry_size_index) {}
 
     FlistThreadCache() = delete;
     FlistThreadCache(FlistThreadCache&&) = delete;
     FlistThreadCache(const FlistThreadCache&) = delete;
 
-    // Offsets of active entries, entry size stored in block unit indicated by
-    // Array index
-    Array<std::vector<PMemOffsetType>> active_entry_offsets;
-    // Protect active_entry_offsets
-    Array<SpinMutex> spins;
-  };
-
-  class SpaceCmp {
-   public:
-    bool operator()(const SpaceEntry& s1, const SpaceEntry& s2) const {
-      if (s1.size > s2.size) return true;
-      if (s1.size == s2.size && s1.offset < s2.offset) return true;
-      return false;
-    }
+    // Offsets of small free space entries whose block size smaller than
+    // max_small_entry_b_size. Array index indicates block size of entries
+    // stored in the vector
+    Array<std::vector<PMemOffsetType>> small_entry_offsets;
+    // Store all large free space entries whose block size larger than
+    // max_small_entry_b_size. Array index indicates entries stored in the set
+    // have block size between (max_small_entry_b_size + index *
+    // kBlockSizeIndexInterval) and (max_small_entry_b_size +
+    // (index + 1) * kBlockSizeIndexInterval)
+    Array<std::set<SpaceEntry, SpaceEntry::SpaceCmp>> large_entries;
+    // Protect small_entry_offsets
+    Array<SpinMutex> small_entry_spins;
+    // Protect large_entries
+    Array<SpinMutex> large_entry_spins;
   };
 
   uint64_t MergeSpace(uint64_t offset, uint64_t max_size,
@@ -211,17 +250,28 @@ class Freelist {
     return size;
   }
 
+  uint32_t blockSizeIndex(uint32_t block_size) {
+    kvdk_assert(block_size <= num_segment_blocks_, "");
+    uint32_t ret = block_size < max_small_entry_block_size_
+                       ? 0
+                       : (block_size - max_small_entry_block_size_) /
+                             kBlockSizeIndexInterval;
+    return std::min(ret, max_large_entry_size_index_ - 1);
+  }
+
+  bool getSmallEntry(uint32_t size, SpaceEntry* space_entry);
+
+  bool getLargeEntry(uint32_t size, SpaceEntry* space_entry);
+
   const uint64_t num_segment_blocks_;
   const uint32_t block_size_;
-  const uint32_t max_classified_b_size_;
+  const uint32_t max_small_entry_block_size_;
+  const uint32_t max_large_entry_size_index_;
   SpaceEntryPool active_pool_;
   SpaceEntryPool merged_pool_;
   SpaceMap space_map_;
   Array<FlistThreadCache> flist_thread_cache_;
   PMEMAllocator* pmem_allocator_;
-  // Store all large free space entries that larger than max_classified_b_size_
-  // TODO: use multimap instead of set
-  std::set<SpaceEntry, SpaceCmp> large_entries_;
   SpinMutex large_entries_spin_;
 };
 


### PR DESCRIPTION
### What problem does this PR solve?

All large free space entries share one global set, which causes high contention overhead

### What is changed and how it works?

What's Changed:

Use similar cache and pool mechanism for large space entries, but store them classified according to their size to save search time. In this patch, size in every 1024 blocks share a free list. For example, size [2K blocks, 3K blocks), [3K blocks, 4K blocks), ... 

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
