### PR TITLE
Fix Batch Write Bug

### DIFF
--- a/engine/hash_table.cpp
+++ b/engine/hash_table.cpp
@@ -37,7 +37,8 @@ bool HashEntry::Match(const StringView& key, uint32_t hash_k_prefix,
     StringView data_entry_key;
 
     switch (header_.index_type) {
-      case PointerType::Empty: {
+      case PointerType::Empty:
+      case PointerType::Allocated: {
         return false;
       }
       case PointerType::StringRecord: {
@@ -143,6 +144,9 @@ HashTable::LookupResult HashTable::Lookup(const StringView& key,
   }
 
   ret.s = NotFound;
+  if (may_insert) {
+    ret.entry_ptr->MarkAsAllocated();
+  }
   return ret;
 }
 

--- a/engine/hash_table.hpp
+++ b/engine/hash_table.hpp
@@ -62,6 +62,11 @@ struct alignas(16) HashEntry {
 
   bool Empty() { return header_.index_type == PointerType::Empty; }
 
+  // Make this hash entry empty while its content been deleted
+  void clear() { header_.index_type = PointerType::Empty; }
+
+  bool Allocated() { return header_.index_type == PointerType::Allocated; }
+
   void MarkAsAllocated() { header_.index_type = PointerType::Allocated; }
 
   Index GetIndex() const { return index_; }
@@ -80,10 +85,6 @@ struct alignas(16) HashEntry {
   // * target_type: a mask of RecordType, search all masked types
   bool Match(const StringView& key, uint32_t hash_k_prefix, uint8_t target_type,
              DataEntry* data_entry_metadata);
-
- private:
-  // Make this hash entry empty while its content been deleted
-  void clear() { header_.index_type = PointerType::Empty; }
 
  private:
   Index index_;

--- a/engine/hash_table.hpp
+++ b/engine/hash_table.hpp
@@ -62,6 +62,8 @@ struct alignas(16) HashEntry {
 
   bool Empty() { return header_.index_type == PointerType::Empty; }
 
+  void MarkAsAllocated() { header_.index_type = PointerType::Allocated; }
+
   Index GetIndex() const { return index_; }
 
   PointerType GetIndexType() const { return header_.index_type; }

--- a/engine/kv_engine.cpp
+++ b/engine/kv_engine.cpp
@@ -845,12 +845,24 @@ Status KVEngine::batchWriteImpl(WriteBatchImpl const& batch) {
 #ifndef KVDK_ENABLE_CRASHPOINT
     for (auto iter = hash_args.rbegin(); iter != hash_args.rend(); ++iter) {
       pmem_allocator_->Free(iter->space);
+      if (iter->res.entry_ptr->Allocated()) {
+        kvdk_assert(iter->res.s == Status::NotFound, "");
+        iter->res.entry_ptr->clear();
+      }
     }
     for (auto iter = sorted_args.rbegin(); iter != sorted_args.rend(); ++iter) {
       pmem_allocator_->Free(iter->space);
+      if (iter->lookup_result.entry_ptr->Allocated()) {
+        kvdk_assert(iter->lookup_result.s == Status::NotFound, "");
+        iter->lookup_result.entry_ptr->clear();
+      }
     }
     for (auto iter = string_args.rbegin(); iter != string_args.rend(); ++iter) {
       pmem_allocator_->Free(iter->space);
+      if (iter->res.entry_ptr->Allocated()) {
+        kvdk_assert(iter->res.s == Status::NotFound, "");
+        iter->res.entry_ptr->clear();
+      }
     }
 #endif
   };

--- a/engine/structures.hpp
+++ b/engine/structures.hpp
@@ -31,6 +31,8 @@ enum class PointerType : uint8_t {
   List = 7,
   // Point to a hash entry of hash table
   HashEntry = 8,
+  // Allocated for later insertion
+  Allocated,
   // Empty which point to nothing
   Empty = 10,
 };

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -753,7 +753,7 @@ TEST_F(EngineBasicTest, TestStringModify) {
   delete engine;
 }
 
-TEST_F(EngineBasicTest, BatchWriteSorted) {
+TEST_F(BatchWriteTest, Sorted) {
   size_t num_threads = 1;
   configs.max_access_threads = num_threads + 1;
   for (int index_with_hashtable : {0, 1}) {
@@ -821,8 +821,6 @@ TEST_F(EngineBasicTest, BatchWriteSorted) {
       }
     };
 
-    LaunchNThreads(num_threads, Put);
-    LaunchNThreads(num_threads, Check);
     LaunchNThreads(num_threads, BatchWrite);
     LaunchNThreads(num_threads, Check);
 
@@ -837,7 +835,7 @@ TEST_F(EngineBasicTest, BatchWriteSorted) {
   }
 }
 
-TEST_F(BatchWriteTest, BatchWriteString) {
+TEST_F(BatchWriteTest, String) {
   size_t num_threads = 16;
   configs.max_access_threads = num_threads;
   ASSERT_EQ(Engine::Open(db_path.c_str(), &engine, configs, stdout),
@@ -895,8 +893,6 @@ TEST_F(BatchWriteTest, BatchWriteString) {
     }
   };
 
-  LaunchNThreads(num_threads, Put);
-  LaunchNThreads(num_threads, Check);
   LaunchNThreads(num_threads, BatchWrite);
   LaunchNThreads(num_threads, Check);
 
@@ -910,7 +906,7 @@ TEST_F(BatchWriteTest, BatchWriteString) {
   delete engine;
 }
 
-TEST_F(BatchWriteTest, BatchWriteHash) {
+TEST_F(BatchWriteTest, Hash) {
   size_t num_threads = 16;
   configs.max_access_threads = num_threads + 1;
   ASSERT_EQ(Engine::Open(db_path.c_str(), &engine, configs, stdout),
@@ -970,8 +966,6 @@ TEST_F(BatchWriteTest, BatchWriteHash) {
     }
   };
 
-  LaunchNThreads(num_threads, Put);
-  LaunchNThreads(num_threads, Check);
   LaunchNThreads(num_threads, BatchWrite);
   LaunchNThreads(num_threads, Check);
 
@@ -2291,7 +2285,7 @@ TEST_F(EngineBasicTest, TestbackgroundDestroyCollections) {
 
 #if KVDK_DEBUG_LEVEL > 0
 
-TEST_F(EngineBasicTest, BatchWriteSortedRollback) {
+TEST_F(BatchWriteTest, SortedRollback) {
   size_t num_threads = 1;
   configs.max_access_threads = num_threads + 1;
   for (int index_with_hashtable : {0, 1}) {
@@ -2408,7 +2402,7 @@ TEST_F(EngineBasicTest, BatchWriteSortedRollback) {
   }
 }
 
-TEST_F(EngineBasicTest, BatchWriteStringRollBack) {
+TEST_F(BatchWriteTest, StringRollBack) {
   // This test case can only be run with single thread.
   // If multiple threads run batchwrite,
   // a thread may crash at CrashPoint and release its id,
@@ -2488,7 +2482,7 @@ TEST_F(EngineBasicTest, BatchWriteStringRollBack) {
   delete engine;
 }
 
-TEST_F(BatchWriteTest, BatchWriteHashRollback) {
+TEST_F(BatchWriteTest, HashRollback) {
   size_t num_threads = 1;
   configs.max_access_threads = num_threads + 1;
   ASSERT_EQ(Engine::Open(db_path.c_str(), &engine, configs, stdout),


### PR DESCRIPTION
Signed-off-by: ZiyanShi <ziyan.shi@intel.com>

<!--
Thank you for contributing to KVDK.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Issue Number: close #318  <!-- REMOVE this line if no issue to close -->

Problem Summary:

Batch Write pre-allocate entries in `HashTable` during preparation stage. Sometimes two keys are allocated to the same entry, causing the previous key to be overwritten by the latter key in the batch.

The PR mark the allocated entry to prevent the overwritting.

Tests <!-- At least one of them must be included. -->

- Unit test
