### PR TITLE
Bug fix: cleaning lock not unlocked

### DIFF
--- a/engine/kv_engine_hash.cpp
+++ b/engine/kv_engine_hash.cpp
@@ -162,6 +162,7 @@ Status KVEngine::HashPut(StringView collection, StringView key,
       if (ret.s == Status::Ok && ret.existing_record &&
           hlist->TryCleaningLock()) {
         removeAndCacheOutdatedVersion<DLRecord>(ret.write_record);
+        hlist->ReleaseCleaningLock();
       }
       tryCleanCachedOutdatedRecord();
       s = ret.s;
@@ -192,6 +193,7 @@ Status KVEngine::HashDelete(StringView collection, StringView key) {
       if (ret.s == Status::Ok && ret.existing_record && ret.write_record &&
           hlist->TryCleaningLock()) {
         removeAndCacheOutdatedVersion(ret.write_record);
+        hlist->ReleaseCleaningLock();
       }
       tryCleanCachedOutdatedRecord();
       s = ret.s;
@@ -220,6 +222,7 @@ Status KVEngine::HashModify(StringView collection, StringView key,
     if (s == Status::Ok && ret.existing_record && ret.write_record &&
         hlist->TryCleaningLock()) {
       removeAndCacheOutdatedVersion<DLRecord>(ret.write_record);
+      hlist->ReleaseCleaningLock();
     }
     tryCleanCachedOutdatedRecord();
   }

--- a/engine/kv_engine_sorted.cpp
+++ b/engine/kv_engine_sorted.cpp
@@ -260,6 +260,7 @@ Status KVEngine::sortedDeleteImpl(Skiplist* skiplist,
 
   if (ret.existing_record && ret.write_record && skiplist->TryCleaningLock()) {
     removeAndCacheOutdatedVersion(ret.write_record);
+    skiplist->ReleaseCleaningLock();
   }
   tryCleanCachedOutdatedRecord();
 
@@ -280,6 +281,7 @@ Status KVEngine::sortedPutImpl(Skiplist* skiplist, const StringView& user_key,
   // Collect outdated version records
   if (ret.existing_record && skiplist->TryCleaningLock()) {
     removeAndCacheOutdatedVersion<DLRecord>(ret.write_record);
+    skiplist->ReleaseCleaningLock();
   }
   tryCleanCachedOutdatedRecord();
 


### PR DESCRIPTION
### What problem does this PR solve?

cleaning lock of collections not unlocked in previous patch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
