### PR TITLE
Avoid merge small space with a far larger one

### DIFF
--- a/engine/pmem_allocator/free_list.cpp
+++ b/engine/pmem_allocator/free_list.cpp
@@ -45,7 +45,7 @@ void SpaceMap::Set(uint64_t offset, uint64_t size) {
     cur += to_set;
     remaining -= to_set;
   }
-  
+
 #if KVDK_DEBUG_LEVEL > 0
   // Check space map is correct after set
   uint64_t debug_cur = offset + size;

--- a/engine/pmem_allocator/free_list.cpp
+++ b/engine/pmem_allocator/free_list.cpp
@@ -26,43 +26,45 @@ void SpaceMap::Set(uint64_t offset, uint64_t size) {
   }
   SpinMutex* last_lock = &map_spins_[offset / lock_granularity_];
   std::lock_guard<SpinMutex> start_lg(*last_lock);
-  std::unique_ptr<std::lock_guard<SpinMutex>> lg(nullptr);
+  std::unique_ptr<std::lock_guard<SpinMutex>> iter_lg(nullptr);
   auto to_set = size > INT8_MAX ? INT8_MAX : size;
   kvdk_assert(map_[offset].Empty(), "Set space map on a already set byte");
   map_[offset] = Token(true, to_set);
   size -= to_set;
   uint64_t cur = offset + to_set;
-  if (size > 0) {
-    while (size > 0) {
-      kvdk_assert(cur < map_.size(), "Set space map overflow");
-      to_set = size > INT8_MAX ? INT8_MAX : size;
-      SpinMutex* cur_lock = &map_spins_[cur / lock_granularity_];
-      if (cur_lock != last_lock) {
-        lg.reset(new std::lock_guard<SpinMutex>(*cur_lock));
-        last_lock = cur_lock;
-      }
-      kvdk_assert(map_[cur].Empty(), "");
-      map_[cur] = Token(false, to_set);
-      cur += to_set;
-      size -= to_set;
-    }
-  }
-  /*
-  #if KVDK_DEBUG_LEVEL > 0
+  while (size > 0) {
+    kvdk_assert(cur < map_.size(), "Set space map overflow");
+    to_set = size > INT8_MAX ? INT8_MAX : size;
     SpinMutex* cur_lock = &map_spins_[cur / lock_granularity_];
     if (cur_lock != last_lock) {
-      lg.reset(new std::lock_guard<SpinMutex>(*cur_lock));
+      iter_lg.reset(new std::lock_guard<SpinMutex>(*cur_lock));
+      last_lock = cur_lock;
     }
-    kvdk_assert(map_[cur].IsStart() || map_[cur].Empty(),
+    kvdk_assert(map_[cur].Empty(), "");
+    map_[cur] = Token(false, to_set);
+    cur += to_set;
+    size -= to_set;
+  }
+// /*
+#if KVDK_DEBUG_LEVEL > 0
+  uint64_t debug_cur = offset + size;
+  if (debug_cur < map_.size()) {
+    SpinMutex* debug_lock = &map_spins_[(debug_cur) / lock_granularity_];
+    if (debug_lock != last_lock) {
+      iter_lg.reset(new std::lock_guard<SpinMutex>(*debug_lock));
+      last_lock = debug_lock;
+    }
+    kvdk_assert(map_[debug_cur].IsStart() || map_[debug_cur].Empty(),
                 "space map error after set");
-  #endif
-  */
+  }
+#endif
+  // */
 }
 
