### PR TITLE
Pause longer in TTS spinlock to optimize performance.

### DIFF
--- a/engine/utils/utils.hpp
+++ b/engine/utils/utils.hpp
@@ -176,8 +176,10 @@ class SpinMutex {
   SpinMutex() = default;
 
   void lock() {
-    while (locked.test_and_set(std::memory_order_acquire)) {
-      asm volatile("pause");
+    while (!try_lock()) {
+      for (size_t i = 0; i != 64; ++i) {
+        _mm_pause();
+      }
     }
   }
 


### PR DESCRIPTION
Signed-off-by: ZiyanShi <ziyan.shi@intel.com>

<!--
Thank you for contributing to KVDK.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Fix the performance drop when scanning SortedSets.

### What is changed and how it works?

Pause longer in spinlock if fail to acquire the lock and retry.
This reduce the XCHG instructions emitted by cores and thus reduce the cache coherency protocol overhead.

Tests <!-- At least one of them must be included. -->

- Unit test

Side effects

- Performance(Only changes greater than 3% are listed, batch write for Zipfian distributions are not listed because baseline is low)
-- String, uniform distribution, batch write improves by 3%.
-- String, Zipfian distribution, improve insertion by 50%, update by 70%.
-- SortedSet, uniform distribution, fix range scan performance drop and improve by 20%.
-- SortedSet, Zipfian distribution, improve insertion by 3%, fixed range scan performance drop and improve by 15%, improve update by 50%.
-- HashSet, uniform distribution, none.
-- HashSet, Zipfian distribution, improve insertion by 70%, update by 150%.
-- List, uniform distribution, none.
-- List, Zipfian distribution, none.

