### PR TITLE
Add compiler barrier to fix an assertion failure

### DIFF
--- a/engine/data_record.hpp
+++ b/engine/data_record.hpp
@@ -134,6 +134,13 @@ struct StringRecord {
     return false;
   }
 
+  bool ValidOrDirty() {
+    bool valid = Validate();
+    asm volatile("" ::: "memory");
+    bool dirty = (GetRecordStatus() == RecordStatus::Dirty);
+    return (valid || dirty);
+  }
+
   // Check whether the record corrupted with expected checksum
   bool Validate(uint32_t expected_checksum) {
     if (ValidateRecordSize()) {

--- a/engine/kv_engine_string.cpp
+++ b/engine/kv_engine_string.cpp
@@ -133,10 +133,7 @@ Status KVEngine::Get(const StringView key, std::string* value) {
     kvdk_assert(string_record->GetRecordType() == RecordType::String &&
                     string_record->GetRecordStatus() != RecordStatus::Outdated,
                 "Got wrong data type in string get");
-    kvdk_assert((string_record->GetRecordStatus() == RecordStatus::Normal &&
-                 string_record->Validate()) ||
-                    string_record->GetRecordStatus() == RecordStatus::Dirty,
-                "Corrupted data in string get");
+    kvdk_assert(string_record->ValidOrDirty(), "Corrupted data in string get");
     value->assign(string_record->Value().data(), string_record->Value().size());
     return Status::Ok;
   } else {


### PR DESCRIPTION
Signed-off-by: ZiyanShi <ziyan.shi@intel.com>

<!--
Thank you for contributing to KVDK.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

An assertion fires because compiler optimized out a necessary memory load.

### What is changed and how it works?

Add a compiler barrier to prevent memory reorder.

Tests <!-- At least one of them must be included. -->

- Unit test
