### PR TITLE
Add update ttl option for write options

### DIFF
--- a/engine/c/kvdk_basic_op.cpp
+++ b/engine/c/kvdk_basic_op.cpp
@@ -58,6 +58,11 @@ void KVDKWriteOptionsSetTTLTime(KVDKWriteOptions* kv_options,
   kv_options->rep.ttl_time = ttl_time;
 }
 
+void KVDKWriteOptionsSetUpdateTTL(KVDKWriteOptions* kv_options,
+                                  int update_ttl) {
+  kv_options->rep.update_ttl = update_ttl;
+}
+
 KVDKStatus KVDKOpen(const char* name, const KVDKConfigs* config, FILE* log_file,
                     KVDKEngine** kv_engine) {
   Engine* engine;

--- a/engine/kv_engine_string.cpp
+++ b/engine/kv_engine_string.cpp
@@ -14,10 +14,6 @@ Status KVEngine::Modify(const StringView key, ModifyFunc modify_func,
     return Status::InvalidArgument;
   }
 
-  ExpireTimeType expired_time = write_options.ttl_time == kPersistTime
-                                    ? kPersistTime
-                                    : write_options.ttl_time + base_time;
-
   Status s = MaybeInitAccessThread();
   if (s != Status::Ok) {
     return s;
@@ -52,6 +48,12 @@ Status KVEngine::Modify(const StringView key, ModifyFunc modify_func,
       if (!CheckValueSize(new_value)) {
         return Status::InvalidDataSize;
       }
+
+      ExpireTimeType expired_time =
+          lookup_result.s == Status::Ok && !write_options.update_ttl
+              ? existing_record->GetExpireTime()
+              : TimeUtils::TTLToExpireTime(write_options.ttl_time, base_time);
+
       SpaceEntry space_entry =
           pmem_allocator_->Allocate(StringRecord::RecordSize(key, new_value));
       if (space_entry.size == 0) {
@@ -197,9 +199,6 @@ Status KVEngine::StringPutImpl(const StringView& key, const StringView& value,
     return Status::InvalidArgument;
   }
 
-  ExpireTimeType expired_time =
-      TimeUtils::TTLToExpireTime(write_options.ttl_time, base_time);
-
   TEST_SYNC_POINT("KVEngine::StringPutImpl::BeforeLock");
   auto ul = hash_table_->AcquireLock(key);
   auto holder = version_controller_.GetLocalSnapshotHolder();
@@ -223,10 +222,14 @@ Status KVEngine::StringPutImpl(const StringView& key, const StringView& value,
   kvdk_assert(!existing_record || new_ts > existing_record->GetTimestamp(),
               "existing record has newer timestamp or wrong return status in "
               "string set");
+  ExpireTimeType expired_time =
+      lookup_result.s == Status::Ok && !write_options.update_ttl
+          ? existing_record->GetExpireTime()
+          : TimeUtils::TTLToExpireTime(write_options.ttl_time, base_time);
 
   // Persist key-value pair to PMem
-  uint32_t requested_size = value.size() + key.size() + sizeof(StringRecord);
-  SpaceEntry space_entry = pmem_allocator_->Allocate(requested_size);
+  SpaceEntry space_entry =
+      pmem_allocator_->Allocate(StringRecord::RecordSize(key, value));
   if (space_entry.size == 0) {
     return Status::PmemOverflow;
   }

--- a/examples/tutorial/c_api_tutorial.c
+++ b/examples/tutorial/c_api_tutorial.c
@@ -454,6 +454,14 @@ void ExpireExample(KVDKEngine* kvdk_engine) {
     s = KVDKGetTTL(kvdk_engine, key, strlen(key), &ttl_time);
     assert(s == Ok);
     assert(ttl_time == INT64_MAX);
+    // case: keep expire time unchanged while updating a existing key
+    KVDKWriteOptionsSetUpdateTTL(write_option, 0);
+    KVDKWriteOptionsSetTTLTime(write_option, 0);
+    s = KVDKPut(kvdk_engine, key, strlen(key), val, strlen(val), write_option);
+    assert(s == Ok);
+    s = KVDKGetTTL(kvdk_engine, key, strlen(key), &ttl_time);
+    assert(s == Ok);
+    assert(ttl_time == INT64_MAX);
     // case: key is expired.
     s = KVDKExpire(kvdk_engine, key, strlen(key), 1);
     assert(s == Ok);
@@ -461,7 +469,6 @@ void ExpireExample(KVDKEngine* kvdk_engine) {
     s = KVDKGet(kvdk_engine, key, strlen(key), &val_len, &got_val);
     assert(s == NotFound);
     // case: ttl time is negative or 0
-    KVDKWriteOptionsSetTTLTime(write_option, 0);
     s = KVDKPut(kvdk_engine, key, strlen(key), val, strlen(val), write_option);
     assert(s == Ok);
     s = KVDKGet(kvdk_engine, key, strlen(key), &val_len, &got_val);

--- a/include/kvdk/configs.hpp
+++ b/include/kvdk/configs.hpp
@@ -137,11 +137,15 @@ struct Configs {
 };
 
 struct WriteOptions {
-  WriteOptions(TTLType _ttl_time = kPersistTTL) : ttl_time(_ttl_time) {}
+  WriteOptions(TTLType _ttl_time = kPersistTTL, bool _update_ttl = true)
+      : ttl_time(_ttl_time), update_ttl(_update_ttl) {}
 
   // expired time in milliseconod, should be kPersistTime for no expiration
   // data, or a certain interge which be in the range [INT64_MIN , INT64_MAX].
   TTLType ttl_time;
+
+  // determine whether to update expired time if key already existed
+  bool update_ttl;
 };
 
 }  // namespace KVDK_NAMESPACE

--- a/include/kvdk/engine.h
+++ b/include/kvdk/engine.h
@@ -45,6 +45,8 @@ extern void KVDKDestroyConfigs(KVDKConfigs* kv_config);
 extern KVDKWriteOptions* KVDKCreateWriteOptions(void);
 extern void KVDKDestroyWriteOptions(KVDKWriteOptions*);
 extern void KVDKWriteOptionsSetTTLTime(KVDKWriteOptions*, int64_t);
+extern void KVDKWriteOptionsSetUpdateTTL(KVDKWriteOptions* kv_options,
+                                         int update_ttl);
 
 extern KVDKSortedCollectionConfigs* KVDKCreateSortedCollectionConfigs();
 extern void KVDKSetSortedCollectionConfigs(KVDKSortedCollectionConfigs* configs,


### PR DESCRIPTION
### What is changed and how it works?

Add update_ttl option in WriteOptions for string to determine whether to update ttl if key already exist

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

Side effects

No
