### PR TITLE
Clean cached outdated records in foreground threads

### DIFF
--- a/engine/kv_engine.cpp
+++ b/engine/kv_engine.cpp
@@ -1324,12 +1324,12 @@ T* KVEngine::removeOutDatedVersion(T* record, TimeStampType min_snapshot_ts) {
         pmem_allocator_->offset2addr_checked<T>(old_record->old_version);
     ret = remove_record;
     old_record->PersistOldVersion(kNullPMemOffset);
-    while (remove_record != nullptr) {
-      if (remove_record->GetRecordStatus() == RecordStatus::Normal) {
-        remove_record->PersistStatus(RecordStatus::Dirty);
-      }
-      remove_record = pmem_allocator_->offset2addr<T>(old_record->old_version);
+    // while (remove_record != nullptr) {
+    if (remove_record->GetRecordStatus() == RecordStatus::Normal) {
+      remove_record->PersistStatus(RecordStatus::Dirty);
     }
+    // remove_record = nullptr;
+    // }
   }
   return ret;
 }

--- a/engine/kv_engine.hpp
+++ b/engine/kv_engine.hpp
@@ -140,9 +140,16 @@ class KVEngine : public Engine {
   };
 
   struct CleanerThreadCache {
+    struct PendingFreeRecord {
+      PendingFreeRecord(TimeStampType _release_time, void* _record)
+          : release_time(_release_time), record(_record) {}
+
+      TimeStampType release_time;
+      void* record;
+    };
+
     CleanerThreadCache() = default;
-    std::vector<StringRecord*> old_str_records;
-    std::vector<DLRecord*> old_dl_records;
+    std::deque<PendingFreeRecord> outdated_records;
     SpinMutex mtx;
   };
 

