### PR TITLE
Dynamically adjust background cleaner thread

### DIFF
--- a/engine/cleaner.hpp
+++ b/engine/cleaner.hpp
@@ -1,0 +1,127 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright(c) 2021-2022 Intel Corporation
+ */
+#pragma once
+
+#include <stdio.h>
+
+#include <atomic>
+#include <condition_variable>
+#include <deque>
+#include <functional>
+#include <future>
+#include <mutex>
+#include <queue>
+#include <thread>
+#include <vector>
+
+#include "alias.hpp"
+#include "collection.hpp"
+#include "hash_table.hpp"
+#include "utils/utils.hpp"
+
+namespace KVDK_NAMESPACE {
+
+struct PendingFreeSpaceEntries {
+  std::vector<SpaceEntry> entries;
+  // Indicate timestamp of the oldest refered snapshot of kvdk instance while we
+  // could safely free these entries
+  TimeStampType release_time;
+};
+
+struct PendingFreeSpaceEntry {
+  SpaceEntry entry;
+  // Indicate timestamp of the oldest refered snapshot of kvdk instance while we
+  // could safely free this entry
+  TimeStampType release_time;
+};
+
+struct PendingPurgeStrRecords {
+  std::vector<StringRecord*> records;
+  TimeStampType release_time;
+};
+
+struct PendingPurgeDLRecords {
+  std::vector<DLRecord*> records;
+  TimeStampType release_time;
+};
+
+struct PendingPrugeFreeRecords {
+  using ListPtr = std::unique_ptr<List>;
+  using HashListPtr = std::unique_ptr<HashList>;
+
+  std::deque<std::pair<TimeStampType, ListPtr>> outdated_lists;
+  std::deque<std::pair<TimeStampType, HashListPtr>> outdated_hash_lists;
+  std::deque<std::pair<TimeStampType, Skiplist*>> outdated_skip_lists;
+  std::deque<PendingPurgeStrRecords> pending_purge_strings;
+  std::deque<PendingPurgeDLRecords> pending_purge_dls;
+  std::deque<Skiplist*> no_index_skiplists;
+  size_t Size() {
+    return outdated_lists.size() + outdated_hash_lists.size() +
+           outdated_skip_lists.size() + pending_purge_strings.size() +
+           pending_purge_dls.size();
+  }
+};
+
+class KVEngine;
+
+class SpaceReclaimer {
+ public:
+  static constexpr int64_t kSlotBlockUnit = 1024;
+  static constexpr double kWakeUpThreshold = 0.1;
+
+  SpaceReclaimer(KVEngine* kv_engine, int64_t max_cleaner_threads)
+      : kv_engine_(kv_engine),
+        max_thread_num_(max_cleaner_threads),
+        close_(false),
+        cur_slot_idx_(-kSlotBlockUnit),
+        live_thread_num_(0),
+        workers_(max_cleaner_threads) {
+    for (size_t thread_id = 0; thread_id < max_thread_num_; ++thread_id) {
+      idled_workers_.push_back(thread_id);
+    }
+  }
+
+  ~SpaceReclaimer() { CloseAllWorkers(); }
+
+  void CloseAllWorkers();
+  void AdjustThread(size_t advice_thread_num);
+
+  void StartReclaim();
+
+  size_t ReclaimerThreadNum() { return live_thread_num_.load(); }
+
+ private:
+  enum class ThreadStatus { Init, Main, Sub, Recycle };
+  struct ThreadWorker {
+    ThreadStatus status;
+    std::thread worker;
+    std::mutex mtx;
+  };
+  KVEngine* kv_engine_;
+  PendingPrugeFreeRecords pending_clean_records_;
+
+  size_t max_thread_num_;
+  size_t min_thread_num_ = 1;
+  std::atomic_bool close_;
+  std::atomic_int64_t cur_slot_idx_;
+  std::atomic<size_t> live_thread_num_;
+  std::vector<ThreadWorker> workers_;
+  std::deque<size_t> idled_workers_;
+  std::deque<size_t> actived_workers_;
+
+ private:
+  void addSubWorker(size_t thread_id);
+  void joinWorker();
+  void mainWorker();
+};
+
+inline void SpaceReclaimer::CloseAllWorkers() {
+  close_ = true;
+  for (size_t i = 0; i < workers_.size(); ++i) {
+    if (workers_[i].worker.joinable()) {
+      workers_[i].worker.join();
+    }
+  }
+}
+}  // namespace KVDK_NAMESPACE