-uint64_t SpaceMap::TestAndUnset(uint64_t offset, uint64_t size) {
+bool SpaceMap::TestAndUnset(uint64_t offset, uint64_t size) {
   assert(offset < map_.size());
   if (size == 0) {
-    return 0;
+    return true;
   }
   std::lock_guard<SpinMutex> start_lg(map_spins_[offset / lock_granularity_]);
   SpinMutex* last_lock = &map_spins_[offset / lock_granularity_];
@@ -88,19 +90,21 @@ uint64_t SpaceMap::TestAndUnset(uint64_t offset, uint64_t size) {
       map_[cur].Clear();
     }
   }
-
-  /*
-  #if KVDK_DEBUG_LEVEL > 0
-    SpinMutex* cur_lock = &map_spins_[offset + res / lock_granularity_];
-    if (cur_lock != last_lock) {
-      lg.reset(new std::lock_guard<SpinMutex>(*cur_lock));
+// /*
+#if KVDK_DEBUG_LEVEL > 0
+  uint64_t debug_cur = offset + res;
+  if (debug_cur < map_.size()) {
+    SpinMutex* debug_lock = &map_spins_[debug_cur / lock_granularity_];
+    if (debug_lock != last_lock) {
+      lg.reset(new std::lock_guard<SpinMutex>(*debug_lock));
     }
     kvdk_assert(res == 0 || res == size, "space map error in TestAndUnset");
-    kvdk_assert(map_[offset + res].IsStart() || map_[offset + res].Empty(),
+    kvdk_assert(map_[debug_cur].IsStart() || map_[debug_cur].Empty(),
                 "space map error after TestAndUnset");
-  #endif
-  */
-  return res;
+  }
+#endif
+  // */
+  return res == size;
 }
 
 uint64_t SpaceMap::TryMerge(uint64_t start_offset, uint64_t start_size,
@@ -110,13 +114,12 @@ uint64_t SpaceMap::TryMerge(uint64_t start_offset, uint64_t start_size,
   if (start_offset + start_size > map_.size()) {
     return 0;
   }
+  std::vector<std::unique_lock<SpinMutex>> locked;
   uint64_t end_offset = std::min(start_offset + limit_merge_size, map_.size());
   SpinMutex* last_lock = &map_spins_[start_offset / lock_granularity_];
-  std::lock_guard<SpinMutex> start_lg(*last_lock);
+  locked.emplace_back(*last_lock);
   uint64_t merged_size = 0;
   if (map_[start_offset].IsStart()) {
-    std::unique_ptr<std::lock_guard<SpinMutex>> lg(nullptr);
-
 #if KVDK_DEBUG_LEVEL > 0
     // check start size
     uint64_t debug_size = map_[start_offset].Size();
@@ -124,7 +127,7 @@ uint64_t SpaceMap::TryMerge(uint64_t start_offset, uint64_t start_size,
     while (true) {
       SpinMutex* debug_lock = &map_spins_[debug_cur / lock_granularity_];
       if (debug_lock != last_lock) {
-        lg.reset(new std::lock_guard<SpinMutex>(*debug_lock));
+        locked.emplace_back(*debug_lock);
         last_lock = debug_lock;
       }
       if (map_[debug_cur].IsStart() || map_[debug_cur].Empty()) {
@@ -149,7 +152,7 @@ uint64_t SpaceMap::TryMerge(uint64_t start_offset, uint64_t start_size,
       }
       SpinMutex* cur_lock = &map_spins_[cur / lock_granularity_];
       if (cur_lock != last_lock) {
-        lg.reset(new std::lock_guard<SpinMutex>(*cur_lock));
+        locked.emplace_back(*cur_lock);
         last_lock = cur_lock;
       }
       if (map_[cur].IsStart() || map_[cur].Empty()) {
@@ -388,7 +391,7 @@ bool Freelist::getSmallEntry(uint32_t size, SpaceEntry* space_entry) {
       flist_thread_cache.small_entry_offsets[i].pop_back();
       assert(space_entry->offset % block_size_ == 0);
       auto b_offset = space_entry->offset / block_size_;
-      if (space_map_.TestAndUnset(b_offset, i) == i) {
+      if (space_map_.TestAndUnset(b_offset, i)) {
         space_entry->size = i * block_size_;
         return true;
       }
@@ -423,7 +426,7 @@ bool Freelist::getLargeEntry(uint32_t size, SpaceEntry* space_entry) {
       }
       auto b_offset = iter->offset / block_size_;
       auto b_size = iter->size / block_size_;
-      if (space_map_.TestAndUnset(b_offset, b_size) == b_size) {
+      if (space_map_.TestAndUnset(b_offset, b_size)) {
         *space_entry = *iter;
         iter = flist_thread_cache.large_entries[i].erase(iter);
         return true;

--- a/engine/pmem_allocator/free_list.cpp
+++ b/engine/pmem_allocator/free_list.cpp
@@ -131,14 +131,9 @@ uint64_t SpaceMap::testLocked(uint64_t start_offset) {
 
 uint64_t SpaceMap::TryMerge(uint64_t start_offset, uint64_t start_size,
                             uint64_t limit_merge_size) {
-  kvdk_assert(start_size > 0, "");
-  assert(start_offset < map_.size());
-  if (start_offset + start_size > map_.size()) {
-    return 0;
-  }
-  if (start_size >= limit_merge_size) {
-    return start_size;
-  }
+  kvdk_assert(start_size > 0 && start_offset + start_size < map_.size() &&
+                  start_size <= limit_merge_size,
+              "");
 
   uint64_t end_offset = std::min(start_offset + limit_merge_size, map_.size());
   uint64_t merged_size = 0;

--- a/engine/pmem_allocator/free_list.cpp
+++ b/engine/pmem_allocator/free_list.cpp
@@ -47,7 +47,7 @@ void SpaceMap::Set(uint64_t offset, uint64_t size) {
   }
 
 #if KVDK_DEBUG_LEVEL > 0
-  // Check space map is correct after set
+  // Check set space followed by another valid space or empty
   uint64_t debug_cur = offset + size;
   if (debug_cur < map_.size()) {
     SpinMutex* debug_lock = &map_spins_[(debug_cur) / lock_granularity_];
@@ -92,7 +92,7 @@ bool SpaceMap::TestAndUnset(uint64_t offset, uint64_t size) {
   }
 
 #if KVDK_DEBUG_LEVEL > 0
-  // Check space map is correct after unset
+  // Check unset space followed by another valid space or empty
   if (res != 0) {
     kvdk_assert(res == size, "space map error in TestAndUnset");
     uint64_t debug_cur = offset + res;
@@ -129,7 +129,7 @@ uint64_t SpaceMap::TryMerge(uint64_t start_offset, uint64_t start_size,
   if (map_[start_offset].IsStart()) {
 #if KVDK_DEBUG_LEVEL > 0
     {
-      // check start size
+      // check start space size is correct
       uint64_t debug_size = map_[start_offset].Size();
       uint64_t debug_cur = start_offset + debug_size;
       while (true) {
@@ -190,7 +190,7 @@ uint64_t SpaceMap::TryMerge(uint64_t start_offset, uint64_t start_size,
   }
 
 #if KVDK_DEBUG_LEVEL > 0
-  // Check space map is correct after merge
+  // Check merged spaced followed by another valid space or empty
   {
     uint64_t debug_cur = start_offset + merged_size;
     if (merged_size > 0 && debug_cur < end_offset && debug_cur < map_.size()) {

--- a/engine/pmem_allocator/free_list.cpp
+++ b/engine/pmem_allocator/free_list.cpp
@@ -92,13 +92,13 @@ bool SpaceMap::TestAndUnset(uint64_t offset, uint64_t size) {
   }
 
 #if KVDK_DEBUG_LEVEL > 0
+  kvdk_assert(res == 0 || res == size, "space map error in TestAndUnset");
   uint64_t debug_cur = offset + res;
   if (debug_cur < map_.size()) {
     SpinMutex* debug_lock = &map_spins_[debug_cur / lock_granularity_];
     if (debug_lock != last_lock) {
       ul = std::unique_lock<SpinMutex>(*debug_lock);
     }
-    kvdk_assert(res == 0 || res == size, "space map error in TestAndUnset");
     kvdk_assert(map_[debug_cur].IsStart() || map_[debug_cur].Empty(),
                 "space map error after TestAndUnset");
   }

--- a/engine/pmem_allocator/free_list.hpp
+++ b/engine/pmem_allocator/free_list.hpp
@@ -31,6 +31,8 @@ class SpaceMap {
 
   bool TestAndUnset(uint64_t offset, uint64_t size);
 
+  uint64_t Test(uint64_t start_offset);
+
   uint64_t TryMerge(uint64_t start_offset, uint64_t start_b_size,
                     uint64_t limit_merge_size);
 

--- a/engine/pmem_allocator/free_list.hpp
+++ b/engine/pmem_allocator/free_list.hpp
@@ -16,7 +16,7 @@ namespace KVDK_NAMESPACE {
 constexpr uint32_t kMaxSmallBlockSize = 255;
 constexpr uint32_t kMaxBlockSizeIndex = 255;
 constexpr uint32_t kBlockSizeIndexInterval = 1024;
-constexpr uint32_t kSpaceMapLockGranularity = 128;
+constexpr uint32_t kSpaceMapLockGranularity = 256;
 
 class PMEMAllocator;
 

--- a/engine/pmem_allocator/free_list.hpp
+++ b/engine/pmem_allocator/free_list.hpp
@@ -29,12 +29,12 @@ class SpaceMap {
         lock_granularity_(kSpaceMapLockGranularity),
         map_spins_(num_blocks / lock_granularity_ + 1) {}
 
-  uint64_t TestAndUnset(uint64_t offset, uint64_t length);
+  bool TestAndUnset(uint64_t offset, uint64_t size);
 
   uint64_t TryMerge(uint64_t start_offset, uint64_t start_b_size,
                     uint64_t limit_merge_size);
 
-  void Set(uint64_t offset, uint64_t length);
+  void Set(uint64_t offset, uint64_t size);
 
   uint64_t Size() { return map_.size(); }
 

--- a/engine/pmem_allocator/free_list.hpp
+++ b/engine/pmem_allocator/free_list.hpp
@@ -16,7 +16,7 @@ namespace KVDK_NAMESPACE {
 constexpr uint32_t kMaxSmallBlockSize = 255;
 constexpr uint32_t kMaxBlockSizeIndex = 255;
 constexpr uint32_t kBlockSizeIndexInterval = 1024;
-constexpr uint32_t kSpaceMapLockGranularity = 64;
+constexpr uint32_t kSpaceMapLockGranularity = 128;
 
 class PMEMAllocator;
 

--- a/engine/pmem_allocator/free_list.hpp
+++ b/engine/pmem_allocator/free_list.hpp
@@ -44,6 +44,11 @@ class SpaceMap {
   // test size with start_offset locked
   uint64_t testLocked(uint64_t start_offset);
 
+  // set remaining space bytes of space "start_offset", the start offset should
+  // already been locked
+  void setRemaining(uint64_t remaining_offset, uint64_t remaining,
+                    uint64_t start_offset);
+
   // The highest 1 bit ot the token indicates if this is the start of a space
   // entry, the lower 7 bits indicate how many free blocks followed
   struct Token {

--- a/engine/pmem_allocator/free_list.hpp
+++ b/engine/pmem_allocator/free_list.hpp
@@ -249,15 +249,6 @@ class Freelist {
     std::atomic<uint64_t> recently_freed;
   };
 
-  uint64_t MergeSpace(uint64_t b_offset, uint64_t b_size,
-                      uint64_t limit_merge_size) {
-    if (b_size > limit_merge_size) {
-      return 0;
-    }
-    uint64_t size = space_map_.TryMerge(b_offset, b_size, limit_merge_size);
-    return size;
-  }
-
   uint32_t blockSizeIndex(uint32_t block_size) {
     kvdk_assert(block_size <= num_segment_blocks_, "");
     uint32_t ret = block_size < max_small_entry_block_size_

--- a/engine/pmem_allocator/free_list.hpp
+++ b/engine/pmem_allocator/free_list.hpp
@@ -29,7 +29,7 @@ class SpaceMap {
         lock_granularity_(kSpaceMapLockGranularity),
         map_spins_(num_blocks / lock_granularity_ + 1) {}
 
-  bool TestAndUnset(uint64_t offset, uint64_t size);
+  bool TestAndClear(uint64_t offset, uint64_t size);
 
   uint64_t Test(uint64_t start_offset);
 
@@ -41,6 +41,9 @@ class SpaceMap {
   uint64_t Size() { return map_.size(); }
 
  private:
+  // test size with start_offset locked
+  uint64_t testLocked(uint64_t start_offset);
+
   // The highest 1 bit ot the token indicates if this is the start of a space
   // entry, the lower 7 bits indicate how many free blocks followed
   struct Token {

--- a/engine/pmem_allocator/free_list.hpp
+++ b/engine/pmem_allocator/free_list.hpp
@@ -31,8 +31,8 @@ class SpaceMap {
 
   uint64_t TestAndUnset(uint64_t offset, uint64_t length);
 
-  uint64_t TryMerge(uint64_t offset, uint64_t max_merge_length,
-                    uint64_t min_merge_length);
+  uint64_t TryMerge(uint64_t start_offset, uint64_t start_b_size,
+                    uint64_t limit_merge_size);
 
   void Set(uint64_t offset, uint64_t length);
 
@@ -249,12 +249,12 @@ class Freelist {
     std::atomic<uint64_t> recently_freed;
   };
 
-  uint64_t MergeSpace(uint64_t offset, uint64_t max_size,
-                      uint64_t min_merge_size) {
-    if (min_merge_size > max_size) {
+  uint64_t MergeSpace(uint64_t b_offset, uint64_t b_size,
+                      uint64_t limit_merge_size) {
+    if (b_size > limit_merge_size) {
       return 0;
     }
-    uint64_t size = space_map_.TryMerge(offset, max_size, min_merge_size);
+    uint64_t size = space_map_.TryMerge(b_offset, b_size, limit_merge_size);
     return size;
   }
 


### PR DESCRIPTION
### What is changed and how it works?

In space merge of PMEMAllocator, avoid merge a small space with a far larger one to save CPU overhead

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

Side effects

- CPU overhead of background merge thread drop from 100% to 2% in  the case that frequently do list pop (e.g. sequentially free space)
