### PR TITLE
Save space merge cpu overhead in spare time

### DIFF
--- a/engine/pmem_allocator/free_list.cpp
+++ b/engine/pmem_allocator/free_list.cpp
@@ -9,7 +9,11 @@
 
 namespace KVDK_NAMESPACE {
 
+// For balance free entries among threads, move a free list to the background
+// pool if more than kMinMovableEntries in the free list
 const uint32_t kMinMovableEntries = 1024;
+// To avoid background space merge consumes resorces in idle time, do merge only
+// if more than kMergeThreshold space entries been freed since last merge
 const uint64_t kMergeThreshold = 1024 * 1024;
 
 void SpaceMap::Set(uint64_t offset, uint64_t length) {

--- a/engine/pmem_allocator/free_list.hpp
+++ b/engine/pmem_allocator/free_list.hpp
@@ -224,7 +224,8 @@ class Freelist {
         : small_entry_offsets(max_small_entry_b_size),
           large_entries(max_large_entry_size_index),
           small_entry_spins(max_small_entry_b_size),
-          large_entry_spins(max_large_entry_size_index) {}
+          large_entry_spins(max_large_entry_size_index),
+          recently_freed(0) {}
 
     FlistThreadCache() = delete;
     FlistThreadCache(FlistThreadCache&&) = delete;
@@ -244,6 +245,8 @@ class Freelist {
     Array<SpinMutex> small_entry_spins;
     // Protect large_entries
     Array<SpinMutex> large_entry_spins;
+    // freed entries after last time organize space in background
+    std::atomic<uint64_t> recently_freed;
   };
 
   uint64_t MergeSpace(uint64_t offset, uint64_t max_size,
@@ -278,6 +281,7 @@ class Freelist {
   Array<FlistThreadCache> flist_thread_cache_;
   PMEMAllocator* pmem_allocator_;
   SpinMutex large_entries_spin_;
+  std::atomic<size_t> last_freed_after_merge_;
 };
 
 }  // namespace KVDK_NAMESPACE

--- a/engine/pmem_allocator/pmem_allocator.hpp
+++ b/engine/pmem_allocator/pmem_allocator.hpp
@@ -125,6 +125,9 @@ class PMEMAllocator : public Allocator {
 
   std::int64_t PMemUsageInBytes();
 
+  // Notice: This function is only for unit test
+  Freelist* GetFreeList() { return &free_list_; }
+
  private:
   friend Freelist;
 


### PR DESCRIPTION
### What is changed and how it works?

Merge space in background only if there are enough space entry freed since last merge

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
