### PR TITLE
Clean invalid records while no valid skiplist to rebuild

### DIFF
--- a/engine/sorted_collection/rebuilder.cpp
+++ b/engine/sorted_collection/rebuilder.cpp
@@ -26,19 +26,13 @@ SortedCollectionRebuilder::SortedCollectionRebuilder(
 SortedCollectionRebuilder::RebuildResult SortedCollectionRebuilder::Rebuild() {
   RebuildResult ret;
   ret.s = initRebuildLists();
+  if (ret.s == Status::Ok && rebuild_skiplits_.size() > 0) {
+    ret.s = segment_based_rebuild_ ? segmentBasedIndexRebuild()
+                                   : listBasedIndexRebuild();
+  }
   if (ret.s == Status::Ok) {
-    if (rebuild_skiplits_.size() > 0) {
-      if (segment_based_rebuild_) {
-        ret.s = segmentBasedIndexRebuild();
-      } else {
-        ret.s = listBasedIndexRebuild();
-      }
-
-      if (ret.s == Status::Ok) {
-        ret.max_id = max_recovered_id_;
-        ret.rebuild_skiplits.swap(rebuild_skiplits_);
-      }
-    }
+    ret.max_id = max_recovered_id_;
+    ret.rebuild_skiplits.swap(rebuild_skiplits_);
     cleanInvalidRecords();
   }
   return ret;

--- a/engine/sorted_collection/rebuilder.cpp
+++ b/engine/sorted_collection/rebuilder.cpp
@@ -26,19 +26,17 @@ SortedCollectionRebuilder::SortedCollectionRebuilder(
 SortedCollectionRebuilder::RebuildResult SortedCollectionRebuilder::Rebuild() {
   RebuildResult ret;
   ret.s = initRebuildLists();
-  if (ret.s != Status::Ok || rebuild_skiplits_.size() == 0) {
-    return ret;
-  }
+  if (ret.s == Status::Ok && rebuild_skiplits_.size() > 0) {
+    if (segment_based_rebuild_) {
+      ret.s = segmentBasedIndexRebuild();
+    } else {
+      ret.s = listBasedIndexRebuild();
+    }
 
-  if (segment_based_rebuild_) {
-    ret.s = segmentBasedIndexRebuild();
-  } else {
-    ret.s = listBasedIndexRebuild();
-  }
-
-  if (ret.s == Status::Ok) {
-    ret.max_id = max_recovered_id_;
-    ret.rebuild_skiplits.swap(rebuild_skiplits_);
+    if (ret.s == Status::Ok) {
+      ret.max_id = max_recovered_id_;
+      ret.rebuild_skiplits.swap(rebuild_skiplits_);
+    }
   }
   cleanInvalidRecords();
   return ret;

--- a/engine/sorted_collection/rebuilder.cpp
+++ b/engine/sorted_collection/rebuilder.cpp
@@ -26,19 +26,21 @@ SortedCollectionRebuilder::SortedCollectionRebuilder(
 SortedCollectionRebuilder::RebuildResult SortedCollectionRebuilder::Rebuild() {
   RebuildResult ret;
   ret.s = initRebuildLists();
-  if (ret.s == Status::Ok && rebuild_skiplits_.size() > 0) {
-    if (segment_based_rebuild_) {
-      ret.s = segmentBasedIndexRebuild();
-    } else {
-      ret.s = listBasedIndexRebuild();
-    }
+  if (ret.s == Status::Ok) {
+    if (rebuild_skiplits_.size() > 0) {
+      if (segment_based_rebuild_) {
+        ret.s = segmentBasedIndexRebuild();
+      } else {
+        ret.s = listBasedIndexRebuild();
+      }
 
-    if (ret.s == Status::Ok) {
-      ret.max_id = max_recovered_id_;
-      ret.rebuild_skiplits.swap(rebuild_skiplits_);
+      if (ret.s == Status::Ok) {
+        ret.max_id = max_recovered_id_;
+        ret.rebuild_skiplits.swap(rebuild_skiplits_);
+      }
     }
+    cleanInvalidRecords();
   }
-  cleanInvalidRecords();
   return ret;
 }
 


### PR DESCRIPTION
What's Changed:

Destroy invalid records in skiplist rebuilder while no valid skiplist to rebuild

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- No code

Side effects

No