--- a/engine/kv_engine.hpp
+++ b/engine/kv_engine.hpp
@@ -600,10 +600,13 @@ class KVEngine : public Engine {
   // Run in background to free obsolete DRAM space
   void backgroundDramCleaner();
 
+  template <typename T>
+  void removeAndCacheOutdatedVersion(T* new_record);
+
   void backgroundCleanRecords(size_t start_slot_idx, size_t end_slot_idx);
 
   // Clean a outdated record in cleaner_thread_cache_
-  void tryCleanCachedOutdatedRecord();
+  void tryCleanCachedOutdatedRecords();
 
   template <typename T>
   void cleanOutdatedRecordImpl(T* record);

--- a/engine/kv_engine.hpp
+++ b/engine/kv_engine.hpp
@@ -281,10 +281,11 @@ class KVEngine : public Engine {
                   "Invalid type!");
     return std::is_same<CollectionType, Skiplist>::value
                ? RecordType::SortedHeader
-           : std::is_same<CollectionType, List>::value ? RecordType::ListRecord
-           : std::is_same<CollectionType, HashList>::value
-               ? RecordType::HashRecord
-               : RecordType::Empty;
+               : std::is_same<CollectionType, List>::value
+                     ? RecordType::ListRecord
+                     : std::is_same<CollectionType, HashList>::value
+                           ? RecordType::HashRecord
+                           : RecordType::Empty;
   }
 
   static PointerType pointerType(RecordType rtype) {

--- a/engine/kv_engine.hpp
+++ b/engine/kv_engine.hpp
@@ -611,8 +611,9 @@ class KVEngine : public Engine {
   void tryCleanCachedOutdatedRecord();
   template <typename T>
   void cleanOutdatedRecordImpl(T* record);
-  void deleteCollections();
   /* functions for cleaner thread cache */
+
+  void deleteCollections();
 
   void startBackgroundWorks();
 

--- a/engine/kv_engine.hpp
+++ b/engine/kv_engine.hpp
@@ -142,11 +142,11 @@ class KVEngine : public Engine {
   struct CleanerThreadCache {
     template <typename T>
     struct OutdatedRecord {
-      OutdatedRecord(TimeStampType _release_time, T* _record)
-          : release_time(_release_time), record(_record) {}
+      OutdatedRecord(T* _record, TimeStampType _release_time)
+          : record(_record), release_time(_release_time) {}
 
-      TimeStampType release_time;
       T* record;
+      TimeStampType release_time;
     };
 
     CleanerThreadCache() = default;
@@ -600,18 +600,18 @@ class KVEngine : public Engine {
   // Run in background to free obsolete DRAM space
   void backgroundDramCleaner();
 
-  template <typename T>
-  void removeAndCacheOutdatedVersion(T* new_record);
-
   void backgroundCleanRecords(size_t start_slot_idx, size_t end_slot_idx);
 
+  /* functions for cleaner thread cache */
+  // Remove old version records from version chain of new_record and cache it
+  template <typename T>
+  void removeAndCacheOutdatedVersion(T* new_record);
   // Clean a outdated record in cleaner_thread_cache_
-  void tryCleanCachedOutdatedRecords();
-
+  void tryCleanCachedOutdatedRecord();
   template <typename T>
   void cleanOutdatedRecordImpl(T* record);
-
   void deleteCollections();
+  /* functions for cleaner thread cache */
 
   void startBackgroundWorks();
 

--- a/engine/kv_engine_cleaner.cpp
+++ b/engine/kv_engine_cleaner.cpp
@@ -206,31 +206,6 @@ void KVEngine::CleanOutDated(size_t start_slot_idx, size_t end_slot_idx) {
        * lock conflict.
        */
       if (slot_num++ % kSlotSegment == 0) {
-        std::vector<StringRecord*> tmp_string_records;
-        std::vector<DLRecord*> tmp_dl_records;
-        {  // Deal with old records from forground
-          round_robin_id_ = (round_robin_id_ + 1) % configs_.max_access_threads;
-          auto& tc = cleaner_thread_cache_[round_robin_id_];
-          std::unique_lock<SpinMutex> lock(tc.mtx);
-          if (!tc.old_str_records.empty()) {
-            tmp_string_records.swap(tc.old_str_records);
-            need_purge_num += tmp_string_records.size();
-          }
-          if (!tc.old_dl_records.empty()) {
-            tmp_dl_records.swap(tc.old_dl_records);
-            need_purge_num += tmp_dl_records.size();
-          }
-        }
-        if (!tmp_string_records.empty()) {
-          purge_string_records.insert(purge_string_records.end(),
-                                      tmp_string_records.begin(),
-                                      tmp_string_records.end());
-        }
-        if (!tmp_dl_records.empty()) {
-          purge_dl_records.insert(purge_dl_records.end(),
-                                  tmp_dl_records.begin(), tmp_dl_records.end());
-        }
-
         // total_num + kWakeUpThreshold to avoid division by zero.
         if (need_purge_num / (double)(total_num + kWakeUpThreshold) <
             kWakeUpThreshold) {

--- a/engine/kv_engine_sorted.cpp
+++ b/engine/kv_engine_sorted.cpp
@@ -260,7 +260,7 @@ Status KVEngine::SortedDeleteImpl(Skiplist* skiplist,
   if (ret.existing_record && ret.write_record) {
     removeAndCacheOutdatedVersion(ret.write_record);
   }
-  tryCleanCachedOutdatedRecords();
+  tryCleanCachedOutdatedRecord();
 
   return ret.s;
 }
@@ -280,7 +280,7 @@ Status KVEngine::SortedPutImpl(Skiplist* skiplist, const StringView& user_key,
   if (ret.existing_record) {
     removeAndCacheOutdatedVersion<DLRecord>(ret.write_record);
   }
-  tryCleanCachedOutdatedRecords();
+  tryCleanCachedOutdatedRecord();
 
   return ret.s;
 }

--- a/engine/kv_engine_sorted.cpp
+++ b/engine/kv_engine_sorted.cpp
@@ -270,28 +270,18 @@ Status KVEngine::SortedPutImpl(Skiplist* skiplist, const StringView& user_key,
   TimeStampType new_ts = version_controller_.GetCurrentTimestamp();
   auto ret = skiplist->Put(user_key, value, new_ts);
 
-  auto& tc = cleaner_thread_cache_[access_thread.id];
   // Collect outdated version records
   if (ret.existing_record) {
     auto old_record = removeOutDatedVersion<DLRecord>(
         ret.write_record, version_controller_.GlobalOldestSnapshotTs());
     if (old_record) {
+      auto& tc = cleaner_thread_cache_[access_thread.id];
       std::unique_lock<SpinMutex> lock(tc.mtx);
-      tc.outdated_records.emplace_back(
+      tc.outdated_dl_records.emplace_back(
           version_controller_.GetCurrentTimestamp(), old_record);
     }
   }
-
-  if (!tc.outdated_records.empty()) {
-    std::lock_guard<SpinMutex> lg(tc.mtx);
-    if (!tc.outdated_records.empty()) {
-      TimeStampType release_time = version_controller_.LocalOldestSnapshotTS();
-      if (tc.outdated_records.front().release_time < release_time) {
-        purgeAndFree(tc.outdated_records.front().record);
-        tc.outdated_records.pop_front();
-      }
-    }
-  }
+  tryCleanCachedOutdatedRecord();
 
   return ret.s;
 }

--- a/engine/kv_engine_sorted.cpp
+++ b/engine/kv_engine_sorted.cpp
@@ -256,6 +256,12 @@ Status KVEngine::SortedDeleteImpl(Skiplist* skiplist,
   TimeStampType new_ts = version_controller_.GetCurrentTimestamp();
 
   auto ret = skiplist->Delete(user_key, new_ts);
+
+  if (ret.existing_record && ret.write_record) {
+    removeAndCacheOutdatedVersion(ret.write_record);
+  }
+  tryCleanCachedOutdatedRecords();
+
   return ret.s;
 }
 
@@ -272,16 +278,9 @@ Status KVEngine::SortedPutImpl(Skiplist* skiplist, const StringView& user_key,
 
   // Collect outdated version records
   if (ret.existing_record) {
-    auto old_record = removeOutDatedVersion<DLRecord>(
-        ret.write_record, version_controller_.GlobalOldestSnapshotTs());
-    if (old_record) {
-      auto& tc = cleaner_thread_cache_[access_thread.id];
-      std::unique_lock<SpinMutex> lock(tc.mtx);
-      tc.outdated_dl_records.emplace_back(
-          version_controller_.GetCurrentTimestamp(), old_record);
-    }
+    removeAndCacheOutdatedVersion<DLRecord>(ret.write_record);
   }
-  tryCleanCachedOutdatedRecord();
+  tryCleanCachedOutdatedRecords();
 
   return ret.s;
 }

--- a/engine/kv_engine_string.cpp
+++ b/engine/kv_engine_string.cpp
@@ -181,7 +181,7 @@ Status KVEngine::StringDeleteImpl(const StringView& key) {
 
     removeAndCacheOutdatedVersion(pmem_ptr);
   }
-  tryCleanCachedOutdatedRecords();
+  tryCleanCachedOutdatedRecord();
 
   return (lookup_result.s == Status::NotFound ||
           lookup_result.s == Status::Outdated)
@@ -243,7 +243,7 @@ Status KVEngine::StringPutImpl(const StringView& key, const StringView& value,
   if (existing_record) {
     removeAndCacheOutdatedVersion(new_record);
   }
-  tryCleanCachedOutdatedRecords();
+  tryCleanCachedOutdatedRecord();
 
   return Status::Ok;
 }

--- a/engine/version/old_records_cleaner.cpp
+++ b/engine/version/old_records_cleaner.cpp
@@ -47,7 +47,7 @@ void OldRecordsCleaner::TryGlobalClean() {
   std::vector<SpaceEntry> space_to_free;
   // Update recorded oldest snapshot up to state so we can know which records
   // can be freed
-  kv_engine_->version_controller_.UpdatedOldestSnapshot();
+  kv_engine_->version_controller_.UpdateLocalOldestSnapshot();
   TimeStampType oldest_snapshot_ts =
       kv_engine_->version_controller_.LocalOldestSnapshotTS();
 
@@ -92,7 +92,7 @@ void OldRecordsCleaner::maybeUpdateOldestSnapshot() {
   constexpr size_t kUpdateSnapshotRound = 10000;
   thread_local size_t round = 0;
   if ((++round) % kUpdateSnapshotRound == 0) {
-    kv_engine_->version_controller_.UpdatedOldestSnapshot();
+    kv_engine_->version_controller_.UpdateLocalOldestSnapshot();
   }
 }
 

--- a/engine/version/version_controller.hpp
+++ b/engine/version/version_controller.hpp
@@ -182,7 +182,7 @@ class VersionController {
   void Init(uint64_t base_timestamp) {
     tsc_on_startup_ = rdtsc();
     base_timestamp_ = base_timestamp;
-    UpdatedOldestSnapshot();
+    UpdateLocalOldestSnapshot();
   }
 
   LocalSnapshotHolder GetLocalSnapshotHolder() {
@@ -272,7 +272,7 @@ class VersionController {
 
   // Update recorded oldest snapshot up to state by iterating every thread
   // holding snapshot
-  void UpdatedOldestSnapshot() {
+  void UpdateLocalOldestSnapshot() {
     // update local oldest snapshot
     TimeStampType ts = GetCurrentTimestamp();
     for (size_t i = 0; i < version_thread_cache_.size(); i++) {

--- a/include/kvdk/configs.hpp
+++ b/include/kvdk/configs.hpp
@@ -133,7 +133,7 @@ struct Configs {
   ComparatorTable comparator;
 
   // Background clean thread numbers.
-  uint64_t clean_threads = 32;
+  uint64_t clean_threads = 8;
 };
 
 struct WriteOptions {

--- a/scripts/run_benchmark.py
+++ b/scripts/run_benchmark.py
@@ -18,6 +18,11 @@ pmem_size = 384 * 1024 * 1024 * 1024  # we need enough space to test insert
 num_collection = 16
 
 benchmarks = [
+    benchmark_impl.batch_insert_random,
+    benchmark_impl.insert_random,
+    benchmark_impl.range_scan,
+    benchmark_impl.read_random,
+    benchmark_impl.read_write_random,
     benchmark_impl.update_random]
 
 data_types = []

--- a/scripts/run_benchmark.py
+++ b/scripts/run_benchmark.py
@@ -18,11 +18,6 @@ pmem_size = 384 * 1024 * 1024 * 1024  # we need enough space to test insert
 num_collection = 16
 
 benchmarks = [
-    benchmark_impl.batch_insert_random,
-    benchmark_impl.insert_random,
-    benchmark_impl.range_scan,
-    benchmark_impl.read_random,
-    benchmark_impl.read_write_random,
     benchmark_impl.update_random]
 
 data_types = []


### PR DESCRIPTION
### What is changed and how it works?

What's Changed:

- Clean outdated records in foreground threads to improve performance
- Background thread do global cache clean before every purge for correctness

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

Performance:
- Updated performance improved 50%
