### PR TITLE
Add keyword volatile to prevent compiler optimization

### DIFF
--- a/engine/sorted_collection/rebuilder.cpp
+++ b/engine/sorted_collection/rebuilder.cpp
@@ -606,8 +606,7 @@ bool SortedCollectionRebuilder::checkAndRepairRecordLinkage(DLRecord* record) {
   if (Skiplist::CheckRecordPrevLinkage(record, pmem_allocator)) {
     DLRecord* next =
         pmem_allocator->offset2addr_checked<DLRecord>(record->next);
-    next->prev = pmem_allocator->addr2offset_checked(record);
-    pmem_persist(&next->prev, sizeof(PMemOffsetType));
+    next->PersistPrevCLWB(pmem_allocator->addr2offset_checked(record));
     return true;
   }
 


### PR DESCRIPTION
Signed-off-by: ZiyanShi <ziyan.shi@intel.com>

<!--
Thank you for contributing to KVDK.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Add volatile keyword to volatile fields in Record to prevent compiler from optimizing out some necessary operations or reordering certain memory operations.

Tests <!-- At least one of them must be included. -->

- Unit test
