### PR TITLE
Rename variables and update license header in recently modified files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   build:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
 
     steps:
       - uses: actions/checkout@v2

--- a/engine/allocator.hpp
+++ b/engine/allocator.hpp
@@ -16,7 +16,6 @@ struct DLRecord;
 struct StringRecord;
 
 constexpr MemoryOffsetType kNullMemoryOffset = UINT64_MAX;
-constexpr PMemOffsetType kNullPMemOffset = UINT64_MAX;
 
 struct SpaceEntry {
   class SpaceCmp {

--- a/engine/data_record.cpp
+++ b/engine/data_record.cpp
@@ -13,7 +13,7 @@ static constexpr int kDataBufferSize = 1024 * 1024;
 
 StringRecord* StringRecord::PersistStringRecord(
     void* addr, uint32_t record_size, TimestampType timestamp, RecordType type,
-    RecordStatus status, PMemOffsetType old_version, const StringView& key,
+    RecordStatus status, MemoryOffsetType old_version, const StringView& key,
     const StringView& value, ExpireTimeType expired_time) {
   void* data_cpy_target = addr;
 
@@ -45,8 +45,8 @@ StringRecord* StringRecord::PersistStringRecord(
 
 DLRecord* DLRecord::PersistDLRecord(
     void* addr, uint32_t record_size, TimestampType timestamp, RecordType type,
-    RecordStatus status, PMemOffsetType old_version, PMemOffsetType prev,
-    PMemOffsetType next, const StringView& key, const StringView& value,
+    RecordStatus status, MemoryOffsetType old_version, MemoryOffsetType prev,
+    MemoryOffsetType next, const StringView& key, const StringView& value,
     ExpireTimeType expired_time) {
   void* data_cpy_target = addr;
 

--- a/engine/data_record.hpp
+++ b/engine/data_record.hpp
@@ -100,7 +100,7 @@ static_assert(sizeof(DataEntry) <= kMinPMemBlockSize);
 struct StringRecord {
  public:
   DataEntry entry;
-  PMemOffsetType old_version;
+  MemoryOffsetType old_version;
   ExpireTimeType expired_time;
   char data[0];
 
@@ -112,7 +112,7 @@ struct StringRecord {
   static StringRecord* ConstructStringRecord(
       void* target_address, uint32_t _record_size, TimestampType _timestamp,
       RecordType _record_type, RecordStatus _record_status,
-      PMemOffsetType _old_version, const StringView& _key,
+      MemoryOffsetType _old_version, const StringView& _key,
       const StringView& _value, ExpireTimeType _expired_time) {
     StringRecord* record = new (target_address)
         StringRecord(_record_size, _timestamp, _record_type, _record_status,
@@ -123,7 +123,7 @@ struct StringRecord {
   // Construct and persist a string record at pmem address "addr"
   static StringRecord* PersistStringRecord(
       void* addr, uint32_t record_size, TimestampType timestamp,
-      RecordType type, RecordStatus status, PMemOffsetType old_version,
+      RecordType type, RecordStatus status, MemoryOffsetType old_version,
       const StringView& key, const StringView& value,
       ExpireTimeType expired_time = kPersistTime);
 
@@ -175,7 +175,7 @@ struct StringRecord {
     _mm_mfence();
   }
 
-  void PersistOldVersion(PMemOffsetType offset) {
+  void PersistOldVersion(MemoryOffsetType offset) {
     _mm_stream_si64(reinterpret_cast<long long*>(&old_version),
                     static_cast<long long>(offset));
     _mm_mfence();
@@ -202,7 +202,7 @@ struct StringRecord {
  private:
   StringRecord(uint32_t _record_size, TimestampType _timestamp,
                RecordType _record_type, RecordStatus _record_status,
-               PMemOffsetType _old_version, const StringView& _key,
+               MemoryOffsetType _old_version, const StringView& _key,
                const StringView& _value, ExpireTimeType _expired_time)
       : entry(0, _record_size, _timestamp, _record_type, _record_status,
               _key.size(), _value.size()),
@@ -234,9 +234,9 @@ struct StringRecord {
 struct DLRecord {
  public:
   DataEntry entry;
-  PMemOffsetType old_version;
-  PMemOffsetType prev;
-  PMemOffsetType next;
+  MemoryOffsetType old_version;
+  MemoryOffsetType prev;
+  MemoryOffsetType next;
   ExpireTimeType expired_time;
 
   char data[0];
@@ -246,14 +246,12 @@ struct DLRecord {
   //
   // target_address: pre-allocated space to store constructed record, it
   // should no smaller than sizeof(DLRecord) + key size + value size
-  static DLRecord* ConstructDLRecord(void* target_address, uint32_t record_size,
-                                     TimestampType timestamp,
-                                     RecordType record_type,
-                                     RecordStatus record_status,
-                                     PMemOffsetType old_version, uint64_t prev,
-                                     uint64_t next, const StringView& key,
-                                     const StringView& value,
-                                     ExpireTimeType expired_time) {
+  static DLRecord* ConstructDLRecord(
+      void* target_address, uint32_t record_size, TimestampType timestamp,
+      RecordType record_type, RecordStatus record_status,
+      MemoryOffsetType old_version, uint64_t prev, uint64_t next,
+      const StringView& key, const StringView& value,
+      ExpireTimeType expired_time) {
     DLRecord* record = new (target_address)
         DLRecord(record_size, timestamp, record_type, record_status,
                  old_version, prev, next, key, value, expired_time);
@@ -282,13 +280,13 @@ struct DLRecord {
     return StringView(data + entry.meta.k_size, entry.meta.v_size);
   }
 
-  void PersistNextNT(PMemOffsetType offset) {
+  void PersistNextNT(MemoryOffsetType offset) {
     _mm_stream_si64(reinterpret_cast<long long*>(&next),
                     static_cast<long long>(offset));
     _mm_mfence();
   }
 
-  void PersistPrevNT(PMemOffsetType offset) {
+  void PersistPrevNT(MemoryOffsetType offset) {
     _mm_stream_si64(reinterpret_cast<long long*>(&prev),
                     static_cast<long long>(offset));
     _mm_mfence();
@@ -301,13 +299,13 @@ struct DLRecord {
     _mm_mfence();
   }
 
-  void PersistNextCLWB(PMemOffsetType offset) {
+  void PersistNextCLWB(MemoryOffsetType offset) {
     next = offset;
     _mm_clwb(&next);
     _mm_mfence();
   }
 
-  void PersistPrevCLWB(PMemOffsetType offset) {
+  void PersistPrevCLWB(MemoryOffsetType offset) {
     prev = offset;
     _mm_clwb(&prev);
     _mm_mfence();
@@ -320,7 +318,7 @@ struct DLRecord {
     _mm_mfence();
   }
 
-  void PersistOldVersion(PMemOffsetType offset) {
+  void PersistOldVersion(MemoryOffsetType offset) {
     _mm_stream_si64(reinterpret_cast<long long*>(&old_version),
                     static_cast<long long>(offset));
     _mm_mfence();
@@ -348,8 +346,8 @@ struct DLRecord {
   // Construct and persist a dl record to PMem address "addr"
   static DLRecord* PersistDLRecord(
       void* addr, uint32_t record_size, TimestampType timestamp,
-      RecordType type, RecordStatus status, PMemOffsetType old_version,
-      PMemOffsetType prev, PMemOffsetType next, const StringView& key,
+      RecordType type, RecordStatus status, MemoryOffsetType old_version,
+      MemoryOffsetType prev, MemoryOffsetType next, const StringView& key,
       const StringView& value, ExpireTimeType expired_time = kPersistTime);
 
   uint32_t GetRecordSize() const { return entry.header.record_size; }
@@ -360,9 +358,10 @@ struct DLRecord {
 
  private:
   DLRecord(uint32_t _record_size, TimestampType _timestamp, RecordType _type,
-           RecordStatus _status, PMemOffsetType _old_version,
-           PMemOffsetType _prev, PMemOffsetType _next, const StringView& _key,
-           const StringView& _value, ExpireTimeType _expired_time)
+           RecordStatus _status, MemoryOffsetType _old_version,
+           MemoryOffsetType _prev, MemoryOffsetType _next,
+           const StringView& _key, const StringView& _value,
+           ExpireTimeType _expired_time)
       : entry(0, _record_size, _timestamp, _type, _status, _key.size(),
               _value.size()),
         old_version(_old_version),

--- a/engine/dl_list.cpp
+++ b/engine/dl_list.cpp
@@ -1,9 +1,13 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright(c) 2021-2022 Intel Corporation
+ */
+
 #include "dl_list.hpp"
 
 namespace KVDK_NAMESPACE {
 std::unique_ptr<DLListRecordIterator> DLList::GetRecordIterator() {
   return std::unique_ptr<DLListRecordIterator>(
-      new DLListRecordIterator(this, pmem_allocator_));
+      new DLListRecordIterator(this, kv_allocator_));
 }
 
 Status DLList::PushBack(const DLList::WriteArgs& args) {
@@ -28,7 +32,7 @@ DLRecord* DLList::RemoveFront() {
   kvdk_assert(header_ != nullptr, "");
   while (true) {
     DLRecord* front =
-        pmem_allocator_->offset2addr_checked<DLRecord>(header_->next);
+        kv_allocator_->offset2addr_checked<DLRecord>(header_->next);
     if (front == header_) {
       return nullptr;
     }
@@ -44,7 +48,7 @@ DLRecord* DLList::RemoveBack() {
   kvdk_assert(header_ != nullptr, "");
   while (true) {
     DLRecord* back =
-        pmem_allocator_->offset2addr_checked<DLRecord>(header_->prev);
+        kv_allocator_->offset2addr_checked<DLRecord>(header_->prev);
     if (back == header_) {
       return nullptr;
     }
@@ -59,8 +63,8 @@ DLRecord* DLList::RemoveBack() {
 Status DLList::InsertBetween(const DLList::WriteArgs& args, DLRecord* prev,
                              DLRecord* next) {
   auto ul = acquireInsertLock(prev);
-  PMemOffsetType next_offset = pmem_allocator_->addr2offset_checked(next);
-  PMemOffsetType prev_offset = pmem_allocator_->addr2offset_checked(prev);
+  MemoryOffsetType next_offset = kv_allocator_->addr2offset_checked(next);
+  MemoryOffsetType prev_offset = kv_allocator_->addr2offset_checked(prev);
   // Check if the linkage has changed before we successfully acquire lock.
   bool check_linkage = prev->next == next_offset && next->prev == prev_offset;
   if (!check_linkage) {
@@ -68,8 +72,8 @@ Status DLList::InsertBetween(const DLList::WriteArgs& args, DLRecord* prev,
   }
 
   DLRecord* new_record = DLRecord::PersistDLRecord(
-      pmem_allocator_->offset2addr_checked(args.space.offset), args.space.size,
-      args.ts, args.type, args.status, kNullPMemOffset, prev_offset,
+      kv_allocator_->offset2addr_checked(args.space.offset), args.space.size,
+      args.ts, args.type, args.status, kNullMemoryOffset, prev_offset,
       next_offset, args.key, args.val);
   linkRecord(prev, next, new_record);
 
@@ -78,28 +82,28 @@ Status DLList::InsertBetween(const DLList::WriteArgs& args, DLRecord* prev,
 
 Status DLList::InsertAfter(const DLList::WriteArgs& args, DLRecord* prev) {
   return InsertBetween(
-      args, prev, pmem_allocator_->offset2addr_checked<DLRecord>(prev->next));
+      args, prev, kv_allocator_->offset2addr_checked<DLRecord>(prev->next));
 }
 
 Status DLList::InsertBefore(const DLList::WriteArgs& args, DLRecord* next) {
   return InsertBetween(
-      args, pmem_allocator_->offset2addr_checked<DLRecord>(next->prev), next);
+      args, kv_allocator_->offset2addr_checked<DLRecord>(next->prev), next);
 }
 
 Status DLList::Update(const DLList::WriteArgs& args, DLRecord* current) {
   kvdk_assert(current != nullptr && equal_string_view(current->Key(), args.key),
               "");
   auto guard = acquireRecordLock(current);
-  PMemOffsetType current_offset = pmem_allocator_->addr2offset_checked(current);
-  PMemOffsetType prev_offset = current->prev;
-  PMemOffsetType next_offset = current->next;
-  DLRecord* prev = pmem_allocator_->offset2addr_checked<DLRecord>(prev_offset);
-  DLRecord* next = pmem_allocator_->offset2addr_checked<DLRecord>(next_offset);
+  MemoryOffsetType current_offset = kv_allocator_->addr2offset_checked(current);
+  MemoryOffsetType prev_offset = current->prev;
+  MemoryOffsetType next_offset = current->next;
+  DLRecord* prev = kv_allocator_->offset2addr_checked<DLRecord>(prev_offset);
+  DLRecord* next = kv_allocator_->offset2addr_checked<DLRecord>(next_offset);
   if (next->prev != current_offset || prev->next != current_offset) {
     return Status::Fail;
   }
   DLRecord* new_record = DLRecord::PersistDLRecord(
-      pmem_allocator_->offset2addr_checked(args.space.offset), args.space.size,
+      kv_allocator_->offset2addr_checked(args.space.offset), args.space.size,
       args.ts, args.type, args.status, current_offset, prev_offset, next_offset,
       args.key, args.val);
   linkRecord(prev, next, new_record);
@@ -107,7 +111,7 @@ Status DLList::Update(const DLList::WriteArgs& args, DLRecord* current) {
 }
 
 bool DLList::Replace(DLRecord* old_record, DLRecord* new_record) {
-  bool ret = Replace(old_record, new_record, pmem_allocator_, lock_table_);
+  bool ret = Replace(old_record, new_record, kv_allocator_, lock_table_);
   if (ret && old_record == header_) {
     header_ = new_record;
   }
@@ -115,18 +119,18 @@ bool DLList::Replace(DLRecord* old_record, DLRecord* new_record) {
 }
 
 bool DLList::Remove(DLRecord* removing_record) {
-  bool ret = Remove(removing_record, pmem_allocator_, lock_table_);
+  bool ret = Remove(removing_record, kv_allocator_, lock_table_);
   return ret;
 }
 
 bool DLList::Replace(DLRecord* old_record, DLRecord* new_record,
-                     Allocator* pmem_allocator, LockTable* lock_table) {
-  auto guard = acquireRecordLock(old_record, pmem_allocator, lock_table);
-  PMemOffsetType prev_offset = old_record->prev;
-  PMemOffsetType next_offset = old_record->next;
-  auto old_record_offset = pmem_allocator->addr2offset(old_record);
-  DLRecord* prev = pmem_allocator->offset2addr_checked<DLRecord>(prev_offset);
-  DLRecord* next = pmem_allocator->offset2addr_checked<DLRecord>(next_offset);
+                     Allocator* kv_allocator, LockTable* lock_table) {
+  auto guard = acquireRecordLock(old_record, kv_allocator, lock_table);
+  MemoryOffsetType prev_offset = old_record->prev;
+  MemoryOffsetType next_offset = old_record->next;
+  auto old_record_offset = kv_allocator->addr2offset(old_record);
+  DLRecord* prev = kv_allocator->offset2addr_checked<DLRecord>(prev_offset);
+  DLRecord* next = kv_allocator->offset2addr_checked<DLRecord>(next_offset);
   bool on_list =
       prev != nullptr && next != nullptr && prev->next == old_record_offset;
   if (on_list) {
@@ -138,28 +142,28 @@ bool DLList::Replace(DLRecord* old_record, DLRecord* new_record,
       kvdk_assert((new_record->GetRecordType() & CollectionType) &&
                       (old_record->GetRecordType() & CollectionType),
                   "Non-header record shouldn't be the only record in a list");
-      linkRecord(new_record, new_record, new_record, pmem_allocator);
-      auto new_record_offset = pmem_allocator->addr2offset(new_record);
+      linkRecord(new_record, new_record, new_record, kv_allocator);
+      auto new_record_offset = kv_allocator->addr2offset(new_record);
       old_record->PersistPrevNT(new_record_offset);
     } else {
       new_record->prev = prev_offset;
-      pmem_persist(&new_record->prev, sizeof(PMemOffsetType));
+      pmem_persist(&new_record->prev, sizeof(MemoryOffsetType));
       new_record->next = next_offset;
-      pmem_persist(&new_record->next, sizeof(PMemOffsetType));
-      linkRecord(prev, next, new_record, pmem_allocator);
+      pmem_persist(&new_record->next, sizeof(MemoryOffsetType));
+      linkRecord(prev, next, new_record, kv_allocator);
     }
   }
   return on_list;
 }
 
-bool DLList::Remove(DLRecord* removing_record, Allocator* pmem_allocator,
+bool DLList::Remove(DLRecord* removing_record, Allocator* kv_allocator,
                     LockTable* lock_table) {
-  auto guard = acquireRecordLock(removing_record, pmem_allocator, lock_table);
-  PMemOffsetType removing_offset = pmem_allocator->addr2offset(removing_record);
-  PMemOffsetType prev_offset = removing_record->prev;
-  PMemOffsetType next_offset = removing_record->next;
-  DLRecord* prev = pmem_allocator->offset2addr_checked<DLRecord>(prev_offset);
-  DLRecord* next = pmem_allocator->offset2addr_checked<DLRecord>(next_offset);
+  auto guard = acquireRecordLock(removing_record, kv_allocator, lock_table);
+  MemoryOffsetType removing_offset = kv_allocator->addr2offset(removing_record);
+  MemoryOffsetType prev_offset = removing_record->prev;
+  MemoryOffsetType next_offset = removing_record->next;
+  DLRecord* prev = kv_allocator->offset2addr_checked<DLRecord>(prev_offset);
+  DLRecord* next = kv_allocator->offset2addr_checked<DLRecord>(next_offset);
   bool on_list =
       prev != nullptr && next != nullptr && prev->next == removing_offset;
   if (on_list) {

--- a/engine/dram_allocator.hpp
+++ b/engine/dram_allocator.hpp
@@ -78,7 +78,7 @@ class ChunkBasedAllocator {
   }
 
   template <typename T>
-  inline T* offset2addr(PMemOffsetType offset) const {
+  inline T* offset2addr(MemoryOffsetType offset) const {
     return alloc_->offset2addr<T>(offset);
   }
 

--- a/engine/hash_collection/hash_list.cpp
+++ b/engine/hash_collection/hash_list.cpp
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: BSD-3-Clause
- * Copyright(c) 2021 Intel Corporation
+ * Copyright(c) 2021-2022 Intel Corporation
  */
 
 #include "hash_list.hpp"
@@ -26,14 +26,14 @@ Status HashList::Get(const StringView& key, std::string* value) {
     return Status::NotFound;
   }
 
-  DLRecord* pmem_record = lookup_result.entry.GetIndex().dl_record;
-  kvdk_assert(pmem_record->GetRecordType() == RecordType::HashElem, "");
+  DLRecord* data_record = lookup_result.entry.GetIndex().dl_record;
+  kvdk_assert(data_record->GetRecordType() == RecordType::HashElem, "");
   // As get is lockless, skiplist node may point to a new elem delete record
   // after we get it from hashtable
-  if (pmem_record->GetRecordStatus() == RecordStatus::Outdated) {
+  if (data_record->GetRecordStatus() == RecordStatus::Outdated) {
     return Status::NotFound;
   } else {
-    value->assign(pmem_record->Value().data(), pmem_record->Value().size());
+    value->assign(data_record->Value().data(), data_record->Value().size());
     return Status::Ok;
   }
 }
@@ -83,10 +83,10 @@ HashList::WriteResult HashList::Modify(const StringView key,
       HashWriteArgs args = InitWriteArgs(key, new_value, WriteOp::Put);
       args.ts = ts;
       args.lookup_result = lookup_result;
-      args.space = pmem_allocator_->Allocate(
+      args.space = kv_allocator_->Allocate(
           DLRecord::RecordSize(internal_key, new_value));
       if (args.space.size == 0) {
-        ret.s = Status::PmemOverflow;
+        ret.s = Status::MemoryOverflow;
         return ret;
       }
       return Write(args);
@@ -97,9 +97,9 @@ HashList::WriteResult HashList::Modify(const StringView key,
       args.ts = ts;
       args.lookup_result = lookup_result;
       args.space =
-          pmem_allocator_->Allocate(DLRecord::RecordSize(internal_key, ""));
+          kv_allocator_->Allocate(DLRecord::RecordSize(internal_key, ""));
       if (args.space.size == 0) {
-        ret.s = Status::PmemOverflow;
+        ret.s = Status::MemoryOverflow;
         return ret;
       }
       return Write(args);
@@ -174,9 +174,9 @@ Status HashList::PrepareWrite(HashWriteArgs& args, TimestampType ts) {
 
   if (allocate_space) {
     auto request_size = DLRecord::RecordSize(internal_key, args.value);
-    args.space = pmem_allocator_->Allocate(request_size);
+    args.space = kv_allocator_->Allocate(request_size);
     if (args.space.size == 0) {
-      return Status::PmemOverflow;
+      return Status::MemoryOverflow;
     }
   }
 
@@ -210,30 +210,30 @@ HashList::WriteResult HashList::SetExpireTime(ExpireTimeType expired_time,
                                               TimestampType timestamp) {
   WriteResult ret;
   DLRecord* header = HeaderRecord();
-  SpaceEntry space = pmem_allocator_->Allocate(
+  SpaceEntry space = kv_allocator_->Allocate(
       DLRecord::RecordSize(header->Key(), header->Value()));
   if (space.size == 0) {
-    ret.s = Status::PmemOverflow;
+    ret.s = Status::MemoryOverflow;
     return ret;
   }
-  DLRecord* pmem_record = DLRecord::PersistDLRecord(
-      pmem_allocator_->offset2addr_checked(space.offset), space.size, timestamp,
+  DLRecord* data_record = DLRecord::PersistDLRecord(
+      kv_allocator_->offset2addr_checked(space.offset), space.size, timestamp,
       RecordType::HashHeader, RecordStatus::Normal,
-      pmem_allocator_->addr2offset_checked(header), header->prev, header->next,
+      kv_allocator_->addr2offset_checked(header), header->prev, header->next,
       header->Key(), header->Value(), expired_time);
-  bool success = dl_list_.Replace(header, pmem_record);
+  bool success = dl_list_.Replace(header, data_record);
   kvdk_assert(success, "existing header should be linked on its list");
   ret.existing_record = header;
-  ret.write_record = pmem_record;
+  ret.write_record = data_record;
   return ret;
 }
 
 Status HashList::CheckIndex() {
   DLRecord* prev = HeaderRecord();
   size_t cnt = 0;
-  DLListRecoveryUtils<HashList> recovery_utils(pmem_allocator_);
+  DLListRecoveryUtils<HashList> recovery_utils(kv_allocator_);
   while (true) {
-    DLRecord* curr = pmem_allocator_->offset2addr_checked<DLRecord>(prev->next);
+    DLRecord* curr = kv_allocator_->offset2addr_checked<DLRecord>(prev->next);
     if (curr == HeaderRecord()) {
       break;
     }
@@ -281,7 +281,7 @@ void HashList::Destroy() {
   if (header) {
     DLRecord* to_destroy = nullptr;
     do {
-      to_destroy = pmem_allocator_->offset2addr_checked<DLRecord>(header->next);
+      to_destroy = kv_allocator_->offset2addr_checked<DLRecord>(header->next);
       StringView key = to_destroy->Key();
       auto ul = hash_table_->AcquireLock(key);
       if (dl_list_.Remove(to_destroy)) {
@@ -307,16 +307,16 @@ void HashList::Destroy() {
         }
 
         to_destroy->Destroy();
-        to_free.emplace_back(pmem_allocator_->addr2offset_checked(to_destroy),
+        to_free.emplace_back(kv_allocator_->addr2offset_checked(to_destroy),
                              to_destroy->GetRecordSize());
         if (to_free.size() > kMaxCachedOldRecords) {
-          pmem_allocator_->BatchFree(to_free);
+          kv_allocator_->BatchFree(to_free);
           to_free.clear();
         }
       }
     } while (to_destroy != header);
   }
-  pmem_allocator_->BatchFree(to_free);
+  kv_allocator_->BatchFree(to_free);
 }
 
 void HashList::DestroyAll() {
@@ -325,7 +325,7 @@ void HashList::DestroyAll() {
   DLRecord* to_destroy = nullptr;
   kvdk_assert(header != nullptr, "");
   do {
-    to_destroy = pmem_allocator_->offset2addr_checked<DLRecord>(header->next);
+    to_destroy = kv_allocator_->offset2addr_checked<DLRecord>(header->next);
     StringView key = to_destroy->Key();
     auto ul = hash_table_->AcquireLock(key);
     if (dl_list_.Remove(to_destroy)) {
@@ -350,25 +350,25 @@ void HashList::DestroyAll() {
         }
       }
       auto old_record =
-          pmem_allocator_->offset2addr<DLRecord>(to_destroy->old_version);
+          kv_allocator_->offset2addr<DLRecord>(to_destroy->old_version);
       while (old_record) {
         auto old_version = old_record->old_version;
-        to_free.emplace_back(pmem_allocator_->addr2offset_checked(old_record),
+        to_free.emplace_back(kv_allocator_->addr2offset_checked(old_record),
                              old_record->GetRecordSize());
         old_record->Destroy();
-        old_record = pmem_allocator_->offset2addr<DLRecord>(old_version);
+        old_record = kv_allocator_->offset2addr<DLRecord>(old_version);
       }
 
-      to_free.emplace_back(pmem_allocator_->addr2offset_checked(to_destroy),
+      to_free.emplace_back(kv_allocator_->addr2offset_checked(to_destroy),
                            to_destroy->GetRecordSize());
       to_destroy->Destroy();
       if (to_free.size() > kMaxCachedOldRecords) {
-        pmem_allocator_->BatchFree(to_free);
+        kv_allocator_->BatchFree(to_free);
         to_free.clear();
       }
     }
   } while (to_destroy != header);
-  pmem_allocator_->BatchFree(to_free);
+  kv_allocator_->BatchFree(to_free);
 }
 
 HashList::WriteResult HashList::putPrepared(
@@ -379,7 +379,7 @@ HashList::WriteResult HashList::putPrepared(
   DLList::WriteArgs args(internal_key, value, RecordType::HashElem,
                          RecordStatus::Normal, timestamp, space);
   ret.write_record =
-      pmem_allocator_->offset2addr_checked<DLRecord>(space.offset);
+      kv_allocator_->offset2addr_checked<DLRecord>(space.offset);
   ret.hash_entry_ptr = lookup_result.entry_ptr;
   if (lookup_result.s == Status::Ok) {
     ret.existing_record = lookup_result.entry.GetIndex().dl_record;
@@ -416,7 +416,7 @@ HashList::WriteResult HashList::deletePrepared(
     kvdk_assert(ret.s == Status::Fail, "");
   }
   ret.write_record =
-      pmem_allocator_->offset2addr_checked<DLRecord>(space.offset);
+      kv_allocator_->offset2addr_checked<DLRecord>(space.offset);
   hash_table_->Insert(lookup_result, RecordType::HashElem,
                       RecordStatus::Outdated, ret.write_record,
                       PointerType::DLRecord);

--- a/engine/hash_collection/hash_list.hpp
+++ b/engine/hash_collection/hash_list.hpp
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright(c) 2021-2022 Intel Corporation
+ */
+
 #pragma once
 
 #include "../dl_list.hpp"
@@ -29,12 +33,12 @@ class HashList : public Collection {
   };
 
   HashList(DLRecord* header, const StringView& name, CollectionIDType id,
-           Allocator* pmem_allocator, HashTable* hash_table,
+           Allocator* kv_allocator, HashTable* hash_table,
            LockTable* lock_table)
       : Collection(name, id),
-        dl_list_(header, pmem_allocator, lock_table),
+        dl_list_(header, kv_allocator, lock_table),
         size_(0),
-        pmem_allocator_(pmem_allocator),
+        kv_allocator_(kv_allocator),
         hash_table_(hash_table) {}
 
   ~HashList() final = default;
@@ -169,7 +173,7 @@ class HashList : public Collection {
   friend HashIteratorImpl;
   DLList dl_list_;
   std::atomic<size_t> size_;
-  Allocator* pmem_allocator_;
+  Allocator* kv_allocator_;
   HashTable* hash_table_;
   // to avoid illegal access caused by cleaning skiplist by multi-thread
   SpinMutex cleaning_lock_;

--- a/engine/hash_collection/iterator.hpp
+++ b/engine/hash_collection/iterator.hpp
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright(c) 2021-2022 Intel Corporation
+ */
+
 #pragma once
 
 #include "../version/version_controller.hpp"
@@ -15,7 +19,7 @@ class HashIteratorImpl final : public HashIterator {
       : hlist_(hlist),
         snapshot_(snapshot),
         own_snapshot_(own_snapshot),
-        dl_iter_(&hlist->dl_list_, hlist->pmem_allocator_, snapshot) {}
+        dl_iter_(&hlist->dl_list_, hlist->kv_allocator_, snapshot) {}
   void SeekToFirst() final { dl_iter_.SeekToFirst(); }
 
   void SeekToLast() final { dl_iter_.SeekToLast(); }

--- a/engine/hash_collection/rebuilder.hpp
+++ b/engine/hash_collection/rebuilder.hpp
@@ -24,12 +24,12 @@ class HashListRebuilder {
         rebuilt_hlists;
   };
 
-  HashListRebuilder(Allocator* pmem_allocator, HashTable* hash_table,
+  HashListRebuilder(Allocator* kv_allocator, HashTable* hash_table,
                     LockTable* lock_table, ThreadManager* thread_manager,
                     uint64_t num_rebuild_threads, const CheckPoint& checkpoint)
-      : recovery_utils_(pmem_allocator),
+      : recovery_utils_(kv_allocator),
         rebuilder_thread_cache_(num_rebuild_threads),
-        pmem_allocator_(pmem_allocator),
+        kv_allocator_(kv_allocator),
         hash_table_(hash_table),
         lock_table_(lock_table),
         thread_manager_(thread_manager),
@@ -45,7 +45,7 @@ class HashListRebuilder {
         // it here
         addUnlinkedRecord(elem_record);
       } else {
-        pmem_allocator_->PurgeAndFree<DLRecord>(elem_record);
+        kv_allocator_->PurgeAndFree<DLRecord>(elem_record);
       }
     }
     return Status::Ok;
@@ -60,7 +60,7 @@ class HashListRebuilder {
         // it here
         addUnlinkedRecord(header_record);
       } else {
-        pmem_allocator_->PurgeAndFree<DLRecord>(header_record);
+        kv_allocator_->PurgeAndFree<DLRecord>(header_record);
       }
     } else {
       linked_headers_.emplace_back(header_record);
@@ -100,18 +100,18 @@ class HashListRebuilder {
   }
 
   Status Rollback(const BatchWriteLog::HashLogEntry& log) {
-    DLRecord* elem = pmem_allocator_->offset2addr_checked<DLRecord>(log.offset);
+    DLRecord* elem = kv_allocator_->offset2addr_checked<DLRecord>(log.offset);
     // We only check prev linkage as a valid prev linkage indicate valid prev
     // and next pointers on the record, so we can safely do remove/replace
     if (elem->Validate() && recovery_utils_.CheckPrevLinkage(elem)) {
-      if (elem->old_version != kNullPMemOffset) {
+      if (elem->old_version != kNullMemoryOffset) {
         bool success = DLList::Replace(
             elem,
-            pmem_allocator_->offset2addr_checked<DLRecord>(elem->old_version),
-            pmem_allocator_, lock_table_);
+            kv_allocator_->offset2addr_checked<DLRecord>(elem->old_version),
+            kv_allocator_, lock_table_);
         kvdk_assert(success, "Replace should success as we checked linkage");
       } else {
-        bool success = DLList::Remove(elem, pmem_allocator_, lock_table_);
+        bool success = DLList::Remove(elem, kv_allocator_, lock_table_);
         kvdk_assert(success, "Remove should success as we checked linkage");
       }
     }
@@ -150,12 +150,12 @@ class HashListRebuilder {
         // break header linkage.
         kvdk_assert(header_record->prev == header_record->next &&
                         header_record->prev ==
-                            pmem_allocator_->addr2offset(header_record),
+                            kv_allocator_->addr2offset(header_record),
                     "outdated header record with valid linkage should always "
                     "point to it self");
         // Break the linkage
         auto newer_offset =
-            pmem_allocator_->addr2offset(linked_headers_[i + 1]);
+            kv_allocator_->addr2offset(linked_headers_[i + 1]);
         header_record->PersistPrevNT(newer_offset);
         kvdk_assert(!recovery_utils_.CheckPrevLinkage(header_record) &&
                         !recovery_utils_.CheckNextLinkage(header_record),
@@ -173,7 +173,7 @@ class HashListRebuilder {
       if (valid_version_record == nullptr ||
           HashList::FetchID(valid_version_record) != id) {
         hlist = std::make_shared<HashList>(header_record, collection_name, id,
-                                           pmem_allocator_, hash_table_,
+                                           kv_allocator_, hash_table_,
                                            lock_table_);
         {
           std::lock_guard<SpinMutex> lg(lock_);
@@ -183,14 +183,14 @@ class HashListRebuilder {
         auto ul = hash_table_->AcquireLock(collection_name);
         if (valid_version_record != header_record) {
           bool success = DLList::Replace(header_record, valid_version_record,
-                                         pmem_allocator_, lock_table_);
+                                         kv_allocator_, lock_table_);
           kvdk_assert(success,
                       "headers in rebuild should passed linkage check");
           addUnlinkedRecord(header_record);
         }
 
         hlist = std::make_shared<HashList>(valid_version_record,
-                                           collection_name, id, pmem_allocator_,
+                                           collection_name, id, kv_allocator_,
                                            hash_table_, lock_table_);
         kvdk_assert(hlist != nullptr, "");
 
@@ -207,7 +207,7 @@ class HashListRebuilder {
           }
         }
         // TODO no need always to persist old version
-        valid_version_record->PersistOldVersion(kNullPMemOffset);
+        valid_version_record->PersistOldVersion(kNullMemoryOffset);
 
         if (!outdated) {
           auto lookup_result = hash_table_->Insert(
@@ -235,20 +235,20 @@ class HashListRebuilder {
     return Status::Ok;
   }
 
-  DLRecord* findCheckpointVersion(DLRecord* pmem_record) {
+  DLRecord* findCheckpointVersion(DLRecord* data_record) {
     if (!recoverToCheckPoint()) {
-      return pmem_record;
+      return data_record;
     }
 
-    CollectionIDType id = HashList::FetchID(pmem_record);
-    DLRecord* curr = pmem_record;
+    CollectionIDType id = HashList::FetchID(data_record);
+    DLRecord* curr = data_record;
     while (curr != nullptr &&
            curr->GetTimestamp() > checkpoint_.CheckpointTS()) {
-      curr = pmem_allocator_->offset2addr<DLRecord>(curr->old_version);
+      curr = kv_allocator_->offset2addr<DLRecord>(curr->old_version);
       kvdk_assert(curr == nullptr || curr->Validate(),
                   "Broken checkpoint: invalid older version sorted record");
       kvdk_assert(
-          curr == nullptr || equal_string_view(curr->Key(), pmem_record->Key()),
+          curr == nullptr || equal_string_view(curr->Key(), data_record->Key()),
           "Broken checkpoint: key of older version sorted data is "
           "not same as new "
           "version");
@@ -308,17 +308,17 @@ class HashListRebuilder {
           }
         }
 
-        valid_version_record->PersistOldVersion(kNullPMemOffset);
+        valid_version_record->PersistOldVersion(kNullMemoryOffset);
       }
     }
     hlist->UpdateSize(num_elems);
     return Status::Ok;
   }
 
-  void addUnlinkedRecord(DLRecord* pmem_record) {
+  void addUnlinkedRecord(DLRecord* data_record) {
     assert(access_thread.id >= 0);
     rebuilder_thread_cache_[access_thread.id].unlinked_records.push_back(
-        pmem_record);
+        data_record);
   }
 
   void cleanInvalidRecords() {
@@ -326,15 +326,15 @@ class HashListRebuilder {
 
     // clean unlinked records
     for (auto& thread_cache : rebuilder_thread_cache_) {
-      for (DLRecord* pmem_record : thread_cache.unlinked_records) {
-        if (!recovery_utils_.CheckLinkage(pmem_record)) {
-          pmem_record->Destroy();
+      for (DLRecord* data_record : thread_cache.unlinked_records) {
+        if (!recovery_utils_.CheckLinkage(data_record)) {
+          data_record->Destroy();
           to_free.emplace_back(
-              pmem_allocator_->addr2offset_checked(pmem_record),
-              pmem_record->GetRecordSize());
+              kv_allocator_->addr2offset_checked(data_record),
+              data_record->GetRecordSize());
         }
       }
-      pmem_allocator_->BatchFree(to_free);
+      kv_allocator_->BatchFree(to_free);
       to_free.clear();
       thread_cache.unlinked_records.clear();
     }
@@ -353,7 +353,7 @@ class HashListRebuilder {
   DLListRecoveryUtils<HashList> recovery_utils_;
   std::vector<ThreadCache> rebuilder_thread_cache_;
   std::vector<DLRecord*> linked_headers_;
-  Allocator* pmem_allocator_;
+  Allocator* kv_allocator_;
   HashTable* hash_table_;
   LockTable* lock_table_;
   ThreadManager* thread_manager_;

--- a/engine/hash_table.hpp
+++ b/engine/hash_table.hpp
@@ -143,7 +143,7 @@ class HashTable {
 
   static HashTable* NewHashTable(uint64_t hash_bucket_num,
                                  uint32_t num_buckets_per_slot,
-                                 const Allocator* pmem_allocator,
+                                 const Allocator* kv_allocator,
                                  Allocator* new_bucket_allocator,
                                  uint32_t max_access_threads);
 
@@ -209,11 +209,11 @@ class HashTable {
 
  private:
   HashTable(uint64_t hash_bucket_num, uint32_t num_buckets_per_slot,
-            const Allocator* pmem_allocator, Allocator* new_bucket_allocator,
+            const Allocator* kv_allocator, Allocator* new_bucket_allocator,
             uint32_t max_access_threads)
       : num_hash_buckets_(hash_bucket_num),
         num_buckets_per_slot_(num_buckets_per_slot),
-        pmem_allocator_(pmem_allocator),
+        kv_allocator_(kv_allocator),
         chunk_based_bucket_allocator_{max_access_threads, new_bucket_allocator},
         slots_(hash_bucket_num / num_buckets_per_slot),
         hash_bucket_entries_(hash_bucket_num, 0),
@@ -249,7 +249,7 @@ class HashTable {
 
   const uint64_t num_hash_buckets_;
   const uint32_t num_buckets_per_slot_;
-  const Allocator* pmem_allocator_;
+  const Allocator* kv_allocator_;
   ChunkBasedAllocator chunk_based_bucket_allocator_;
   Array<Slot> slots_;
   std::vector<uint64_t> hash_bucket_entries_;

--- a/engine/kv_engine.hpp
+++ b/engine/kv_engine.hpp
@@ -526,7 +526,7 @@ class KVEngine : public Engine {
 
   void terminateBackgroundWorks();
 
-  std::unique_ptr<Allocator> pmem_allocator_;
+  std::unique_ptr<Allocator> kv_allocator_;
   std::unique_ptr<Allocator> skiplist_node_allocator_;
   std::unique_ptr<Allocator> hashtable_new_bucket_allocator_;
   std::shared_ptr<ThreadManager> thread_manager_;
@@ -591,20 +591,20 @@ class KVEngine : public Engine {
   Status restoreExistingData();
   Status restoreSortedHeader(DLRecord* header);
   Status restoreSortedElem(DLRecord* elem);
-  Status restoreStringRecord(StringRecord* pmem_record,
+  Status restoreStringRecord(StringRecord* data_record,
                              const DataEntry& cached_entry);
 
   Status sortedRollback(BatchWriteLog::SortedLogEntry const& entry);
   Status listRollback(BatchWriteLog::ListLogEntry const& entry);
   Status hashListRollback(BatchWriteLog::HashLogEntry const& entry);
 
-  Status listRestoreElem(DLRecord* pmem_record);
-  Status listRestoreList(DLRecord* pmem_record);
+  Status listRestoreElem(DLRecord* data_record);
+  Status listRestoreList(DLRecord* data_record);
 
   Status restoreHashElem(DLRecord* rec);
   Status restoreHashHeader(DLRecord* rec);
 
-  bool validateRecord(void* pmem_record);
+  bool validateRecord(void* data_record);
 
   // If this instance is a backup of another kvdk instance
   bool recoverToCheckpoint() {

--- a/engine/kv_engine_string.cpp
+++ b/engine/kv_engine_string.cpp
@@ -55,20 +55,19 @@ Status KVEngine::Modify(const StringView key, ModifyFunc modify_func,
               : TimeUtils::TTLToExpireTime(write_options.ttl_time, base_time);
 
       SpaceEntry space_entry =
-          pmem_allocator_->Allocate(StringRecord::RecordSize(key, new_value));
+          kv_allocator_->Allocate(StringRecord::RecordSize(key, new_value));
       if (space_entry.size == 0) {
-        return Status::PmemOverflow;
+        return Status::MemoryOverflow;
       }
 
       StringRecord* new_record =
-          pmem_allocator_->offset2addr_checked<StringRecord>(
-              space_entry.offset);
+          kv_allocator_->offset2addr_checked<StringRecord>(space_entry.offset);
       StringRecord::PersistStringRecord(
           new_record, space_entry.size, new_ts, RecordType::String,
           RecordStatus::Normal,
           existing_record == nullptr
-              ? kNullPMemOffset
-              : pmem_allocator_->addr2offset_checked(existing_record),
+              ? kNullMemoryOffset
+              : kv_allocator_->addr2offset_checked(existing_record),
           key, new_value, expired_time);
       insertKeyOrElem(lookup_result, RecordType::String, RecordStatus::Normal,
                       new_record);
@@ -77,19 +76,18 @@ Status KVEngine::Modify(const StringView key, ModifyFunc modify_func,
     case ModifyOperation::Delete: {
       if (lookup_result.s == Status::Ok) {
         SpaceEntry space_entry =
-            pmem_allocator_->Allocate(StringRecord::RecordSize(key, ""));
+            kv_allocator_->Allocate(StringRecord::RecordSize(key, ""));
         if (space_entry.size == 0) {
-          return Status::PmemOverflow;
+          return Status::MemoryOverflow;
         }
 
-        void* pmem_ptr =
-            pmem_allocator_->offset2addr_checked(space_entry.offset);
+        void* data_ptr = kv_allocator_->offset2addr_checked(space_entry.offset);
         StringRecord::PersistStringRecord(
-            pmem_ptr, space_entry.size, new_ts, RecordType::String,
+            data_ptr, space_entry.size, new_ts, RecordType::String,
             RecordStatus::Outdated,
-            pmem_allocator_->addr2offset_checked(existing_record), key, "");
+            kv_allocator_->addr2offset_checked(existing_record), key, "");
         insertKeyOrElem(lookup_result, RecordType::String,
-                        RecordStatus::Outdated, pmem_ptr);
+                        RecordStatus::Outdated, data_ptr);
         break;
       }
       case ModifyOperation::Abort: {
@@ -166,23 +164,23 @@ Status KVEngine::stringDeleteImpl(const StringView& key) {
   if (lookup_result.s == Status::Ok) {
     // We only write delete record if key exist
     auto request_size = key.size() + sizeof(StringRecord);
-    SpaceEntry space_entry = pmem_allocator_->Allocate(request_size);
+    SpaceEntry space_entry = kv_allocator_->Allocate(request_size);
     if (space_entry.size == 0) {
-      return Status::PmemOverflow;
+      return Status::MemoryOverflow;
     }
 
-    StringRecord* pmem_ptr =
-        pmem_allocator_->offset2addr_checked<StringRecord>(space_entry.offset);
+    StringRecord* data_ptr =
+        kv_allocator_->offset2addr_checked<StringRecord>(space_entry.offset);
     StringRecord::PersistStringRecord(
-        pmem_ptr, space_entry.size, new_ts, RecordType::String,
+        data_ptr, space_entry.size, new_ts, RecordType::String,
         RecordStatus::Outdated,
-        pmem_allocator_->addr2offset_checked(
+        kv_allocator_->addr2offset_checked(
             lookup_result.entry.GetIndex().string_record),
         key, "");
     insertKeyOrElem(lookup_result, RecordType::String, RecordStatus::Outdated,
-                    pmem_ptr);
+                    data_ptr);
 
-    removeAndCacheOutdatedVersion(pmem_ptr);
+    removeAndCacheOutdatedVersion(data_ptr);
   }
   tryCleanCachedOutdatedRecord();
 
@@ -229,17 +227,17 @@ Status KVEngine::stringPutImpl(const StringView& key, const StringView& value,
 
   // Save key-value pair
   SpaceEntry space_entry =
-      pmem_allocator_->Allocate(StringRecord::RecordSize(key, value));
+      kv_allocator_->Allocate(StringRecord::RecordSize(key, value));
   if (space_entry.size == 0) {
-    return Status::PmemOverflow;
+    return Status::MemoryOverflow;
   }
 
   StringRecord* new_record =
-      pmem_allocator_->offset2addr_checked<StringRecord>(space_entry.offset);
-  StringRecord::PersistStringRecord(
-      new_record, space_entry.size, new_ts, RecordType::String,
-      RecordStatus::Normal, pmem_allocator_->addr2offset(existing_record), key,
-      value, expired_time);
+      kv_allocator_->offset2addr_checked<StringRecord>(space_entry.offset);
+  StringRecord::PersistStringRecord(new_record, space_entry.size, new_ts,
+                                    RecordType::String, RecordStatus::Normal,
+                                    kv_allocator_->addr2offset(existing_record),
+                                    key, value, expired_time);
 
   insertKeyOrElem(lookup_result, RecordType::String, RecordStatus::Normal,
                   new_record);
@@ -253,16 +251,16 @@ Status KVEngine::stringPutImpl(const StringView& key, const StringView& value,
 }
 
 #ifdef KVDK_WITH_PMEM
-Status KVEngine::restoreStringRecord(StringRecord* pmem_record,
+Status KVEngine::restoreStringRecord(StringRecord* data_record,
                                      const DataEntry& cached_entry) {
-  assert(pmem_record->GetRecordType() == RecordType::String);
+  assert(data_record->GetRecordType() == RecordType::String);
   if (recoverToCheckpoint() &&
       cached_entry.meta.timestamp > persist_checkpoint_->CheckpointTS()) {
-    pmem_allocator_->PurgeAndFree<StringRecord>(pmem_record);
+    kv_allocator_->PurgeAndFree<StringRecord>(data_record);
     return Status::Ok;
   }
 
-  auto view = pmem_record->Key();
+  auto view = data_record->Key();
   std::string key{view.data(), view.size()};
   auto ul = hash_table_->AcquireLock(key);
   auto lookup_result = hash_table_->Lookup<true>(key, RecordType::String);
@@ -274,16 +272,16 @@ Status KVEngine::restoreStringRecord(StringRecord* pmem_record,
   if (lookup_result.s == Status::Ok &&
       lookup_result.entry.GetIndex().string_record->GetTimestamp() >=
           cached_entry.meta.timestamp) {
-    pmem_allocator_->PurgeAndFree<StringRecord>(pmem_record);
+    kv_allocator_->PurgeAndFree<StringRecord>(data_record);
     return Status::Ok;
   }
 
   insertKeyOrElem(lookup_result, cached_entry.meta.type,
-                  cached_entry.meta.status, pmem_record);
-  pmem_record->PersistOldVersion(kNullPMemOffset);
+                  cached_entry.meta.status, data_record);
+  data_record->PersistOldVersion(kNullMemoryOffset);
 
   if (lookup_result.s == Status::Ok) {
-    pmem_allocator_->PurgeAndFree<StringRecord>(
+    kv_allocator_->PurgeAndFree<StringRecord>(
         lookup_result.entry.GetIndex().string_record);
   }
 
@@ -302,9 +300,9 @@ Status KVEngine::stringWritePrepare(StringWriteArgs& args, TimestampType ts) {
     return Status::Ok;
   }
   args.space =
-      pmem_allocator_->Allocate(StringRecord::RecordSize(args.key, args.value));
+      kv_allocator_->Allocate(StringRecord::RecordSize(args.key, args.value));
   if (args.space.size == 0) {
-    return Status::PmemOverflow;
+    return Status::MemoryOverflow;
   }
   return Status::Ok;
 }
@@ -312,14 +310,14 @@ Status KVEngine::stringWritePrepare(StringWriteArgs& args, TimestampType ts) {
 Status KVEngine::stringWrite(StringWriteArgs& args) {
   RecordStatus record_status =
       args.op == WriteOp::Put ? RecordStatus::Normal : RecordStatus::Outdated;
-  void* new_addr = pmem_allocator_->offset2addr_checked(args.space.offset);
-  PMemOffsetType old_off;
+  void* new_addr = kv_allocator_->offset2addr_checked(args.space.offset);
+  MemoryOffsetType old_off;
   if (args.res.s == Status::NotFound) {
     kvdk_assert(args.op == WriteOp::Put, "");
-    old_off = kNullPMemOffset;
+    old_off = kNullMemoryOffset;
   } else {
     kvdk_assert(args.res.s == Status::Ok || args.res.s == Status::Outdated, "");
-    old_off = pmem_allocator_->addr2offset_checked(
+    old_off = kv_allocator_->addr2offset_checked(
         args.res.entry.GetIndex().string_record);
   }
   args.new_rec = StringRecord::PersistStringRecord(
@@ -338,7 +336,7 @@ Status KVEngine::stringWritePublish(StringWriteArgs const& args) {
 
 Status KVEngine::stringRollback(TimestampType,
                                 BatchWriteLog::StringLogEntry const& log) {
-  static_cast<DataEntry*>(pmem_allocator_->offset2addr_checked(log.offset))
+  static_cast<DataEntry*>(kv_allocator_->offset2addr_checked(log.offset))
       ->Destroy();
   return Status::Ok;
 }

--- a/engine/list_collection/iterator.hpp
+++ b/engine/list_collection/iterator.hpp
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright(c) 2021-2022 Intel Corporation
+ */
+
 #pragma once
 
 #include "../version/version_controller.hpp"
@@ -12,7 +16,7 @@ class ListIteratorImpl final : public ListIterator {
       : list_(list),
         snapshot_(snapshot),
         own_snapshot_(own_snapshot),
-        dl_iter_(&list->dl_list_, list->pmem_allocator_, snapshot) {}
+        dl_iter_(&list->dl_list_, list->kv_allocator_, snapshot) {}
 
   void Seek(long index) final {
     if (index < 0) {

--- a/engine/list_collection/list.hpp
+++ b/engine/list_collection/list.hpp
@@ -14,11 +14,11 @@ class ListIteratorImpl;
 class List : public Collection {
  public:
   List(DLRecord* header, const StringView& name, CollectionIDType id,
-       Allocator* pmem_allocator, LockTable* lock_table)
+       Allocator* kv_allocator, LockTable* lock_table)
       : Collection(name, id),
         list_lock_(),
-        dl_list_(header, pmem_allocator, lock_table),
-        pmem_allocator_(pmem_allocator),
+        dl_list_(header, kv_allocator, lock_table),
+        kv_allocator_(kv_allocator),
         live_records_() {}
 
   struct WriteResult {
@@ -160,7 +160,7 @@ class List : public Collection {
   friend ListIteratorImpl;
   std::recursive_mutex list_lock_;
   DLList dl_list_;
-  Allocator* pmem_allocator_;
+  Allocator* kv_allocator_;
   std::atomic<size_t> size_;
   // to avoid illegal access caused by cleaning skiplist by multi-thread
   SpinMutex cleaning_lock_;

--- a/engine/lock_table.hpp
+++ b/engine/lock_table.hpp
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright(c) 2021-2022 Intel Corporation
+ */
+
 #pragma once
 
 #include <mutex>

--- a/engine/macros.hpp
+++ b/engine/macros.hpp
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright(c) 2021-2022 Intel Corporation
+ */
+
 #pragma once
 
 #include <iomanip>

--- a/engine/snapshot.hpp
+++ b/engine/snapshot.hpp
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright(c) 2021-2022 Intel Corporation
+ */
+
 #include "utils/utils.hpp"
 
 namespace KVDK_NAMESPACE {

--- a/engine/sorted_collection/iterator.hpp
+++ b/engine/sorted_collection/iterator.hpp
@@ -13,12 +13,12 @@ class KVEngine;
 
 class SortedIteratorImpl : public SortedIterator {
  public:
-  SortedIteratorImpl(Skiplist* skiplist, const Allocator* pmem_allocator,
+  SortedIteratorImpl(Skiplist* skiplist, const Allocator* kv_allocator,
                      const SnapshotImpl* snapshot, bool own_snapshot)
       : skiplist_(skiplist),
         snapshot_(snapshot),
         own_snapshot_(own_snapshot),
-        dl_iter_(&skiplist->dl_list_, pmem_allocator, snapshot) {}
+        dl_iter_(&skiplist->dl_list_, kv_allocator, snapshot) {}
 
   virtual ~SortedIteratorImpl() = default;
 
@@ -26,7 +26,7 @@ class SortedIteratorImpl : public SortedIterator {
     assert(skiplist_);
     Splice splice(skiplist_);
     skiplist_->Seek(key, &splice);
-    dl_iter_.Locate(splice.next_pmem_record, true);
+    dl_iter_.Locate(splice.next_data_record, true);
   }
 
   virtual void SeekToFirst() override { dl_iter_.SeekToFirst(); }

--- a/engine/sorted_collection/rebuilder.cpp
+++ b/engine/sorted_collection/rebuilder.cpp
@@ -15,7 +15,7 @@ SortedCollectionRebuilder::SortedCollectionRebuilder(
     KVEngine* kv_engine, bool segment_based_rebuild,
     uint64_t num_rebuild_threads, const CheckPoint& checkpoint)
     : kv_engine_(kv_engine),
-      recovery_utils_(kv_engine->pmem_allocator_.get()),
+      recovery_utils_(kv_engine->kv_allocator_.get()),
       checkpoint_(checkpoint),
       segment_based_rebuild_(segment_based_rebuild),
       num_rebuild_threads_(std::min(num_rebuild_threads,
@@ -47,7 +47,7 @@ Status SortedCollectionRebuilder::AddHeader(DLRecord* header_record) {
   bool linked_record = recovery_utils_.CheckAndRepairLinkage(header_record);
   if (!linked_record) {
     if (!recoverToCheckpoint()) {
-      kv_engine_->pmem_allocator_->PurgeAndFree<DLRecord>(header_record);
+      kv_engine_->kv_allocator_->PurgeAndFree<DLRecord>(header_record);
     } else {
       // We do not know if this is a checkpoint version record, so we can't free
       // it here
@@ -68,7 +68,7 @@ Status SortedCollectionRebuilder::AddElement(DLRecord* record) {
 
   if (!linked_record) {
     if (!recoverToCheckpoint()) {
-      kv_engine_->pmem_allocator_->PurgeAndFree<DLRecord>(record);
+      kv_engine_->kv_allocator_->PurgeAndFree<DLRecord>(record);
     } else {
       // We do not know if this is a checkpoint version record, so we can't free
       // it here
@@ -95,21 +95,19 @@ Status SortedCollectionRebuilder::AddElement(DLRecord* record) {
 
 Status SortedCollectionRebuilder::Rollback(
     const BatchWriteLog::SortedLogEntry& log) {
-  Allocator* pmem_allocator = kv_engine_->pmem_allocator_.get();
+  Allocator* kv_allocator = kv_engine_->kv_allocator_.get();
   LockTable* lock_table = kv_engine_->dllist_locks_.get();
-  DLRecord* elem = pmem_allocator->offset2addr_checked<DLRecord>(log.offset);
+  DLRecord* elem = kv_allocator->offset2addr_checked<DLRecord>(log.offset);
   // We only check prev linkage as a valid prev linkage indicate valid prev
   // and next pointers on the record, so we can safely do remove/replace
   if (elem->Validate() && recovery_utils_.CheckPrevLinkage(elem)) {
-    if (elem->old_version != kNullPMemOffset) {
+    if (elem->old_version != kNullMemoryOffset) {
       bool success = Skiplist::Replace(
-          elem,
-          pmem_allocator->offset2addr_checked<DLRecord>(elem->old_version),
-          nullptr, pmem_allocator, lock_table);
+          elem, kv_allocator->offset2addr_checked<DLRecord>(elem->old_version),
+          nullptr, kv_allocator, lock_table);
       kvdk_assert(success, "Replace should success as we checked linkage");
     } else {
-      bool success =
-          Skiplist::Remove(elem, nullptr, pmem_allocator, lock_table);
+      bool success = Skiplist::Remove(elem, nullptr, kv_allocator, lock_table);
       kvdk_assert(success, "Remove should success as we checked linkage");
     }
   }
@@ -118,7 +116,7 @@ Status SortedCollectionRebuilder::Rollback(
 }
 
 Status SortedCollectionRebuilder::initRebuildLists() {
-  Allocator* pmem_allocator = kv_engine_->pmem_allocator_.get();
+  Allocator* kv_allocator = kv_engine_->kv_allocator_.get();
   Status s = kv_engine_->maybeInitAccessThread();
   if (s != Status::Ok) {
     return s;
@@ -145,11 +143,11 @@ Status SortedCollectionRebuilder::initRebuildLists() {
       // header linkage.
       kvdk_assert(
           header_record->prev == header_record->next &&
-              header_record->prev == pmem_allocator->addr2offset(header_record),
+              header_record->prev == kv_allocator->addr2offset(header_record),
           "outdated header record with valid linkage should always "
           "point to it self");
       // Break the linkage
-      auto newer_offset = pmem_allocator->addr2offset(linked_headers_[i + 1]);
+      auto newer_offset = kv_allocator->addr2offset(linked_headers_[i + 1]);
       header_record->PersistPrevNT(newer_offset);
       kvdk_assert(!recovery_utils_.CheckPrevLinkage(header_record) &&
                       !recovery_utils_.CheckNextLinkage(header_record),
@@ -191,7 +189,7 @@ Status SortedCollectionRebuilder::initRebuildLists() {
       // No valid version, or valid version header belongs to another linked
       // skiplist with same name
       skiplist = std::make_shared<Skiplist>(
-          header_record, collection_name, id, comparator, pmem_allocator,
+          header_record, collection_name, id, comparator, kv_allocator,
           kv_engine_->hash_table_.get(), kv_engine_->dllist_locks_.get(), false /* we do not build hash index for a invalid skiplist as it will be destroyed soon */);
       {
         std::lock_guard<SpinMutex> lg(lock_);
@@ -203,7 +201,7 @@ Status SortedCollectionRebuilder::initRebuildLists() {
       if (valid_version_record != header_record) {
         bool success =
             Skiplist::Replace(header_record, valid_version_record, nullptr,
-                              pmem_allocator, kv_engine_->dllist_locks_.get());
+                              kv_allocator, kv_engine_->dllist_locks_.get());
         kvdk_assert(success, "headers in rebuild should passed linkage check");
         addUnlinkedRecord(header_record);
       }
@@ -214,18 +212,18 @@ Status SortedCollectionRebuilder::initRebuildLists() {
 
       if (outdated) {
         skiplist = std::make_shared<Skiplist>(
-            valid_version_record, collection_name, id, comparator,
-            pmem_allocator, kv_engine_->hash_table_.get(),
-            kv_engine_->dllist_locks_.get(), false);
+            valid_version_record, collection_name, id, comparator, kv_allocator,
+            kv_engine_->hash_table_.get(), kv_engine_->dllist_locks_.get(),
+            false);
         {
           std::lock_guard<SpinMutex> lg(lock_);
           invalid_skiplists_[id] = skiplist;
         }
       } else {
         skiplist = std::make_shared<Skiplist>(
-            valid_version_record, collection_name, id, comparator,
-            pmem_allocator, kv_engine_->hash_table_.get(),
-            kv_engine_->dllist_locks_.get(), s_configs.index_with_hashtable);
+            valid_version_record, collection_name, id, comparator, kv_allocator,
+            kv_engine_->hash_table_.get(), kv_engine_->dllist_locks_.get(),
+            s_configs.index_with_hashtable);
         {
           std::lock_guard<SpinMutex> lg(lock_);
           rebuild_skiplits_[id] = skiplist;
@@ -235,7 +233,7 @@ Status SortedCollectionRebuilder::initRebuildLists() {
           addRecoverySegment(skiplist->HeaderNode());
         }
 
-        valid_version_record->PersistOldVersion(kNullPMemOffset);
+        valid_version_record->PersistOldVersion(kNullMemoryOffset);
         // Always build hash index for skiplist
         s = insertHashIndex(skiplist->Name(), skiplist.get(),
                             PointerType::Skiplist);
@@ -348,13 +346,13 @@ Status SortedCollectionRebuilder::rebuildSegmentIndex(SkiplistNode* start_node,
   }
   kvdk_assert(findCheckpointVersion(start_node->record) == start_node->record,
               "start node of a recovery segment must be valid verion");
-  start_node->record->PersistOldVersion(kNullPMemOffset);
+  start_node->record->PersistOldVersion(kNullMemoryOffset);
 
   SkiplistNode* cur_node = start_node;
   DLRecord* cur_record = cur_node->record;
   while (true) {
     DLRecord* next_record =
-        kv_engine_->pmem_allocator_->offset2addr_checked<DLRecord>(
+        kv_engine_->kv_allocator_->offset2addr_checked<DLRecord>(
             cur_record->next);
     if (next_record == segment_owner->HeaderRecord()) {
       cur_node->RelaxedSetNext(1, nullptr);
@@ -372,16 +370,15 @@ Status SortedCollectionRebuilder::rebuildSegmentIndex(SkiplistNode* start_node,
       if (valid_version_record == nullptr ||
           valid_version_record->GetRecordStatus() == RecordStatus::Outdated) {
         bool success = Skiplist::Remove(next_record, nullptr,
-                                        kv_engine_->pmem_allocator_.get(),
+                                        kv_engine_->kv_allocator_.get(),
                                         kv_engine_->dllist_locks_.get());
         kvdk_assert(success, "elems in rebuild should passed linkage check");
         addUnlinkedRecord(next_record);
       } else {
         if (valid_version_record != next_record) {
-          bool success =
-              Skiplist::Replace(next_record, valid_version_record, nullptr,
-                                kv_engine_->pmem_allocator_.get(),
-                                kv_engine_->dllist_locks_.get());
+          bool success = Skiplist::Replace(
+              next_record, valid_version_record, nullptr,
+              kv_engine_->kv_allocator_.get(), kv_engine_->dllist_locks_.get());
           kvdk_assert(success, "elems in rebuild should passed linkage check");
           addUnlinkedRecord(next_record);
         }
@@ -408,7 +405,7 @@ Status SortedCollectionRebuilder::rebuildSegmentIndex(SkiplistNode* start_node,
             return s;
           }
         }
-        valid_version_record->PersistOldVersion(kNullPMemOffset);
+        valid_version_record->PersistOldVersion(kNullMemoryOffset);
         cur_record = valid_version_record;
       }
     } else {
@@ -505,13 +502,13 @@ Status SortedCollectionRebuilder::rebuildSkiplistIndex(Skiplist* skiplist) {
   Splice splice(skiplist);
   for (uint8_t i = 1; i <= kMaxHeight; i++) {
     splice.prevs[i] = skiplist->HeaderNode();
-    splice.prev_pmem_record = skiplist->HeaderRecord();
+    splice.prev_data_record = skiplist->HeaderRecord();
   }
 
   while (true) {
-    uint64_t next_offset = splice.prev_pmem_record->next;
+    uint64_t next_offset = splice.prev_data_record->next;
     DLRecord* next_record =
-        kv_engine_->pmem_allocator_->offset2addr_checked<DLRecord>(next_offset);
+        kv_engine_->kv_allocator_->offset2addr_checked<DLRecord>(next_offset);
     if (next_record == skiplist->HeaderRecord()) {
       break;
     }
@@ -524,7 +521,7 @@ Status SortedCollectionRebuilder::rebuildSkiplistIndex(Skiplist* skiplist) {
         valid_version_record->GetRecordStatus() == RecordStatus::Outdated) {
       // purge invalid version record from list
       bool success = Skiplist::Remove(next_record, nullptr,
-                                      kv_engine_->pmem_allocator_.get(),
+                                      kv_engine_->kv_allocator_.get(),
                                       kv_engine_->dllist_locks_.get());
       kvdk_assert(success, "elems in rebuild should passed linkage check");
       addUnlinkedRecord(next_record);
@@ -533,7 +530,7 @@ Status SortedCollectionRebuilder::rebuildSkiplistIndex(Skiplist* skiplist) {
         // repair linkage of checkpoint version
         bool success = Skiplist::Replace(
             next_record, valid_version_record, nullptr,
-            kv_engine_->pmem_allocator_.get(), kv_engine_->dllist_locks_.get());
+            kv_engine_->kv_allocator_.get(), kv_engine_->dllist_locks_.get());
         kvdk_assert(success, "elems in rebuild should passed linkage check");
         addUnlinkedRecord(next_record);
       }
@@ -568,8 +565,8 @@ Status SortedCollectionRebuilder::rebuildSkiplistIndex(Skiplist* skiplist) {
         }
       }
 
-      valid_version_record->PersistOldVersion(kNullPMemOffset);
-      splice.prev_pmem_record = valid_version_record;
+      valid_version_record->PersistOldVersion(kNullMemoryOffset);
+      splice.prev_data_record = valid_version_record;
     }
   }
   skiplist->UpdateSize(num_elems);
@@ -602,16 +599,16 @@ void SortedCollectionRebuilder::cleanInvalidRecords() {
 
   // clean unlinked records
   for (auto& thread_cache : rebuilder_thread_cache_) {
-    for (DLRecord* pmem_record : thread_cache.unlinked_records) {
-      if (!Skiplist::MatchType(pmem_record) ||
-          !recovery_utils_.CheckLinkage(pmem_record)) {
-        pmem_record->Destroy();
+    for (DLRecord* data_record : thread_cache.unlinked_records) {
+      if (!Skiplist::MatchType(data_record) ||
+          !recovery_utils_.CheckLinkage(data_record)) {
+        data_record->Destroy();
         to_free.emplace_back(
-            kv_engine_->pmem_allocator_->addr2offset_checked(pmem_record),
-            pmem_record->GetRecordSize());
+            kv_engine_->kv_allocator_->addr2offset_checked(data_record),
+            data_record->GetRecordSize());
       }
     }
-    kv_engine_->pmem_allocator_->BatchFree(to_free);
+    kv_engine_->kv_allocator_->BatchFree(to_free);
     to_free.clear();
     thread_cache.unlinked_records.clear();
   }
@@ -686,22 +683,21 @@ Status SortedCollectionRebuilder::insertHashIndex(const StringView& key,
 }
 
 DLRecord* SortedCollectionRebuilder::findCheckpointVersion(
-    DLRecord* pmem_record) {
-  kvdk_assert(pmem_record != nullptr,
+    DLRecord* data_record) {
+  kvdk_assert(data_record != nullptr,
               "pass nullptr to SortedCollectionRebuilder::findValidVersion");
   if (!recoverToCheckpoint()) {
-    return pmem_record;
+    return data_record;
   }
-  CollectionIDType id = Skiplist::FetchID(pmem_record);
-  DLRecord* curr = pmem_record;
+  CollectionIDType id = Skiplist::FetchID(data_record);
+  DLRecord* curr = data_record;
   while (curr != nullptr && curr->GetTimestamp() > checkpoint_.CheckpointTS()) {
-    curr =
-        kv_engine_->pmem_allocator_->offset2addr<DLRecord>(curr->old_version);
+    curr = kv_engine_->kv_allocator_->offset2addr<DLRecord>(curr->old_version);
 
     kvdk_assert(curr == nullptr || curr->Validate(),
                 "Broken checkpoint: invalid older version sorted record");
     kvdk_assert(
-        curr == nullptr || equal_string_view(curr->Key(), pmem_record->Key()),
+        curr == nullptr || equal_string_view(curr->Key(), data_record->Key()),
         "Broken checkpoint: key of older version sorted data is "
         "not same as new "
         "version");

--- a/engine/sorted_collection/rebuilder.hpp
+++ b/engine/sorted_collection/rebuilder.hpp
@@ -63,11 +63,11 @@ class SortedCollectionRebuilder {
 
   bool recoverToCheckpoint() { return checkpoint_.Valid(); }
 
-  // Find the version of pmem_record under checkpoint version if checkpoint
-  // exist, otherwise return pmem_record itself. Return nullptr if no valid
-  // version of pmem_record exist.
+  // Find the version of data_record under checkpoint version if checkpoint
+  // exist, otherwise return data_record itself. Return nullptr if no valid
+  // version of data_record exist.
   // If invalid_version_records is not null, put all invalid versions into it.
-  DLRecord* findCheckpointVersion(DLRecord* pmem_record);
+  DLRecord* findCheckpointVersion(DLRecord* data_record);
 
   // Rebuild DRAM index based on skiplists, i.e., every recovery thread rebuilds
   // a whole skiplist one by one in parallel
@@ -110,10 +110,10 @@ class SortedCollectionRebuilder {
   Status insertHashIndex(const StringView& key, void* ptr,
                          PointerType index_type);
 
-  void addUnlinkedRecord(DLRecord* pmem_record) {
+  void addUnlinkedRecord(DLRecord* data_record) {
     assert(access_thread.id >= 0);
     rebuilder_thread_cache_[access_thread.id].unlinked_records.push_back(
-        pmem_record);
+        data_record);
   }
 
   struct ThreadCache {

--- a/engine/structures.hpp
+++ b/engine/structures.hpp
@@ -112,7 +112,7 @@ struct PendingBatch {
   // Mark batch write as process and record writing offsets.
   // Make sure the struct is on PMem and there is enough space followed the
   // struct to store record
-  void PersistProcessing(const std::vector<PMemOffsetType>& record,
+  void PersistProcessing(const std::vector<MemoryOffsetType>& record,
                          TimestampType ts);
 
   // Mark batch write as finished.
@@ -123,7 +123,7 @@ struct PendingBatch {
   Stage stage;
   uint32_t num_kv;
   TimestampType timestamp;
-  PMemOffsetType record_offsets[0];
+  MemoryOffsetType record_offsets[0];
 };
 #endif  // #ifdef KVDK_WITH_PMEM
 

--- a/engine/version/old_records_cleaner.cpp
+++ b/engine/version/old_records_cleaner.cpp
@@ -47,7 +47,7 @@ void OldRecordsCleaner::TryGlobalClean() {
       global_pending_free_space_entries_.begin(), iter);
 
   if (free_entries.size() > 0) {
-    kv_engine_->pmem_allocator_->BatchFree(space_to_free);
+    kv_engine_->kv_allocator_->BatchFree(space_to_free);
   }
 }
 

--- a/engine/write_batch_impl.cpp
+++ b/engine/write_batch_impl.cpp
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright(c) 2021-2022 Intel Corporation
+ */
+
 #include "write_batch_impl.hpp"
 
 #include "alias.hpp"

--- a/engine/write_batch_impl.hpp
+++ b/engine/write_batch_impl.hpp
@@ -1,3 +1,7 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright(c) 2021-2022 Intel Corporation
+ */
+
 #pragma once
 
 #include <x86intrin.h>
@@ -158,57 +162,57 @@ class BatchWriteLog {
 
   struct StringLogEntry {
     Op op;
-    PMemOffsetType offset;
+    MemoryOffsetType offset;
   };
 
   struct SortedLogEntry {
     Op op;
-    PMemOffsetType offset;
+    MemoryOffsetType offset;
   };
 
   struct HashLogEntry {
     Op op;
-    PMemOffsetType offset;
+    MemoryOffsetType offset;
   };
 
   struct ListLogEntry {
     Op op;
-    PMemOffsetType offset;
+    MemoryOffsetType offset;
   };
 
   explicit BatchWriteLog() {}
 
   void SetTimestamp(TimestampType ts) { timestamp_ = ts; }
 
-  void StringPut(PMemOffsetType offset) {
+  void StringPut(MemoryOffsetType offset) {
     string_logs_.emplace_back(StringLogEntry{Op::Put, offset});
   }
 
-  void StringDelete(PMemOffsetType offset) {
+  void StringDelete(MemoryOffsetType offset) {
     string_logs_.emplace_back(StringLogEntry{Op::Delete, offset});
   }
 
-  void SortedPut(PMemOffsetType offset) {
+  void SortedPut(MemoryOffsetType offset) {
     sorted_logs_.emplace_back(SortedLogEntry{Op::Put, offset});
   }
 
-  void SortedDelete(PMemOffsetType offset) {
+  void SortedDelete(MemoryOffsetType offset) {
     sorted_logs_.emplace_back(SortedLogEntry{Op::Delete, offset});
   }
 
-  void HashPut(PMemOffsetType offset) {
+  void HashPut(MemoryOffsetType offset) {
     hash_logs_.emplace_back(HashLogEntry{Op::Put, offset});
   }
 
-  void HashDelete(PMemOffsetType offset) {
+  void HashDelete(MemoryOffsetType offset) {
     hash_logs_.emplace_back(HashLogEntry{Op::Delete, offset});
   }
 
-  void ListEmplace(PMemOffsetType offset) {
+  void ListEmplace(MemoryOffsetType offset) {
     list_logs_.emplace_back(ListLogEntry{Op::Put, offset});
   }
 
-  void ListDelete(PMemOffsetType offset) {
+  void ListDelete(MemoryOffsetType offset) {
     list_logs_.emplace_back(ListLogEntry{Op::Delete, offset});
   }
 

--- a/include/kvdk/engine.hpp
+++ b/include/kvdk/engine.hpp
@@ -109,8 +109,7 @@ class Engine {
   // Status::Ok on success
   // Status::Existed if sorted collection already existed
   // Status::WrongType if collection existed but not a sorted collection
-  // Status::PMemOverflow if PMem exhausted
-  // Status::MemoryOverflow if DRAM exhausted
+  // Status::MemoryOverflow if runtime/KV memory exhausted
   virtual Status SortedCreate(
       const StringView collection,
       const SortedCollectionConfigs& configs = SortedCollectionConfigs()) = 0;
@@ -119,7 +118,7 @@ class Engine {
   // Return:
   // Status::Ok on success
   // Status::WrongType if collection existed but not a sorted collection
-  // Status::PMemOverflow if PMem exhausted
+  // Status::MemoryOverflow if runtime/KV memory exhausted
   virtual Status SortedDestroy(const StringView collection) = 0;
 
   // Get number of elements in a sorted collection
@@ -151,7 +150,7 @@ class Engine {
   // Return:
   //    Status::WrongType if list name is not a List.
   //    Status::Existed if a List named list already exists.
-  //    Status::PMemOverflow if PMem exhausted.
+  //    Status::MemoryOverflow if runtime/KV memory exhausted.
   //    Status::Ok if successfully created the List.
   virtual Status ListCreate(StringView list) = 0;
 
@@ -174,7 +173,7 @@ class Engine {
   // Return:
   //    Status::InvalidDataSize if list name or elem is too long
   //    Status::WrongType if list name is not a List.
-  //    Status::PMemOverflow if PMem exhausted.
+  //    Status::MemoryOverflow if runtime/KV memory exhausted.
   //    Status::Ok if operation succeeded.
   virtual Status ListPushFront(StringView list, StringView elem) = 0;
 
@@ -182,7 +181,7 @@ class Engine {
   // Return:
   //    Status::InvalidDataSize if list name or elem is too long
   //    Status::WrongType if list name in the instance is not a List.
-  //    Status::PMemOverflow if PMem exhausted.
+  //    Status::MemoryOverflow if runtime/KV memory exhausted.
   //    Status::Ok if operation succeeded.
   virtual Status ListPushBack(StringView list, StringView elem) = 0;
 
@@ -206,7 +205,7 @@ class Engine {
   // Return:
   //    Status::InvalidDataSize if list name or elem is too long
   //    Status::WrongType if list is not a List.
-  //    Status::PMemOverflow if PMem exhausted.
+  //    Status::MemoryOverflow if runtime/KV memory exhausted.
   //    Status::Ok if operation succeeded.
   virtual Status ListBatchPushFront(StringView list,
                                     std::vector<std::string> const& elems) = 0;
@@ -217,7 +216,7 @@ class Engine {
   // Return:
   //    Status::InvalidDataSize if list or elem is too long
   //    Status::WrongType if list name is not a List.
-  //    Status::PMemOverflow if PMem exhausted.
+  //    Status::MemoryOverflow if runtime/KV memory exhausted.
   //    Status::Ok if operation succeeded.
   virtual Status ListBatchPushBack(StringView list,
                                    std::vector<std::string> const& elems) = 0;
@@ -265,7 +264,7 @@ class Engine {
   // Insert an element before element "pos" in list "collection"
   // Return:
   //    Status::InvalidDataSize if elem is too long.
-  //    Status::PMemOverflow if PMem exhausted.
+  //    Status::MemoryOverflow if runtime/KV memory exhausted.
   //    Status::NotFound if List of the ListIterator has expired or been
   //    deleted, or "pos" not exist in the list
   //    Status::Ok if operation succeeded.
@@ -275,7 +274,7 @@ class Engine {
   // Insert an element after element "pos" in list "collection"
   // Return:
   //    Status::InvalidDataSize if elem is too long.
-  //    Status::PMemOverflow if PMem exhausted.
+  //    Status::MemoryOverflow if runtime/KV memory exhausted.
   //    Status::NotFound if List of the ListIterator has expired or been
   //    deleted, or "pos" not exist in the list
   //    Status::Ok if operation succeeded.

--- a/tests/allocator.hpp
+++ b/tests/allocator.hpp
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: BSD-3-Clause
- * Copyright(c) 2022 Intel Corporation
+ * Copyright(c) 2021-2022 Intel Corporation
  */
 
 #pragma once


### PR DESCRIPTION
<!--
Thank you for contributing to KVDK.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Problem Summary: 
- Following the last pull request, many variables should be renamed, e.g. `pmem_allocator` -> `kv_allocator`
- CI environment `ubuntu-18.04` has been deprecated and should be updated

### What is changed and how it works?

What's Changed: 
- Rename variables and update license header in recently modified files
- Upgrade  CI environment from `ubuntu-18.04`  to `ubuntu-20.04`

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

Side effects

- None
