### PR TITLE
Use std::exit instead of exception to implement crash point

### DIFF
--- a/engine/kv_engine.cpp
+++ b/engine/kv_engine.cpp
@@ -1038,7 +1038,7 @@ Status KVEngine::batchWriteImpl(WriteBatchImpl const& batch) {
     kvdk_assert(s == Status::Ok, "");
   }
 
-  TEST_CRASH_POINT("KVEngine::batchWriteImpl::BeforeCommit", "");
+  TEST_CRASH_POINT("KVEngine::batchWriteImpl::BeforeCommit");
 
   BatchWriteLog::MarkCommitted(tc.batch_log);
 
@@ -1834,7 +1834,7 @@ Status KVEngine::ListMove(StringView src, int src_pos, StringView dst,
   } else {
     src_list->PopBack([&](DLRecord*) { return; });
   }
-  TEST_CRASH_POINT("KVEngine::ListMove", "");
+  TEST_CRASH_POINT("KVEngine::ListMove");
   if (dst_pos == 0) {
     dst_list->PushFront(space, bw_token.Timestamp(), "", sw);
   } else {
@@ -2096,13 +2096,13 @@ Status KVEngine::listBatchPushImpl(StringView key, int pos,
   if (pos == 0) {
     for (size_t i = 0; i < elems.size(); i++) {
       list->PushFront(spaces[i], bw_token.Timestamp(), "", elems[i]);
-      TEST_CRASH_POINT("KVEngine::listBatchPushImpl", "");
+      TEST_CRASH_POINT("KVEngine::listBatchPushImpl");
     }
   } else {
     kvdk_assert(pos == -1, "");
     for (size_t i = 0; i < elems.size(); i++) {
       list->PushBack(spaces[i], bw_token.Timestamp(), "", elems[i]);
-      TEST_CRASH_POINT("KVEngine::listBatchPushImpl", "");
+      TEST_CRASH_POINT("KVEngine::listBatchPushImpl");
     }
   }
   BatchWriteLog::MarkCommitted(tc.batch_log);
@@ -2156,12 +2156,12 @@ Status KVEngine::listBatchPopImpl(StringView key, int pos, size_t n,
   if (pos == 0) {
     for (size_t i = 0; i < n && list->Size() > 0; i++) {
       list->PopFront([&](DLRecord* rec) { old_records.push_back(rec); });
-      TEST_CRASH_POINT("KVEngine::listBatchPopImpl", "");
+      TEST_CRASH_POINT("KVEngine::listBatchPopImpl");
     }
   } else {
     for (size_t i = 0; i < n && list->Size() > 0; i++) {
       list->PopBack([&](DLRecord* rec) { old_records.push_back(rec); });
-      TEST_CRASH_POINT("KVEngine::listBatchPopImpl", "");
+      TEST_CRASH_POINT("KVEngine::listBatchPopImpl");
     }
   }
   BatchWriteLog::MarkCommitted(tc.batch_log);

--- a/engine/sorted_collection/skiplist.cpp
+++ b/engine/sorted_collection/skiplist.cpp
@@ -165,7 +165,8 @@ void Skiplist::linkDLRecord(DLRecord* prev, DLRecord* next, DLRecord* linking,
   uint64_t inserting_record_offset = pmem_allocator->addr2offset(linking);
   prev->next = inserting_record_offset;
   pmem_persist(&prev->next, 8);
-  TEST_SYNC_POINT("KVEngine::Skiplist::LinkDLRecord::HalfLink");
+  TEST_CRASH_POINT_PREDICATE("KVEngine::Skiplist::LinkDLRecord::HalfLink",
+                             nullptr);
   next->prev = inserting_record_offset;
   pmem_persist(&next->prev, 8);
 }

--- a/engine/utils/sync_point.cpp
+++ b/engine/utils/sync_point.cpp
@@ -29,12 +29,14 @@ void SyncPoint::LoadDependency(const std::vector<SyncPointPair>& dependencies) {
   sync_impl_->LoadDependency(dependencies);
 }
 
-void SyncPoint::EnableCrashPoint(std::string const& name) {
-  sync_impl_->EnableCrashPoint(name);
+void SyncPoint::EnableCrashPoint(std::string const& name,
+                                 std::string const& msg,
+                                 std::function<bool(void*)> pred) {
+  sync_impl_->EnableCrashPoint(name, msg, pred);
 }
 
-void SyncPoint::Crash(std::string const& name, std::string const& msg) {
-  sync_impl_->Crash(name, msg);
+void SyncPoint::Crash(std::string const& name, void* args) {
+  sync_impl_->Crash(name, args);
 }
 
 void SyncPoint::EnableProcessing() { sync_impl_->EnableProcessing(); }
@@ -52,6 +54,7 @@ void SyncPoint::ClearDependTrace() { sync_impl_->ClearDependTrace(); }
 
 void SyncPoint::Reset() { sync_impl_->Reset(); }
 
+std::string const SyncPoint::DefaultCrashMessage = "Crashed";
 }  // namespace KVDK_NAMESPACE
 
 #endif

--- a/engine/utils/sync_point.hpp
+++ b/engine/utils/sync_point.hpp
@@ -38,7 +38,6 @@ namespace KVDK_NAMESPACE {
  */
 class SyncPoint {
  public:
-  using CrashPoint = SyncImpl::CrashPoint;
   static SyncPoint* GetInstance();
   SyncPoint(const SyncPoint&) = delete;
   SyncPoint& operator=(const SyncPoint&) = delete;
@@ -52,9 +51,14 @@ class SyncPoint {
   void SetCallBack(const std::string& point,
                    const std::function<void(void*)>& callback);
 
-  void EnableCrashPoint(std::string const& name);
+  static std::string const DefaultCrashMessage;
+  // msg will be printed to stderr before exit(-1) and will be captured by gtest
+  // for checking.
+  void EnableCrashPoint(std::string const& name,
+                        std::string const& msg = DefaultCrashMessage,
+                        std::function<bool(void*)> pred = nullptr);
 
-  void Crash(std::string const& name, std::string const& msg);
+  void Crash(std::string const& name, void* args = nullptr);
 
   void ClearAllCallBacks();
 
@@ -74,11 +78,13 @@ class SyncPoint {
 #define TEST_SYNC_POINT(x) KVDK_NAMESPACE::SyncPoint::GetInstance()->Process(x)
 #define TEST_SYNC_POINT_CALLBACK(x, y) \
   KVDK_NAMESPACE::SyncPoint::GetInstance()->Process(x, y)
-#define TEST_CRASH_POINT(name, msg) \
-  KVDK_NAMESPACE::SyncPoint::GetInstance()->Crash(name, msg)
+#define TEST_CRASH_POINT(name) \
+  KVDK_NAMESPACE::SyncPoint::GetInstance()->Crash(name)
+#define TEST_CRASH_POINT_PREDICATE(name, args) \
+  KVDK_NAMESPACE::SyncPoint::GetInstance()->Crash(name, args)
 
 #else
 #define TEST_SYNC_POINT(x)
 #define TEST_SYNC_POINT_CALLBACK(x, y)
-#define TEST_CRASH_POINT(name, msg)
+#define TEST_CRASH_POINT(name, pred, args)
 #endif

--- a/engine/utils/sync_point.hpp
+++ b/engine/utils/sync_point.hpp
@@ -86,5 +86,6 @@ class SyncPoint {
 #else
 #define TEST_SYNC_POINT(x)
 #define TEST_SYNC_POINT_CALLBACK(x, y)
-#define TEST_CRASH_POINT(name, pred, args)
+#define TEST_CRASH_POINT(name)
+#define TEST_CRASH_POINT_PREDICATE(name, args)
 #endif

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -753,7 +753,7 @@ TEST_F(EngineBasicTest, TestStringModify) {
   delete engine;
 }
 
-TEST_F(EngineBasicTest, BatchWriteSorted) {
+TEST_F(BatchWriteTest, BatchWriteSorted) {
   size_t num_threads = 1;
   configs.max_access_threads = num_threads + 1;
   for (int index_with_hashtable : {0, 1}) {


### PR DESCRIPTION
<!--
Thank you for contributing to KVDK.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Use std::exit instead of exception to implement crash point so that we can kill all threads within the process.

Tests <!-- At least one of them must be included. -->

- Unit test failed