--- a/engine/kv_engine.cpp
+++ b/engine/kv_engine.cpp
@@ -125,12 +125,12 @@ void KVEngine::startBackgroundWorks() {
   TEST_SYNC_POINT_CALLBACK("KVEngine::backgroundCleaner::NothingToDo",
                            &close_reclaimer);
   if (!close_reclaimer) {
-    space_reclaimer_.StartReclaim();
+    cleaner_.StartClean();
   }
 }
 
 void KVEngine::terminateBackgroundWorks() {
-  space_reclaimer_.CloseAllWorkers();
+  cleaner_.CloseAllWorkers();
   {
     std::unique_lock<SpinMutex> ul(bg_work_signals_.terminating_lock);
     bg_work_signals_.terminating = true;

--- a/engine/version/old_records_cleaner.hpp
+++ b/engine/version/old_records_cleaner.hpp
@@ -8,9 +8,9 @@
 #include <vector>
 
 #include "../alias.hpp"
-#include "../cleaner.hpp"
 #include "../collection.hpp"
 #include "../hash_table.hpp"
+#include "../kv_engine_cleaner.hpp"
 #include "../thread_manager.hpp"
 #include "../utils/utils.hpp"
 #include "kvdk/configs.hpp"

--- a/engine/version/old_records_cleaner.hpp
+++ b/engine/version/old_records_cleaner.hpp
@@ -8,6 +8,7 @@
 #include <vector>
 
 #include "../alias.hpp"
+#include "../cleaner.hpp"
 #include "../collection.hpp"
 #include "../hash_table.hpp"
 #include "../thread_manager.hpp"
@@ -17,20 +18,6 @@
 
 namespace KVDK_NAMESPACE {
 class KVEngine;
-
-struct PendingFreeSpaceEntries {
-  std::vector<SpaceEntry> entries;
-  // Indicate timestamp of the oldest refered snapshot of kvdk instance while we
-  // could safely free these entries
-  TimeStampType release_time;
-};
-
-struct PendingFreeSpaceEntry {
-  SpaceEntry entry;
-  // Indicate timestamp of the oldest refered snapshot of kvdk instance while we
-  // could safely free this entry
-  TimeStampType release_time;
-};
 
 // OldRecordsCleaner is used to clean old version PMem records of kvdk
 //


### PR DESCRIPTION
### What problem does this PR solve?
Dynamically adjust cleaner's thread according to outdated records ratio of a slot block. 

### What is changed and how it works?

What's Changed:
    Replaced fixed cleaner thread  by dynamically adjust cleaner thread. 
    When having lots of outdated records, the cleaner thread will reach max cleaner thread user set.
    When inserting new records, only the one thread is running.
    The cleaner's thread number depends on the outdated records ratio of a slot block.
     
- Unit test
   All passed.  Add "TestDynamicSpaceReclaimer" to check if the number of threads can be dynamically increased or decreased.
- Integration test
- No code

Side effects
   Not found.

**_Performance bench:_**
![image](https://user-images.githubusercontent.com/7602435/176843791-54a8cce1-06b7-4bd7-a572-a6f641b3e013.png)
![image](https://user-images.githubusercontent.com/7602435/176847749-0cd67fed-5b7a-45c3-bb36-27e3442a7cb4.png)

![image](https://user-images.githubusercontent.com/7602435/176858225-b02c29f6-f29f-41ba-bc29-2286f656f9bc.png)



**_Performance large expire/delete records:_**
_Thread configure：32 access thread ，32 clean threads。_
When having large expire/delete records, the background clean thread number would reach maximum.
string expire/delete: 1000w ops.
sorted expire sorted collection: 1000w ops.
list expire list collection: 1000w ops.
hash expire hash collection: 1000w ops.