### PR TITLE
Refactor worker threads of cleaner

### DIFF
--- a/engine/kv_engine.cpp
+++ b/engine/kv_engine.cpp
@@ -123,12 +123,12 @@ void KVEngine::startBackgroundWorks() {
   TEST_SYNC_POINT_CALLBACK("KVEngine::backgroundCleaner::NothingToDo",
                            &close_reclaimer);
   if (!close_reclaimer) {
-    cleaner_.StartClean();
+    cleaner_.Start();
   }
 }
 
 void KVEngine::terminateBackgroundWorks() {
-  cleaner_.CloseAllWorkers();
+  cleaner_.Close();
   {
     std::unique_lock<SpinMutex> ul(bg_work_signals_.terminating_lock);
     bg_work_signals_.terminating = true;

--- a/engine/kv_engine_cleaner.cpp
+++ b/engine/kv_engine_cleaner.cpp
@@ -242,7 +242,7 @@ void KVEngine::cleanNoHashIndexedSkiplist(
   auto prev_node = skiplist->HeaderNode();
   auto iter = skiplist->GetDLList()->GetRecordIterator();
   iter->SeekToFirst();
-  while (iter->Valid()) {
+  while (iter->Valid() && !closing_) {
     DLRecord* cur_record = iter->Record();
     iter->Next();
     auto min_snapshot_ts = version_controller_.GlobalOldestSnapshotTs();
@@ -301,7 +301,7 @@ void KVEngine::cleanNoHashIndexedSkiplist(
 void KVEngine::cleanList(List* list, std::vector<DLRecord*>& purge_dl_records) {
   auto iter = list->GetDLList()->GetRecordIterator();
   iter->SeekToFirst();
-  while (iter->Valid()) {
+  while (iter->Valid() && !closing_) {
     DLRecord* cur_record = iter->Record();
     iter->Next();
     auto ul = list->AcquireLock();
@@ -485,7 +485,7 @@ double KVEngine::cleanOutDated(PendingCleanRecords& pending_clean_records,
     end_slot_idx = hash_table_->GetSlotsNum();
   }
   auto hashtable_iter = hash_table_->GetIterator(start_slot_idx, end_slot_idx);
-  while (hashtable_iter.Valid()) {
+  while (hashtable_iter.Valid() && !closing_) {
     {  // Slot lock section
       auto min_snapshot_ts = version_controller_.GlobalOldestSnapshotTs();
       auto now = TimeUtils::millisecond_time();
@@ -655,47 +655,31 @@ void KVEngine::TestCleanOutDated(size_t start_slot_idx, size_t end_slot_idx) {
 
 Cleaner::OutDatedCollections::~OutDatedCollections() {}
 
-void Cleaner::doCleanWork(size_t thread_id) {
+void Cleaner::cleanWork() {
   PendingCleanRecords pending_clean_records;
-  while (true) {
-    if (close_) return;
+  std::int64_t start_pos = start_slot_.fetch_add(kSlotBlockUnit) %
+                           (kv_engine_->hash_table_->GetSlotsNum());
+  kv_engine_->cleanOutDated(pending_clean_records, start_pos, kSlotBlockUnit);
 
-    std::int64_t start_pos = start_slot_.fetch_add(kSlotBlockUnit) %
-                             (kv_engine_->hash_table_->GetSlotsNum());
-    kv_engine_->cleanOutDated(pending_clean_records, start_pos, kSlotBlockUnit);
-
-    if (workers_[thread_id].finish) {
-      while (pending_clean_records.Size() != 0 && !close_.load()) {
-        kv_engine_->version_controller_.UpdateLocalOldestSnapshot();
-        kv_engine_->purgeAndFree(pending_clean_records);
-      }
-      return;
-    }
+  while (pending_clean_records.Size() != 0 && !close_.load()) {
+    kv_engine_->version_controller_.UpdateLocalOldestSnapshot();
+    kv_engine_->purgeAndFree(pending_clean_records);
   }
 }
 
-void Cleaner::AdjustThread(size_t advice_thread_num) {
-  auto active_thread_num = live_thread_num_.load();
-  if (active_thread_num < advice_thread_num) {
-    for (size_t i = active_thread_num; i < advice_thread_num; ++i) {
-      size_t thread_id = idled_workers_.front();
-      idled_workers_.pop_front();
-      workers_[thread_id].finish.store(false);
-      workers_[thread_id].worker =
-          std::thread(&Cleaner::doCleanWork, this, thread_id);
-      actived_workers_.push_back(thread_id);
-      live_thread_num_++;
+void Cleaner::AdjustCleanWorkers(size_t advice_wokers_num) {
+  kvdk_assert(advice_wokers_num <= clean_workers_.size(), "");
+  auto active_workers_num = active_clean_workers_.load();
+  if (active_workers_num < advice_wokers_num) {
+    for (size_t i = active_workers_num; i < advice_wokers_num; ++i) {
+      clean_workers_[i].Run();
     }
-  } else if (active_thread_num > advice_thread_num) {
-    for (size_t i = advice_thread_num; i < active_thread_num; ++i) {
-      auto thread_id = actived_workers_.front();
-      actived_workers_.pop_front();
-      workers_[thread_id].finish.store(true);
-      workers_[thread_id].worker.detach();
-      idled_workers_.push_back(thread_id);
-      --live_thread_num_;
+  } else if (active_workers_num > advice_wokers_num) {
+    for (size_t i = advice_wokers_num; i < active_workers_num; ++i) {
+      clean_workers_[i].Stop();
     }
   }
+  active_clean_workers_ = advice_wokers_num;
 }
 
 double Cleaner::SearchOutdatedCollections() {
@@ -709,7 +693,7 @@ double Cleaner::SearchOutdatedCollections() {
     std::unique_lock<std::mutex> skiplist_lock(kv_engine_->skiplists_mu_);
     auto iter = kv_engine_->expirable_skiplists_.begin();
     while (!kv_engine_->expirable_skiplists_.empty() && (*iter)->HasExpired() &&
-           limited_fetch_num < max_thread_num_) {
+           limited_fetch_num < max_clean_worker_) {
       auto outdated_skiplist = *iter;
       iter = kv_engine_->expirable_skiplists_.erase(iter);
       outdated_collections_.skiplists.emplace(
@@ -723,7 +707,7 @@ double Cleaner::SearchOutdatedCollections() {
     std::unique_lock<std::mutex> list_lock(kv_engine_->lists_mu_);
     auto iter = kv_engine_->expirable_lists_.begin();
     while (!kv_engine_->expirable_lists_.empty() && (*iter)->HasExpired() &&
-           limited_fetch_num < max_thread_num_) {
+           limited_fetch_num < max_clean_worker_) {
       auto outdated_list = *iter;
       iter = kv_engine_->expirable_lists_.erase(iter);
       outdated_collections_.lists.emplace(
@@ -736,7 +720,7 @@ double Cleaner::SearchOutdatedCollections() {
     std::unique_lock<std::mutex> hlist_lock(kv_engine_->hlists_mu_);
     auto iter = kv_engine_->expirable_hlists_.begin();
     while (!kv_engine_->expirable_hlists_.empty() && (*iter)->HasExpired() &&
-           limited_fetch_num < max_thread_num_) {
+           limited_fetch_num < max_clean_worker_) {
       auto expired_hash_list = *iter;
       iter = kv_engine_->expirable_hlists_.erase(iter);
       outdated_collections_.hashlists.emplace(
@@ -752,7 +736,7 @@ double Cleaner::SearchOutdatedCollections() {
                            outdated_collections_.skiplists.size());
 
   double diff_size_ratio =
-      (after_queue_size - before_queue_size) / max_thread_num_;
+      (after_queue_size - before_queue_size) / max_clean_worker_;
   if (diff_size_ratio > 0) {
     outdated_collections_.increase_ratio =
         outdated_collections_.increase_ratio == 0
@@ -849,43 +833,31 @@ void Cleaner::FetchOutdatedCollections(
   }
 }
 
-void Cleaner::mainWorker() {
+void Cleaner::mainWork() {
   PendingCleanRecords pending_clean_records;
-  while (true) {
-    if (close_) return;
+  std::int64_t start_pos = start_slot_.fetch_add(kSlotBlockUnit) %
+                           (kv_engine_->hash_table_->GetSlotsNum());
 
-    std::int64_t start_pos = start_slot_.fetch_add(kSlotBlockUnit) %
-                             (kv_engine_->hash_table_->GetSlotsNum());
+  double outdated_ratio = kv_engine_->cleanOutDated(pending_clean_records,
+                                                    start_pos, kSlotBlockUnit);
 
-    double outdated_ratio = kv_engine_->cleanOutDated(
-        pending_clean_records, start_pos, kSlotBlockUnit);
+  size_t advice_thread_num = 1;
+  if (outdated_ratio >= kWakeUpThreshold) {
+    advice_thread_num = std::ceil(outdated_ratio * (max_clean_worker_ + 1));
+  }
+  TEST_SYNC_POINT_CALLBACK("KVEngine::Cleaner::AdjustCleanWorkers",
+                           &advice_thread_num);
+  size_t advice_clean_workers = std::min(
+      std::max(advice_thread_num - 1, min_clean_worker_), max_clean_worker_);
 
-    size_t advice_thread_num = min_thread_num_;
-    if (outdated_ratio >= kWakeUpThreshold) {
-      advice_thread_num = std::ceil(outdated_ratio * max_thread_num_);
+  AdjustCleanWorkers(advice_clean_workers);
+  if (outdated_ratio < kWakeUpThreshold) {
+    sleep(1);
+  }
 
-      advice_thread_num = std::min(std::max(advice_thread_num, min_thread_num_),
-                                   max_thread_num_);
-    }
-    TEST_SYNC_POINT_CALLBACK("KVEngine::Cleaner::AdjustThread",
-                             &advice_thread_num);
-
-    AdjustThread(advice_thread_num);
-    if (outdated_ratio < kWakeUpThreshold) {
-      sleep(1);
-    }
+  while (pending_clean_records.Size() != 0 && !close_.load()) {
+    kv_engine_->version_controller_.UpdateLocalOldestSnapshot();
+    kv_engine_->purgeAndFree(pending_clean_records);
   }
 }
-
-void Cleaner::StartClean() {
-  if (!close_) {
-    auto thread_id = idled_workers_.front();
-    idled_workers_.pop_front();
-    std::thread worker(&Cleaner::mainWorker, this);
-    workers_[thread_id].finish.store(false);
-    workers_[thread_id].worker.swap(worker);
-    live_thread_num_++;
-  }
-}
-
 }  // namespace KVDK_NAMESPACE

--- a/engine/sorted_collection/skiplist.cpp
+++ b/engine/sorted_collection/skiplist.cpp
@@ -860,23 +860,13 @@ void Skiplist::destroyAllRecords() {
 }
 
 void Skiplist::Destroy() {
-  GlobalLogger.Debug("Start Destroy skiplist %s\n", Name().c_str());
   destroyRecords();
   destroyNodes();
-  GlobalLogger.Debug("Finish Destroy skiplist %s\n", Name().c_str());
 }
 
 void Skiplist::DestroyAll() {
-  GlobalLogger.Debug(
-      "Start Destroy skiplist with old version lists: %s, collection ID: %ld, "
-      "size: %ld\n",
-      Name().c_str(), ID(), Size());
   destroyAllRecords();
   destroyNodes();
-  GlobalLogger.Debug(
-      "Finish Destroy skiplist with old version lists: %s, collection ID: "
-      "%ld\n",
-      Name().c_str(), ID());
 }
 
 void Skiplist::destroyNodes() {

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -369,7 +369,6 @@ TEST_F(EngineBasicTest, TestUniqueKey) {
 
   ASSERT_EQ(Engine::Open(db_path.c_str(), &engine, configs, stdout),
             Status::Ok);
-
   ASSERT_EQ(engine->Put(str, val), Status::Ok);
 
   ASSERT_EQ(engine->SortedCreate(sorted_collection), Status::Ok);
@@ -3279,9 +3278,9 @@ TEST_F(EngineBasicTest, TestBackGroundCleaner) {
   auto ExpiredClean = [&]() {
     auto test_kvengine = static_cast<KVEngine*>(engine);
     auto cleaner = test_kvengine->EngineCleaner();
-    cleaner->StartClean();
+    cleaner->Start();
     sleep(2);
-    cleaner->CloseAllWorkers();
+    cleaner->Close();
   };
 
   {
@@ -3378,9 +3377,9 @@ TEST_F(EngineBasicTest, TestBackGroundIterNoHashIndexSkiplist) {
   auto backgroundCleaner = [&]() {
     auto test_kvengine = static_cast<KVEngine*>(engine);
     auto cleaner = test_kvengine->EngineCleaner();
-    cleaner->StartClean();
+    cleaner->Start();
     sleep(2);
-    cleaner->CloseAllWorkers();
+    cleaner->Close();
   };
   std::vector<std::thread> ts;
   ts.emplace_back(PutAndDeleteSorted);
@@ -3421,7 +3420,7 @@ TEST_F(EngineBasicTest, TestDynamicCleaner) {
         *((std::atomic_bool*)close_reclaimer) = true;
         return;
       });
-  SyncPoint::GetInstance()->SetCallBack("KVEngine::Cleaner::AdjustThread",
+  SyncPoint::GetInstance()->SetCallBack("KVEngine::Cleaner::AdjustCleanWorkers",
                                         [&](void* advice_thread_num) {
                                           if (op == OpType::update) {
                                             *((size_t*)advice_thread_num) = 6;
@@ -3446,7 +3445,7 @@ TEST_F(EngineBasicTest, TestDynamicCleaner) {
   ASSERT_EQ(engine->SortedCreate(sorted_collection), Status::Ok);
   auto test_kvengine = static_cast<KVEngine*>(engine);
   auto space_cleaner = test_kvengine->EngineCleaner();
-  space_cleaner->StartClean();
+  space_cleaner->Start();
 
   size_t cnt = 16;
   // only insert


### PR DESCRIPTION
### What is changed and how it works?

In current impl, main worker of cleaner may create new thread, and not be joined after kvdk instance closed.

In this patch, refactor worker threads with thread-pool-like manner, and avoid the mentioned problem

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Stress test
