### PR TITLE
Fix List and Hash Iterator Behavior

### DIFF
--- a/engine/hash_list.hpp
+++ b/engine/hash_list.hpp
@@ -20,13 +20,19 @@ class HashIteratorImpl final : public HashIterator {
     return (rep != list->Tail());
   }
 
-  void Next() final { ++rep; }
+  void Next() final {
+    if (!Valid()) return;
+    ++rep;
+  }
 
-  void Prev() final { --rep; }
+  void Prev() final {
+    if (!Valid()) return;
+    --rep;
+  }
 
   std::string Key() const final {
     if (!Valid()) {
-      kvdk_assert(false, "Accessing data with invalid ListIterator!");
+      kvdk_assert(false, "Accessing data with invalid HashIterator!");
       return std::string{};
     }
     auto sw = Collection::ExtractUserKey(rep->Key());
@@ -35,7 +41,7 @@ class HashIteratorImpl final : public HashIterator {
 
   std::string Value() const final {
     if (!Valid()) {
-      kvdk_assert(false, "Accessing data with invalid ListIterator!");
+      kvdk_assert(false, "Accessing data with invalid HashIterator!");
       return std::string{};
     }
     auto sw = rep->Value();
@@ -43,6 +49,10 @@ class HashIteratorImpl final : public HashIterator {
   }
 
   bool MatchKey(std::regex const& re) final {
+    if (!Valid()) {
+      kvdk_assert(false, "Accessing data with invalid HashIterator!");
+      return false;
+    }
     return std::regex_match(Key(), re);
   }
 

--- a/engine/simple_list.hpp
+++ b/engine/simple_list.hpp
@@ -19,9 +19,15 @@ class ListIteratorImpl final : public ListIterator {
 
   void SeekToLast() final { rep = list->Back(); }
 
-  void Next() final { ++rep; }
+  void Next() final {
+    if (!Valid()) return;
+    ++rep;
+  }
 
-  void Prev() final { --rep; }
+  void Prev() final {
+    if (!Valid()) return;
+    --rep;
+  }
 
   void SeekToFirst(StringView elem) final {
     SeekToFirst();


### PR DESCRIPTION
Signed-off-by: ZiyanShi <ziyan.shi@intel.com>

<!--
Thank you for contributing to KVDK.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Calling `Prev()` and `Next()` on a `Iterator` where `Valid() == false` will do nothing. This prevents misuse of an invalid iterator when user forgets to check `Valid()` right after a call of `Seek()`.

Tests <!-- At least one of them must be included. -->

- Unit test

