### PR TITLE
Return not found while delete keys from a non-existed sorted collection

### DIFF
--- a/engine/kv_engine_sorted.cpp
+++ b/engine/kv_engine_sorted.cpp
@@ -198,8 +198,9 @@ Status KVEngine::SortedDelete(const StringView collection,
   Skiplist* skiplist = nullptr;
   auto ret = lookupKey<false>(collection, RecordType::SortedHeader);
   if (ret.s != Status::Ok) {
-    return (ret.s == Status::Outdated || ret.s == Status::NotFound) ? Status::Ok
-                                                                    : ret.s;
+    return (ret.s == Status::Outdated || ret.s == Status::NotFound)
+               ? Status::NotFound
+               : ret.s;
   }
 
   kvdk_assert(ret.entry.GetIndexType() == PointerType::Skiplist,

--- a/include/kvdk/engine.hpp
+++ b/include/kvdk/engine.hpp
@@ -140,8 +140,11 @@ class Engine {
                            std::string* value) = 0;
 
   // Remove SORTED-type KV of "key" in the sorted collection "collection".
-  // Return Ok on success or the "collection"/"key" did not exist, return non-Ok
-  // on any error.
+  // Return:
+  // Status::Ok on success or key not existed in collection
+  // Status::NotFound if collection not exist
+  // Status::WrongType if collection exists but is not a sorted collection
+  // Status::PMemOverflow if PMem exhausted.
   virtual Status SortedDelete(const StringView collection,
                               const StringView key) = 0;
 
@@ -149,7 +152,7 @@ class Engine {
 
   // Create an empty List.
   // Return:
-  //    Status::WrongType if list name is not a List.
+  //    Status::WrongType if list name existed but is not a List.
   //    Status::Existed if a List named list already exists.
   //    Status::PMemOverflow if PMem exhausted.
   //    Status::Ok if successfully created the List.
@@ -157,9 +160,9 @@ class Engine {
 
   // Destroy a List associated with key
   // Return:
-  //    Status::WrongType if list name is not a List.
-  //    Status::Ok if successfully destroyed the List.
-  //    Status::NotFound if list does not exist.
+  // Status::WrongType if list name is not a List.
+  // Status::Ok if successfully destroyed the List or the List not existed
+  // Status::PMemOverflow if PMem exhausted
   virtual Status ListDestroy(StringView list) = 0;
 
   // Total elements in List.

--- a/java/src/test/java/io/pmem/kvdk/EngineTest.java
+++ b/java/src/test/java/io/pmem/kvdk/EngineTest.java
@@ -90,8 +90,13 @@ public class EngineTest extends EngineTestBase {
         // destroy destroyed sorted collection: OK
         kvdkEngine.sortedDestroy(nameHandle);
 
-        // delete on destroyed sorted collection: OK
+        // delete on destroyed sorted collection: Not OK
+        try {
         kvdkEngine.sortedDelete(nameHandle, key.getBytes());
+        } catch (KVDKException ex) {
+            // should be NotFound
+            assertEquals(ex.getStatus().getCode(), Code.NotFound);
+        }
 
         // put on destroyed sorted collection: Not OK
         try {

--- a/java/src/test/java/io/pmem/kvdk/EngineTest.java
+++ b/java/src/test/java/io/pmem/kvdk/EngineTest.java
@@ -92,7 +92,7 @@ public class EngineTest extends EngineTestBase {
 
         // delete on destroyed sorted collection: Not OK
         try {
-        kvdkEngine.sortedDelete(nameHandle, key.getBytes());
+            kvdkEngine.sortedDelete(nameHandle, key.getBytes());
         } catch (KVDKException ex) {
             // should be NotFound
             assertEquals(ex.getStatus().getCode(), Code.NotFound);

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -315,7 +315,7 @@ class EngineBasicTest : public testing::Test {
     ASSERT_EQ(DestroyFunc(collection), Status::Ok);
     ASSERT_EQ(PutFunc(collection, key, val), Status::NotFound);
     ASSERT_EQ(GetFunc(collection, key, &got_val), Status::NotFound);
-    ASSERT_EQ(DeleteFunc(collection, key), Status::Ok);
+    ASSERT_EQ(DeleteFunc(collection, key), Status::NotFound);
   }
 
   void createBasicOperationTest(const std::string& collection,


### PR DESCRIPTION
What's Changed:

Return not found while delete keys from a non-existed sorted collection

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Stress test

Side effects

- No
