### PR TITLE
Explicitly register access thread to KVDK instance instead of implicitly

### DIFF
--- a/benchmark/bench.cpp
+++ b/benchmark/bench.cpp
@@ -169,6 +169,10 @@ void DBWrite(int tid) {
   std::unique_ptr<WriteBatch> batch;
   if (engine != nullptr) {
     batch = engine->WriteBatchCreate();
+    Status s = engine->RegisterAccessThread();
+    if (s != Status::Ok) {
+      std::abort();
+    }
   }
 
   for (size_t operations = 0; operations < operations_per_thread;
@@ -260,6 +264,12 @@ void DBWrite(int tid) {
 }
 
 void DBScan(int tid) {
+  if (engine != nullptr) {
+    Status s = engine->RegisterAccessThread();
+    if (s != Status::Ok) {
+      std::abort();
+    }
+  }
   std::string key(8, ' ');
   std::string value_sink;
 
@@ -331,6 +341,12 @@ void DBScan(int tid) {
 }
 
 void DBRead(int tid) {
+  if (engine != nullptr) {
+    Status s = engine->RegisterAccessThread();
+    if (s != Status::Ok) {
+      std::abort();
+    }
+  }
   std::string key(8, ' ');
   std::string value_sink;
 
@@ -527,6 +543,10 @@ int main(int argc, char** argv) {
 
   switch (bench_data_type) {
     case DataType::Sorted: {
+      Status s = engine->RegisterAccessThread();
+      if (s != Status::Ok) {
+        std::abort();
+      }
       printf("Create %ld Sorted Collections\n", FLAGS_num_collection);
       for (auto col : collections) {
         SortedCollectionConfigs s_configs;
@@ -539,6 +559,10 @@ int main(int argc, char** argv) {
       break;
     }
     case DataType::Hashes: {
+      Status s = engine->RegisterAccessThread();
+      if (s != Status::Ok) {
+        std::abort();
+      }
       for (auto col : collections) {
         Status s = engine->HashCreate(col);
         if (s != Status::Ok && s != Status::Existed) {
@@ -549,6 +573,10 @@ int main(int argc, char** argv) {
       break;
     }
     case DataType::List: {
+      Status s = engine->RegisterAccessThread();
+      if (s != Status::Ok) {
+        std::abort();
+      }
       for (auto col : collections) {
         Status s = engine->ListCreate(col);
         if (s != Status::Ok && s != Status::Existed) {

--- a/engine/c/kvdk_basic_op.cpp
+++ b/engine/c/kvdk_basic_op.cpp
@@ -96,6 +96,10 @@ KVDKStatus KVDKRestore(const char* name, const char* backup_log,
   return s;
 }
 
+extern KVDKStatus KVDKRegisterAccessThread(KVDKEngine* engine) {
+  return engine->rep->RegisterAccessThread();
+}
+
 void KVDKReleaseAccessThread(KVDKEngine* engine) {
   engine->rep->ReleaseAccessThread();
 }

--- a/engine/hash_collection/rebuilder.hpp
+++ b/engine/hash_collection/rebuilder.hpp
@@ -122,7 +122,7 @@ class HashListRebuilder {
   bool recoverToCheckPoint() { return checkpoint_.Valid(); }
 
   Status initRebuildLists() {
-    Status s = thread_manager_->MaybeInitThread(access_thread);
+    Status s = thread_manager_->MaybeRegisterThread(access_thread);
     if (s != Status::Ok) {
       return s;
     }
@@ -258,7 +258,7 @@ class HashListRebuilder {
   }
 
   Status rebuildIndex(HashList* hlist) {
-    Status s = thread_manager_->MaybeInitThread(access_thread);
+    Status s = thread_manager_->MaybeRegisterThread(access_thread);
     if (s != Status::Ok) {
       return s;
     }

--- a/engine/hash_collection/rebuilder.hpp
+++ b/engine/hash_collection/rebuilder.hpp
@@ -126,6 +126,7 @@ class HashListRebuilder {
     if (s != Status::Ok) {
       return s;
     }
+    defer(thread_manager_->Release(access_thread));
 
     // Keep headers with same id together for recognize outdated ones
     auto cmp = [](const DLRecord* header1, const DLRecord* header2) {

--- a/engine/kv_engine.cpp
+++ b/engine/kv_engine.cpp
@@ -902,7 +902,7 @@ Status KVEngine::maybeInitBatchLogFile() {
 }
 
 Status KVEngine::BatchWrite(std::unique_ptr<WriteBatch> const& batch) {
-  if (!access_thread.Registered()) {
+  if (!ThreadRegistered()) {
     return Status::InvalidAccessThread;
   }
   WriteBatchImpl const* batch_impl =
@@ -1289,7 +1289,7 @@ Status KVEngine::TypeOf(StringView key, ValueType* type) {
 }
 
 Status KVEngine::Expire(const StringView str, TTLType ttl_time) {
-  if (!access_thread.Registered()) {
+  if (!ThreadRegistered()) {
     return Status::InvalidAccessThread;
   }
 

--- a/engine/kv_engine.hpp
+++ b/engine/kv_engine.hpp
@@ -308,10 +308,11 @@ class KVEngine : public Engine {
                   "Invalid type!");
     return std::is_same<CollectionType, Skiplist>::value
                ? RecordType::SortedHeader
-           : std::is_same<CollectionType, List>::value ? RecordType::ListHeader
-           : std::is_same<CollectionType, HashList>::value
-               ? RecordType::HashHeader
-               : RecordType::Empty;
+               : std::is_same<CollectionType, List>::value
+                     ? RecordType::ListHeader
+                     : std::is_same<CollectionType, HashList>::value
+                           ? RecordType::HashHeader
+                           : RecordType::Empty;
   }
 
   static PointerType pointerType(RecordType rtype) {

--- a/engine/kv_engine.hpp
+++ b/engine/kv_engine.hpp
@@ -174,10 +174,16 @@ class KVEngine : public Engine {
   }
 
   virtual Status RegisterAccessThread() final {
-    return maybeInitAccessThread();
+    return thread_manager_->MaybeRegisterThread(access_thread);
   }
 
-  void ReleaseAccessThread() override { access_thread.Release(); }
+  void ReleaseAccessThread() override {
+    thread_manager_->Release(access_thread);
+  }
+
+  inline bool ThreadRegistered() {
+    return thread_manager_->Registered(access_thread);
+  }
 
   // For test cases
   const std::unordered_map<CollectionIDType, std::shared_ptr<Skiplist>>&
@@ -237,10 +243,6 @@ class KVEngine : public Engine {
 
   Status hashGetImpl(const StringView& key, std::string* value,
                      uint16_t type_mask);
-
-  inline Status maybeInitAccessThread() {
-    return thread_manager_->MaybeRegisterThread(access_thread);
-  }
 
   bool registerComparator(const StringView& collection_name,
                           Comparator comp_func) {

--- a/engine/kv_engine.hpp
+++ b/engine/kv_engine.hpp
@@ -173,6 +173,10 @@ class KVEngine : public Engine {
     return std::unique_ptr<WriteBatch>{new WriteBatchImpl{}};
   }
 
+  virtual Status RegisterAccessThread() final {
+    return maybeInitAccessThread();
+  }
+
   void ReleaseAccessThread() override { access_thread.Release(); }
 
   // For test cases
@@ -235,7 +239,7 @@ class KVEngine : public Engine {
                      uint16_t type_mask);
 
   inline Status maybeInitAccessThread() {
-    return thread_manager_->MaybeInitThread(access_thread);
+    return thread_manager_->MaybeRegisterThread(access_thread);
   }
 
   bool registerComparator(const StringView& collection_name,
@@ -302,11 +306,10 @@ class KVEngine : public Engine {
                   "Invalid type!");
     return std::is_same<CollectionType, Skiplist>::value
                ? RecordType::SortedHeader
-               : std::is_same<CollectionType, List>::value
-                     ? RecordType::ListHeader
-                     : std::is_same<CollectionType, HashList>::value
-                           ? RecordType::HashHeader
-                           : RecordType::Empty;
+           : std::is_same<CollectionType, List>::value ? RecordType::ListHeader
+           : std::is_same<CollectionType, HashList>::value
+               ? RecordType::HashHeader
+               : RecordType::Empty;
   }
 
   static PointerType pointerType(RecordType rtype) {

--- a/engine/kv_engine_hash.cpp
+++ b/engine/kv_engine_hash.cpp
@@ -7,7 +7,7 @@
 
 namespace KVDK_NAMESPACE {
 Status KVEngine::HashCreate(StringView collection) {
-  if (!access_thread.Registered()) {
+  if (!ThreadRegistered()) {
     return Status::InvalidAccessThread;
   }
 
@@ -59,7 +59,7 @@ Status KVEngine::buildHashlist(const StringView& collection,
 }
 
 Status KVEngine::HashDestroy(StringView collection) {
-  if (!access_thread.Registered()) {
+  if (!ThreadRegistered()) {
     return Status::InvalidAccessThread;
   }
 
@@ -99,9 +99,10 @@ Status KVEngine::HashDestroy(StringView collection) {
 }
 
 Status KVEngine::HashSize(StringView collection, size_t* len) {
-  if (!access_thread.Registered()) {
+  if (!ThreadRegistered()) {
     return Status::InvalidAccessThread;
   }
+
   if (!checkKeySize(collection)) {
     return Status::InvalidDataSize;
   }
@@ -118,7 +119,7 @@ Status KVEngine::HashSize(StringView collection, size_t* len) {
 
 Status KVEngine::HashGet(StringView collection, StringView key,
                          std::string* value) {
-  if (!access_thread.Registered()) {
+  if (!ThreadRegistered()) {
     return Status::InvalidAccessThread;
   }
 
@@ -135,7 +136,7 @@ Status KVEngine::HashGet(StringView collection, StringView key,
 
 Status KVEngine::HashPut(StringView collection, StringView key,
                          StringView value) {
-  if (!access_thread.Registered()) {
+  if (!ThreadRegistered()) {
     return Status::InvalidAccessThread;
   }
 
@@ -165,7 +166,7 @@ Status KVEngine::HashPut(StringView collection, StringView key,
 }
 
 Status KVEngine::HashDelete(StringView collection, StringView key) {
-  if (!access_thread.Registered()) {
+  if (!ThreadRegistered()) {
     return Status::InvalidAccessThread;
   }
 
@@ -195,7 +196,7 @@ Status KVEngine::HashDelete(StringView collection, StringView key) {
 
 Status KVEngine::HashModify(StringView collection, StringView key,
                             ModifyFunc modify_func, void* cb_args) {
-  if (!access_thread.Registered()) {
+  if (!ThreadRegistered()) {
     return Status::InvalidAccessThread;
   }
 
@@ -221,7 +222,7 @@ Status KVEngine::HashModify(StringView collection, StringView key,
 
 HashIterator* KVEngine::HashIteratorCreate(StringView collection,
                                            Snapshot* snapshot, Status* status) {
-  if (!access_thread.Registered()) {
+  if (!ThreadRegistered()) {
     if (status != nullptr) {
       *status = Status::InvalidAccessThread;
     }

--- a/engine/kv_engine_list.cpp
+++ b/engine/kv_engine_list.cpp
@@ -4,9 +4,8 @@
 
 namespace KVDK_NAMESPACE {
 Status KVEngine::ListCreate(StringView list_name) {
-  Status s = maybeInitAccessThread();
-  if (s != Status::Ok) {
-    return s;
+  if (!access_thread.Registered()) {
+    return Status::InvalidAccessThread;
   }
 
   if (!checkKeySize(list_name)) {
@@ -56,11 +55,11 @@ Status KVEngine::buildList(const StringView& list_name,
 }
 
 Status KVEngine::ListDestroy(StringView collection) {
+  if (!access_thread.Registered()) {
+    return Status::InvalidAccessThread;
+  }
   if (!checkKeySize(collection)) {
     return Status::InvalidDataSize;
-  }
-  if (maybeInitAccessThread() != Status::Ok) {
-    return Status::TooManyAccessThreads;
   }
 
   auto ul = hash_table_->AcquireLock(collection);
@@ -95,11 +94,11 @@ Status KVEngine::ListDestroy(StringView collection) {
 }
 
 Status KVEngine::ListSize(StringView list_name, size_t* sz) {
+  if (!access_thread.Registered()) {
+    return Status::InvalidAccessThread;
+  }
   if (!checkKeySize(list_name)) {
     return Status::InvalidDataSize;
-  }
-  if (maybeInitAccessThread() != Status::Ok) {
-    return Status::TooManyAccessThreads;
   }
 
   auto token = version_controller_.GetLocalSnapshotHolder();
@@ -115,11 +114,11 @@ Status KVEngine::ListSize(StringView list_name, size_t* sz) {
 }
 
 Status KVEngine::ListPushFront(StringView collection, StringView elem) {
+  if (!access_thread.Registered()) {
+    return Status::InvalidAccessThread;
+  }
   if (!checkKeySize(collection) || !checkValueSize(elem)) {
     return Status::InvalidDataSize;
-  }
-  if (maybeInitAccessThread() != Status::Ok) {
-    return Status::TooManyAccessThreads;
   }
 
   auto token = version_controller_.GetLocalSnapshotHolder();
@@ -134,11 +133,11 @@ Status KVEngine::ListPushFront(StringView collection, StringView elem) {
 }
 
 Status KVEngine::ListPushBack(StringView list_name, StringView elem) {
+  if (!access_thread.Registered()) {
+    return Status::InvalidAccessThread;
+  }
   if (!checkKeySize(list_name) || !checkValueSize(elem)) {
     return Status::InvalidDataSize;
-  }
-  if (maybeInitAccessThread() != Status::Ok) {
-    return Status::TooManyAccessThreads;
   }
 
   auto token = version_controller_.GetLocalSnapshotHolder();
@@ -153,11 +152,11 @@ Status KVEngine::ListPushBack(StringView list_name, StringView elem) {
 }
 
 Status KVEngine::ListPopFront(StringView list_name, std::string* elem) {
+  if (!access_thread.Registered()) {
+    return Status::InvalidAccessThread;
+  }
   if (!checkKeySize(list_name)) {
     return Status::InvalidDataSize;
-  }
-  if (maybeInitAccessThread() != Status::Ok) {
-    return Status::TooManyAccessThreads;
   }
 
   auto token = version_controller_.GetLocalSnapshotHolder();
@@ -186,11 +185,11 @@ Status KVEngine::ListPopFront(StringView list_name, std::string* elem) {
 }
 
 Status KVEngine::ListPopBack(StringView list_name, std::string* elem) {
+  if (!access_thread.Registered()) {
+    return Status::InvalidAccessThread;
+  }
   if (!checkKeySize(list_name)) {
     return Status::InvalidDataSize;
-  }
-  if (maybeInitAccessThread() != Status::Ok) {
-    return Status::TooManyAccessThreads;
   }
 
   auto token = version_controller_.GetLocalSnapshotHolder();
@@ -231,6 +230,9 @@ Status KVEngine::ListBatchPushFront(StringView list_name,
 
 Status KVEngine::ListBatchPushFront(StringView list_name,
                                     std::vector<StringView> const& elems) {
+  if (!access_thread.Registered()) {
+    return Status::InvalidAccessThread;
+  }
   if (!checkKeySize(list_name)) {
     return Status::InvalidDataSize;
   }
@@ -242,11 +244,8 @@ Status KVEngine::ListBatchPushFront(StringView list_name,
       return Status::InvalidDataSize;
     }
   }
-  Status s = maybeInitAccessThread();
-  if (s != Status::Ok) {
-    return s;
-  }
-  s = maybeInitBatchLogFile();
+
+  Status s = maybeInitBatchLogFile();
   if (s != Status::Ok) {
     return s;
   }
@@ -261,6 +260,9 @@ Status KVEngine::ListBatchPushBack(StringView list_name,
 
 Status KVEngine::ListBatchPushBack(StringView list_name,
                                    std::vector<StringView> const& elems) {
+  if (!access_thread.Registered()) {
+    return Status::InvalidAccessThread;
+  }
   if (!checkKeySize(list_name)) {
     return Status::InvalidDataSize;
   }
@@ -272,11 +274,7 @@ Status KVEngine::ListBatchPushBack(StringView list_name,
       return Status::InvalidDataSize;
     }
   }
-  Status s = maybeInitAccessThread();
-  if (s != Status::Ok) {
-    return s;
-  }
-  s = maybeInitBatchLogFile();
+  Status s = maybeInitBatchLogFile();
   if (s != Status::Ok) {
     return s;
   }
@@ -285,14 +283,13 @@ Status KVEngine::ListBatchPushBack(StringView list_name,
 
 Status KVEngine::ListBatchPopFront(StringView list_name, size_t n,
                                    std::vector<std::string>* elems) {
+  if (!access_thread.Registered()) {
+    return Status::InvalidAccessThread;
+  }
   if (!checkKeySize(list_name)) {
     return Status::InvalidDataSize;
   }
-  Status s = maybeInitAccessThread();
-  if (s != Status::Ok) {
-    return s;
-  }
-  s = maybeInitBatchLogFile();
+  Status s = maybeInitBatchLogFile();
   if (s != Status::Ok) {
     return s;
   }
@@ -301,14 +298,13 @@ Status KVEngine::ListBatchPopFront(StringView list_name, size_t n,
 
 Status KVEngine::ListBatchPopBack(StringView list_name, size_t n,
                                   std::vector<std::string>* elems) {
+  if (!access_thread.Registered()) {
+    return Status::InvalidAccessThread;
+  }
   if (!checkKeySize(list_name)) {
     return Status::InvalidDataSize;
   }
-  Status s = maybeInitAccessThread();
-  if (s != Status::Ok) {
-    return s;
-  }
-  s = maybeInitBatchLogFile();
+  Status s = maybeInitBatchLogFile();
   if (s != Status::Ok) {
     return s;
   }
@@ -318,15 +314,13 @@ Status KVEngine::ListBatchPopBack(StringView list_name, size_t n,
 
 Status KVEngine::ListMove(StringView src, ListPos src_pos, StringView dst,
                           ListPos dst_pos, std::string* elem) {
+  if (!access_thread.Registered()) {
+    return Status::InvalidAccessThread;
+  }
   if (!checkKeySize(src) || !checkKeySize(dst)) {
     return Status::InvalidDataSize;
   }
-  Status s = maybeInitAccessThread();
-  if (s != Status::Ok) {
-    return s;
-  }
-
-  s = maybeInitBatchLogFile();
+  Status s = maybeInitBatchLogFile();
   if (s != Status::Ok) {
     return s;
   }
@@ -407,12 +401,13 @@ Status KVEngine::ListMove(StringView src, ListPos src_pos, StringView dst,
 
 Status KVEngine::ListInsertAt(StringView list_name, StringView elem,
                               long index) {
+  if (!access_thread.Registered()) {
+    return Status::InvalidAccessThread;
+  }
   if (!checkValueSize(elem)) {
     return Status::InvalidDataSize;
   }
-  if (maybeInitAccessThread() != Status::Ok) {
-    return Status::TooManyAccessThreads;
-  }
+
   auto token = version_controller_.GetLocalSnapshotHolder();
   List* list;
   Status s = listFind(list_name, &list);
@@ -426,11 +421,11 @@ Status KVEngine::ListInsertAt(StringView list_name, StringView elem,
 
 Status KVEngine::ListInsertBefore(StringView list_name, StringView elem,
                                   StringView pos) {
+  if (!access_thread.Registered()) {
+    return Status::InvalidAccessThread;
+  }
   if (!checkValueSize(elem)) {
     return Status::InvalidDataSize;
-  }
-  if (maybeInitAccessThread() != Status::Ok) {
-    return Status::TooManyAccessThreads;
   }
 
   auto token = version_controller_.GetLocalSnapshotHolder();
@@ -448,11 +443,11 @@ Status KVEngine::ListInsertBefore(StringView list_name, StringView elem,
 
 Status KVEngine::ListInsertAfter(StringView collection, StringView elem,
                                  StringView dst) {
+  if (!access_thread.Registered()) {
+    return Status::InvalidAccessThread;
+  }
   if (!checkValueSize(elem)) {
     return Status::InvalidDataSize;
-  }
-  if (maybeInitAccessThread() != Status::Ok) {
-    return Status::TooManyAccessThreads;
   }
 
   auto token = version_controller_.GetLocalSnapshotHolder();
@@ -469,8 +464,8 @@ Status KVEngine::ListInsertAfter(StringView collection, StringView elem,
 
 Status KVEngine::ListErase(StringView list_name, long index,
                            std::string* elem) {
-  if (maybeInitAccessThread() != Status::Ok) {
-    return Status::TooManyAccessThreads;
+  if (!access_thread.Registered()) {
+    return Status::InvalidAccessThread;
   }
 
   auto token = version_controller_.GetLocalSnapshotHolder();
@@ -499,8 +494,8 @@ Status KVEngine::ListErase(StringView list_name, long index,
 // Replace the element at pos
 Status KVEngine::ListReplace(StringView collection, long index,
                              StringView elem) {
-  if (maybeInitAccessThread() != Status::Ok) {
-    return Status::TooManyAccessThreads;
+  if (!access_thread.Registered()) {
+    return Status::InvalidAccessThread;
   }
 
   auto token = version_controller_.GetLocalSnapshotHolder();
@@ -515,6 +510,13 @@ Status KVEngine::ListReplace(StringView collection, long index,
 
 ListIterator* KVEngine::ListIteratorCreate(StringView collection,
                                            Snapshot* snapshot, Status* status) {
+  if (!access_thread.Registered()) {
+    if (status != nullptr) {
+      *status = Status::InvalidAccessThread;
+    }
+    return nullptr;
+  }
+  auto holder = version_controller_.GetLocalSnapshotHolder();
   Status s{Status::Ok};
   ListIterator* ret(nullptr);
   if (!checkKeySize(collection)) {

--- a/engine/kv_engine_list.cpp
+++ b/engine/kv_engine_list.cpp
@@ -4,7 +4,7 @@
 
 namespace KVDK_NAMESPACE {
 Status KVEngine::ListCreate(StringView list_name) {
-  if (!access_thread.Registered()) {
+  if (!ThreadRegistered()) {
     return Status::InvalidAccessThread;
   }
 
@@ -55,7 +55,7 @@ Status KVEngine::buildList(const StringView& list_name,
 }
 
 Status KVEngine::ListDestroy(StringView collection) {
-  if (!access_thread.Registered()) {
+  if (!ThreadRegistered()) {
     return Status::InvalidAccessThread;
   }
   if (!checkKeySize(collection)) {
@@ -94,7 +94,7 @@ Status KVEngine::ListDestroy(StringView collection) {
 }
 
 Status KVEngine::ListSize(StringView list_name, size_t* sz) {
-  if (!access_thread.Registered()) {
+  if (!ThreadRegistered()) {
     return Status::InvalidAccessThread;
   }
   if (!checkKeySize(list_name)) {
@@ -114,7 +114,7 @@ Status KVEngine::ListSize(StringView list_name, size_t* sz) {
 }
 
 Status KVEngine::ListPushFront(StringView collection, StringView elem) {
-  if (!access_thread.Registered()) {
+  if (!ThreadRegistered()) {
     return Status::InvalidAccessThread;
   }
   if (!checkKeySize(collection) || !checkValueSize(elem)) {
@@ -133,7 +133,7 @@ Status KVEngine::ListPushFront(StringView collection, StringView elem) {
 }
 
 Status KVEngine::ListPushBack(StringView list_name, StringView elem) {
-  if (!access_thread.Registered()) {
+  if (!ThreadRegistered()) {
     return Status::InvalidAccessThread;
   }
   if (!checkKeySize(list_name) || !checkValueSize(elem)) {
@@ -152,7 +152,7 @@ Status KVEngine::ListPushBack(StringView list_name, StringView elem) {
 }
 
 Status KVEngine::ListPopFront(StringView list_name, std::string* elem) {
-  if (!access_thread.Registered()) {
+  if (!ThreadRegistered()) {
     return Status::InvalidAccessThread;
   }
   if (!checkKeySize(list_name)) {
@@ -185,7 +185,7 @@ Status KVEngine::ListPopFront(StringView list_name, std::string* elem) {
 }
 
 Status KVEngine::ListPopBack(StringView list_name, std::string* elem) {
-  if (!access_thread.Registered()) {
+  if (!ThreadRegistered()) {
     return Status::InvalidAccessThread;
   }
   if (!checkKeySize(list_name)) {
@@ -230,7 +230,7 @@ Status KVEngine::ListBatchPushFront(StringView list_name,
 
 Status KVEngine::ListBatchPushFront(StringView list_name,
                                     std::vector<StringView> const& elems) {
-  if (!access_thread.Registered()) {
+  if (!ThreadRegistered()) {
     return Status::InvalidAccessThread;
   }
   if (!checkKeySize(list_name)) {
@@ -260,7 +260,7 @@ Status KVEngine::ListBatchPushBack(StringView list_name,
 
 Status KVEngine::ListBatchPushBack(StringView list_name,
                                    std::vector<StringView> const& elems) {
-  if (!access_thread.Registered()) {
+  if (!ThreadRegistered()) {
     return Status::InvalidAccessThread;
   }
   if (!checkKeySize(list_name)) {
@@ -283,7 +283,7 @@ Status KVEngine::ListBatchPushBack(StringView list_name,
 
 Status KVEngine::ListBatchPopFront(StringView list_name, size_t n,
                                    std::vector<std::string>* elems) {
-  if (!access_thread.Registered()) {
+  if (!ThreadRegistered()) {
     return Status::InvalidAccessThread;
   }
   if (!checkKeySize(list_name)) {
@@ -298,7 +298,7 @@ Status KVEngine::ListBatchPopFront(StringView list_name, size_t n,
 
 Status KVEngine::ListBatchPopBack(StringView list_name, size_t n,
                                   std::vector<std::string>* elems) {
-  if (!access_thread.Registered()) {
+  if (!ThreadRegistered()) {
     return Status::InvalidAccessThread;
   }
   if (!checkKeySize(list_name)) {
@@ -314,7 +314,7 @@ Status KVEngine::ListBatchPopBack(StringView list_name, size_t n,
 
 Status KVEngine::ListMove(StringView src, ListPos src_pos, StringView dst,
                           ListPos dst_pos, std::string* elem) {
-  if (!access_thread.Registered()) {
+  if (!ThreadRegistered()) {
     return Status::InvalidAccessThread;
   }
   if (!checkKeySize(src) || !checkKeySize(dst)) {
@@ -401,7 +401,7 @@ Status KVEngine::ListMove(StringView src, ListPos src_pos, StringView dst,
 
 Status KVEngine::ListInsertAt(StringView list_name, StringView elem,
                               long index) {
-  if (!access_thread.Registered()) {
+  if (!ThreadRegistered()) {
     return Status::InvalidAccessThread;
   }
   if (!checkValueSize(elem)) {
@@ -421,7 +421,7 @@ Status KVEngine::ListInsertAt(StringView list_name, StringView elem,
 
 Status KVEngine::ListInsertBefore(StringView list_name, StringView elem,
                                   StringView pos) {
-  if (!access_thread.Registered()) {
+  if (!ThreadRegistered()) {
     return Status::InvalidAccessThread;
   }
   if (!checkValueSize(elem)) {
@@ -443,7 +443,7 @@ Status KVEngine::ListInsertBefore(StringView list_name, StringView elem,
 
 Status KVEngine::ListInsertAfter(StringView collection, StringView elem,
                                  StringView dst) {
-  if (!access_thread.Registered()) {
+  if (!ThreadRegistered()) {
     return Status::InvalidAccessThread;
   }
   if (!checkValueSize(elem)) {
@@ -464,7 +464,7 @@ Status KVEngine::ListInsertAfter(StringView collection, StringView elem,
 
 Status KVEngine::ListErase(StringView list_name, long index,
                            std::string* elem) {
-  if (!access_thread.Registered()) {
+  if (!ThreadRegistered()) {
     return Status::InvalidAccessThread;
   }
 
@@ -494,7 +494,7 @@ Status KVEngine::ListErase(StringView list_name, long index,
 // Replace the element at pos
 Status KVEngine::ListReplace(StringView collection, long index,
                              StringView elem) {
-  if (!access_thread.Registered()) {
+  if (!ThreadRegistered()) {
     return Status::InvalidAccessThread;
   }
 
@@ -510,7 +510,7 @@ Status KVEngine::ListReplace(StringView collection, long index,
 
 ListIterator* KVEngine::ListIteratorCreate(StringView collection,
                                            Snapshot* snapshot, Status* status) {
-  if (!access_thread.Registered()) {
+  if (!ThreadRegistered()) {
     if (status != nullptr) {
       *status = Status::InvalidAccessThread;
     }

--- a/engine/kv_engine_sorted.cpp
+++ b/engine/kv_engine_sorted.cpp
@@ -8,7 +8,7 @@
 namespace KVDK_NAMESPACE {
 Status KVEngine::SortedCreate(const StringView collection_name,
                               const SortedCollectionConfigs& s_configs) {
-  if (!access_thread.Registered()) {
+  if (!ThreadRegistered()) {
     return Status::InvalidAccessThread;
   }
 
@@ -72,7 +72,7 @@ Status KVEngine::buildSkiplist(const StringView& collection_name,
 }
 
 Status KVEngine::SortedDestroy(const StringView collection_name) {
-  if (!access_thread.Registered()) {
+  if (!ThreadRegistered()) {
     return Status::InvalidAccessThread;
   }
   auto ul = hash_table_->AcquireLock(collection_name);
@@ -114,7 +114,7 @@ Status KVEngine::SortedDestroy(const StringView collection_name) {
 }
 
 Status KVEngine::SortedSize(const StringView collection, size_t* size) {
-  if (!access_thread.Registered()) {
+  if (!ThreadRegistered()) {
     return Status::InvalidAccessThread;
   }
 
@@ -135,7 +135,7 @@ Status KVEngine::SortedSize(const StringView collection, size_t* size) {
 
 Status KVEngine::SortedGet(const StringView collection,
                            const StringView user_key, std::string* value) {
-  if (!access_thread.Registered()) {
+  if (!ThreadRegistered()) {
     return Status::InvalidAccessThread;
   }
 
@@ -158,7 +158,7 @@ Status KVEngine::SortedGet(const StringView collection,
 
 Status KVEngine::SortedPut(const StringView collection,
                            const StringView user_key, const StringView value) {
-  if (!access_thread.Registered()) {
+  if (!ThreadRegistered()) {
     return Status::InvalidAccessThread;
   }
 
@@ -179,7 +179,7 @@ Status KVEngine::SortedPut(const StringView collection,
 
 Status KVEngine::SortedDelete(const StringView collection,
                               const StringView user_key) {
-  if (!access_thread.Registered()) {
+  if (!ThreadRegistered()) {
     return Status::InvalidAccessThread;
   }
   // Hold current snapshot in this thread
@@ -201,7 +201,7 @@ Status KVEngine::SortedDelete(const StringView collection,
 
 SortedIterator* KVEngine::SortedIteratorCreate(const StringView collection,
                                                Snapshot* snapshot, Status* s) {
-  if (!access_thread.Registered()) {
+  if (!ThreadRegistered()) {
     if (s != nullptr) {
       *s = Status::InvalidAccessThread;
     }

--- a/engine/kv_engine_string.cpp
+++ b/engine/kv_engine_string.cpp
@@ -9,14 +9,12 @@ namespace KVDK_NAMESPACE {
 
 Status KVEngine::Modify(const StringView key, ModifyFunc modify_func,
                         void* modify_args, const WriteOptions& write_options) {
+  if (!access_thread.Registered()) {
+    return Status::InvalidAccessThread;
+  }
   int64_t base_time = TimeUtils::millisecond_time();
   if (!TimeUtils::CheckTTL(write_options.ttl_time, base_time)) {
     return Status::InvalidArgument;
-  }
-
-  Status s = maybeInitAccessThread();
-  if (s != Status::Ok) {
-    return s;
   }
 
   auto ul = hash_table_->AcquireLock(key);
@@ -106,9 +104,8 @@ Status KVEngine::Modify(const StringView key, ModifyFunc modify_func,
 
 Status KVEngine::Put(const StringView key, const StringView value,
                      const WriteOptions& options) {
-  Status s = maybeInitAccessThread();
-  if (s != Status::Ok) {
-    return s;
+  if (!access_thread.Registered()) {
+    return Status::InvalidAccessThread;
   }
 
   if (!checkKeySize(key) || !checkValueSize(value)) {
@@ -119,10 +116,8 @@ Status KVEngine::Put(const StringView key, const StringView value,
 }
 
 Status KVEngine::Get(const StringView key, std::string* value) {
-  Status s = maybeInitAccessThread();
-
-  if (s != Status::Ok) {
-    return s;
+  if (!access_thread.Registered()) {
+    return Status::InvalidAccessThread;
   }
 
   if (!checkKeySize(key)) {
@@ -144,10 +139,8 @@ Status KVEngine::Get(const StringView key, std::string* value) {
 }
 
 Status KVEngine::Delete(const StringView key) {
-  Status s = maybeInitAccessThread();
-
-  if (s != Status::Ok) {
-    return s;
+  if (!access_thread.Registered()) {
+    return Status::InvalidAccessThread;
   }
 
   if (!checkKeySize(key)) {

--- a/engine/kv_engine_string.cpp
+++ b/engine/kv_engine_string.cpp
@@ -9,7 +9,7 @@ namespace KVDK_NAMESPACE {
 
 Status KVEngine::Modify(const StringView key, ModifyFunc modify_func,
                         void* modify_args, const WriteOptions& write_options) {
-  if (!access_thread.Registered()) {
+  if (!ThreadRegistered()) {
     return Status::InvalidAccessThread;
   }
   int64_t base_time = TimeUtils::millisecond_time();
@@ -104,7 +104,7 @@ Status KVEngine::Modify(const StringView key, ModifyFunc modify_func,
 
 Status KVEngine::Put(const StringView key, const StringView value,
                      const WriteOptions& options) {
-  if (!access_thread.Registered()) {
+  if (!ThreadRegistered()) {
     return Status::InvalidAccessThread;
   }
 
@@ -116,7 +116,7 @@ Status KVEngine::Put(const StringView key, const StringView value,
 }
 
 Status KVEngine::Get(const StringView key, std::string* value) {
-  if (!access_thread.Registered()) {
+  if (!ThreadRegistered()) {
     return Status::InvalidAccessThread;
   }
 
@@ -139,7 +139,7 @@ Status KVEngine::Get(const StringView key, std::string* value) {
 }
 
 Status KVEngine::Delete(const StringView key) {
-  if (!access_thread.Registered()) {
+  if (!ThreadRegistered()) {
     return Status::InvalidAccessThread;
   }
 

--- a/engine/list_collection/rebuilder.hpp
+++ b/engine/list_collection/rebuilder.hpp
@@ -223,7 +223,7 @@ class ListRebuilder {
 
   Status rebuildIndex(List* list) {
     auto ul = list->AcquireLock();
-    Status s = thread_manager_->MaybeInitThread(access_thread);
+    Status s = thread_manager_->MaybeRegisterThread(access_thread);
     if (s != Status::Ok) {
       return s;
     }

--- a/engine/list_collection/rebuilder.hpp
+++ b/engine/list_collection/rebuilder.hpp
@@ -122,11 +122,13 @@ class ListRebuilder {
   bool recoverToCheckPoint() { return checkpoint_.Valid(); }
 
   Status initRebuildLists() {
+    Status s = thread_manager_->MaybeRegisterThread(access_thread);
+    if (s != Status::Ok) {
+      return s;
+    }
+    defer(thread_manager_->Release(access_thread));
     for (size_t i = 0; i < linked_headers_.size(); i++) {
       DLRecord* header_record = linked_headers_[i];
-      // if (i + 1 < linked_headers_.size() /*&& xx*/) {
-      // continue;
-      // }
 
       auto collection_name = header_record->Key();
       CollectionIDType id = Collection::DecodeID(header_record->Value());

--- a/engine/sorted_collection/rebuilder.cpp
+++ b/engine/sorted_collection/rebuilder.cpp
@@ -121,6 +121,7 @@ Status SortedCollectionRebuilder::initRebuildLists() {
   if (s != Status::Ok) {
     return s;
   }
+  defer(kv_engine_->ReleaseAccessThread());
 
   // Keep headers with same id together for recognize outdated ones
   auto cmp = [](const DLRecord* header1, const DLRecord* header2) {

--- a/engine/sorted_collection/rebuilder.cpp
+++ b/engine/sorted_collection/rebuilder.cpp
@@ -117,7 +117,7 @@ Status SortedCollectionRebuilder::Rollback(
 
 Status SortedCollectionRebuilder::initRebuildLists() {
   PMEMAllocator* pmem_allocator = kv_engine_->pmem_allocator_.get();
-  Status s = kv_engine_->maybeInitAccessThread();
+  Status s = kv_engine_->RegisterAccessThread();
   if (s != Status::Ok) {
     return s;
   }
@@ -253,7 +253,7 @@ Status SortedCollectionRebuilder::segmentBasedIndexRebuild() {
   std::vector<std::future<Status>> fs;
 
   auto rebuild_segments_index = [&]() -> Status {
-    Status s = this->kv_engine_->maybeInitAccessThread();
+    Status s = this->kv_engine_->RegisterAccessThread();
     if (s != Status::Ok) {
       return s;
     }
@@ -492,7 +492,7 @@ Status SortedCollectionRebuilder::linkHighDramNodes(Skiplist* skiplist) {
 }
 
 Status SortedCollectionRebuilder::rebuildSkiplistIndex(Skiplist* skiplist) {
-  Status s = kv_engine_->maybeInitAccessThread();
+  Status s = kv_engine_->RegisterAccessThread();
   if (s != Status::Ok) {
     return s;
   }

--- a/engine/thread_manager.cpp
+++ b/engine/thread_manager.cpp
@@ -19,7 +19,7 @@ void Thread::Release() {
 
 Thread::~Thread() { Release(); }
 
-Status ThreadManager::MaybeInitThread(Thread& t) {
+Status ThreadManager::MaybeRegisterThread(Thread& t) {
   if (t.id < 0) {
     if (!usable_id_.empty()) {
       std::lock_guard<SpinMutex> lg(spin_);

--- a/engine/thread_manager.cpp
+++ b/engine/thread_manager.cpp
@@ -25,32 +25,35 @@ Status ThreadManager::MaybeRegisterThread(Thread& t) {
         auto it = usable_id_.begin();
         t.thread_manager = shared_from_this();
         t.id = *it;
+        t.manager_id = manager_id_;
         usable_id_.erase(it);
         return Status::Ok;
       }
     }
-    int id = ids_.fetch_add(1, std::memory_order_relaxed);
+    int id = next_thread_id_.fetch_add(1, std::memory_order_relaxed);
     if (static_cast<unsigned>(id) >= max_threads_) {
       return Status::TooManyAccessThreads;
     }
     t.thread_manager = shared_from_this();
     t.id = id;
+    t.manager_id = manager_id_;
   }
   return Status::Ok;
 }
 
 bool ThreadManager::Registered(const Thread& t) {
-  return t.thread_manager.get() == this && t.id >= 0;
+  return t.thread_manager.get() == this && t.manager_id == manager_id_ &&
+         t.id >= 0;
 }
 
 void ThreadManager::Release(Thread& t) {
   if (Registered(t)) {
     assert(static_cast<unsigned>(t.id) < max_threads_);
-    auto id = t.id;
     std::lock_guard<SpinMutex> lg(spin_);
-    usable_id_.insert(id);
+    usable_id_.insert(t.id);
     t.thread_manager = nullptr;
     t.id = -1;
+    t.manager_id = -1;
   }
 }
 

--- a/engine/thread_manager.hpp
+++ b/engine/thread_manager.hpp
@@ -19,7 +19,6 @@ struct Thread {
  public:
   Thread() : id(-1), thread_manager(nullptr) {}
   ~Thread();
-  bool Registered() { return id >= 0; }
   void Release();
   int id;
   std::shared_ptr<ThreadManager> thread_manager;
@@ -29,8 +28,9 @@ class ThreadManager : public std::enable_shared_from_this<ThreadManager> {
  public:
   ThreadManager(uint32_t max_threads) : max_threads_(max_threads), ids_(0) {}
   Status MaybeRegisterThread(Thread& t);
+  bool Registered(const Thread& t);
 
-  void Release(const Thread& t);
+  void Release(Thread& t);
 
  private:
   uint32_t max_threads_;

--- a/engine/thread_manager.hpp
+++ b/engine/thread_manager.hpp
@@ -19,6 +19,7 @@ struct Thread {
  public:
   Thread() : id(-1), thread_manager(nullptr) {}
   ~Thread();
+  bool Registered() { return id >= 0; }
   void Release();
   int id;
   std::shared_ptr<ThreadManager> thread_manager;
@@ -27,7 +28,7 @@ struct Thread {
 class ThreadManager : public std::enable_shared_from_this<ThreadManager> {
  public:
   ThreadManager(uint32_t max_threads) : max_threads_(max_threads), ids_(0) {}
-  Status MaybeInitThread(Thread& t);
+  Status MaybeRegisterThread(Thread& t);
 
   void Release(const Thread& t);
 

--- a/examples/tutorial/c_api_tutorial.c
+++ b/examples/tutorial/c_api_tutorial.c
@@ -612,8 +612,8 @@ void ModifyExample(KVDKEngine* kvdk_engine) {
 
   int recycle = 100;
   for (int i = 1; i <= recycle; i++) {
-    s = KVDKModify(kvdk_engine, incr_key, strlen(incr_key), IncN,
-                              &args, free, write_option);
+    s = KVDKModify(kvdk_engine, incr_key, strlen(incr_key), IncN, &args, free,
+                   write_option);
     assert(s == Ok);
     assert(args.result == args.incr_by * (int)i);
 
@@ -736,7 +736,7 @@ int main() {
   assert(s == Ok);
 
   s = KVDKRegisterAccessThread(kvdk_engine);
-assert(s==Ok);
+  assert(s == Ok);
 
   // Modify Example
   ModifyExample(kvdk_engine);

--- a/examples/tutorial/c_api_tutorial.c
+++ b/examples/tutorial/c_api_tutorial.c
@@ -612,7 +612,7 @@ void ModifyExample(KVDKEngine* kvdk_engine) {
 
   int recycle = 100;
   for (int i = 1; i <= recycle; i++) {
-    KVDKStatus s = KVDKModify(kvdk_engine, incr_key, strlen(incr_key), IncN,
+    s = KVDKModify(kvdk_engine, incr_key, strlen(incr_key), IncN,
                               &args, free, write_option);
     assert(s == Ok);
     assert(args.result == args.incr_by * (int)i);
@@ -734,6 +734,9 @@ int main() {
   KVDKEngine* kvdk_engine;
   KVDKStatus s = KVDKOpen(engine_path, kvdk_configs, stdout, &kvdk_engine);
   assert(s == Ok);
+
+  s = KVDKRegisterAccessThread(kvdk_engine);
+assert(s==Ok);
 
   // Modify Example
   ModifyExample(kvdk_engine);

--- a/examples/tutorial/cpp_api_tutorial.cpp
+++ b/examples/tutorial/cpp_api_tutorial.cpp
@@ -432,6 +432,8 @@ int main() {
 
   status = kvdk::Engine::Open(engine_path, &engine, engine_configs, stdout);
   assert(status == kvdk::Status::Ok);
+  status = engine->RegisterAccessThread();
+  assert(status == kvdk::Status::Ok);
   printf("Successfully opened a KVDK instance.\n");
 
   // Reads and Writes on Anonymous Global Collection

--- a/examples/tutorial/zset.c
+++ b/examples/tutorial/zset.c
@@ -269,7 +269,7 @@ int main() {
   KVDKStatus s = KVDKOpen(engine_path, kvdk_configs, stdout, &kvdk_engine);
   assert(s == Ok);
   s = KVDKRegisterAccessThread(kvdk_engine);
-  assert(s==Ok);
+  assert(s == Ok);
   KVDKRegisterCompFunc(kvdk_engine, comp_name, strlen(comp_name), ScoreCmp);
   ZSetTest(kvdk_engine);
 

--- a/examples/tutorial/zset.c
+++ b/examples/tutorial/zset.c
@@ -268,6 +268,8 @@ int main() {
   KVDKEngine* kvdk_engine;
   KVDKStatus s = KVDKOpen(engine_path, kvdk_configs, stdout, &kvdk_engine);
   assert(s == Ok);
+  s = KVDKRegisterAccessThread(kvdk_engine);
+  assert(s==Ok);
   KVDKRegisterCompFunc(kvdk_engine, comp_name, strlen(comp_name), ScoreCmp);
   ZSetTest(kvdk_engine);
 

--- a/include/kvdk/engine.h
+++ b/include/kvdk/engine.h
@@ -63,6 +63,7 @@ extern KVDKStatus KVDKBackup(KVDKEngine* engine, const char* backup_path,
 extern KVDKStatus KVDKRestore(const char* name, const char* backup_log,
                               const KVDKConfigs* config, FILE* log_file,
                               KVDKEngine** engine);
+extern KVDKStatus KVDKRegisterAccessThread(KVDKEngine* engine);
 extern void KVDKReleaseAccessThread(KVDKEngine* engine);
 extern void KVDKCloseEngine(KVDKEngine* engine);
 extern void KVDKRemovePMemContents(const char* name);

--- a/include/kvdk/engine.hpp
+++ b/include/kvdk/engine.hpp
@@ -52,6 +52,25 @@ class Engine {
                         const std::string& backup_log, Engine** engine_ptr,
                         const Configs& configs, FILE* log_file = stdout);
 
+  // Register this thread as access thread of the engine, you must register
+  // access thread before read/write engine
+  // The access thread will be un-registered by calling ReleaseAccessThread() or
+  // while the thread destroyed
+  // Return:
+  // Status::Ok on success Return
+  // Status::TooManyAccessThreads if existing access threads reached
+  // Configs::max_access_threads
+  //
+  // Notice !:
+  // A thread only can be registered to one kvdk instance, if you register it to
+  // another one, the previous one will be released
+  // TODO: support multiple instance
+  virtual Status RegisterAccessThread() = 0;
+
+  // Release resources occupied by this access thread so new thread can take
+  // part. New write requests of this thread need to re-request write resources.
+  virtual void ReleaseAccessThread() = 0;
+
   virtual Status TypeOf(StringView key, ValueType* type) = 0;
 
   // Insert a STRING-type KV to set "key" to hold "value", return Ok on
@@ -370,19 +389,6 @@ class Engine {
 
   // Release a sorted iterator
   virtual void SortedIteratorRelease(SortedIterator*) = 0;
-
-  // Register this thread as access thread of the engine, you must register
-  // access thread before read/write engine
-  // The access thread will be un-registered by calling ReleaseAccessThread() or
-  // while the thread destroyed
-  // Return Status::Ok on success Return
-  // Status::TooManyAccessThreads if existing access threads reached
-  // Configs::max_access_threads
-  virtual Status RegisterAccessThread() = 0;
-
-  // Release resources occupied by this access thread so new thread can take
-  // part. New write requests of this thread need to re-request write resources.
-  virtual void ReleaseAccessThread() = 0;
 
   // Register a customized comparator to the engine on runtime
   //

--- a/include/kvdk/engine.hpp
+++ b/include/kvdk/engine.hpp
@@ -371,6 +371,15 @@ class Engine {
   // Release a sorted iterator
   virtual void SortedIteratorRelease(SortedIterator*) = 0;
 
+  // Register this thread as access thread of the engine, you must register
+  // access thread before read/write engine
+  // The access thread will be un-registered by calling ReleaseAccessThread() or
+  // while the thread destroyed
+  // Return Status::Ok on success Return
+  // Status::TooManyAccessThreads if existing access threads reached
+  // Configs::max_access_threads
+  virtual Status RegisterAccessThread() = 0;
+
   // Release resources occupied by this access thread so new thread can take
   // part. New write requests of this thread need to re-request write resources.
   virtual void ReleaseAccessThread() = 0;

--- a/include/kvdk/types.h
+++ b/include/kvdk/types.h
@@ -66,6 +66,7 @@ __attribute__((unused)) static char const* KVDKValueTypeString[] = {
   GEN(PMemMapFileError)     \
   GEN(InvalidBatchSize)     \
   GEN(TooManyAccessThreads) \
+  GEN(InvalidAccessThread)  \
   GEN(InvalidDataSize)      \
   GEN(InvalidArgument)      \
   GEN(IOError)              \

--- a/tests/allocator.hpp
+++ b/tests/allocator.hpp
@@ -72,7 +72,7 @@ class PMemAllocatorWrapper : public AllocatorAdaptor {
   }
 
   void InitThread() override {
-    thread_manager_->MaybeInitThread(access_thread);
+    thread_manager_->MaybeRegisterThread(access_thread);
   }
 
   ~PMemAllocatorWrapper(void) {

--- a/tests/c_api_test_hash.cpp
+++ b/tests/c_api_test_hash.cpp
@@ -32,6 +32,7 @@ int FetchAdd(char const* old_val_data, size_t old_val_len, char** new_val_data,
 }
 
 TEST_F(EngineCAPITestBase, Hash) {
+  ASSERT_EQ(KVDKRegisterAccessThread(engine), KVDKStatus::Ok);
   size_t num_threads = 16;
   size_t count = 1000;
 
@@ -42,6 +43,7 @@ TEST_F(EngineCAPITestBase, Hash) {
   std::mutex mu;
 
   auto HPut = [&](size_t tid) {
+    ASSERT_EQ(KVDKRegisterAccessThread(engine), KVDKStatus::Ok);
     umap& local_copy = local_copies[tid];
     for (size_t j = 0; j < count; j++) {
       std::string field{std::to_string(tid) + "_" + GetRandomString(10)};
@@ -54,6 +56,7 @@ TEST_F(EngineCAPITestBase, Hash) {
   };
 
   auto HGet = [&](size_t tid) {
+    ASSERT_EQ(KVDKRegisterAccessThread(engine), KVDKStatus::Ok);
     umap const& local_copy = local_copies[tid];
     for (auto const& kv : local_copy) {
       char* resp_data;
@@ -67,6 +70,7 @@ TEST_F(EngineCAPITestBase, Hash) {
   };
 
   auto HDelete = [&](size_t tid) {
+    ASSERT_EQ(KVDKRegisterAccessThread(engine), KVDKStatus::Ok);
     umap& local_copy = local_copies[tid];
     std::string sink;
     for (size_t i = 0; i < count / 2; i++) {
@@ -84,6 +88,7 @@ TEST_F(EngineCAPITestBase, Hash) {
   };
 
   auto HashSize = [&](size_t) {
+    ASSERT_EQ(KVDKRegisterAccessThread(engine), KVDKStatus::Ok);
     size_t len = 0;
     ASSERT_EQ(KVDKHashLength(engine, key.data(), key.size(), &len),
               KVDKStatus::Ok);
@@ -95,6 +100,7 @@ TEST_F(EngineCAPITestBase, Hash) {
   };
 
   auto HashIterate = [&](size_t tid) {
+    ASSERT_EQ(KVDKRegisterAccessThread(engine), KVDKStatus::Ok);
     umap combined;
     for (size_t tid = 0; tid < num_threads; tid++) {
       umap const& local_copy = local_copies[tid];
@@ -162,6 +168,7 @@ TEST_F(EngineCAPITestBase, Hash) {
 
   std::string counter{"counter"};
   auto HashModify = [&](size_t) {
+    ASSERT_EQ(KVDKRegisterAccessThread(engine), KVDKStatus::Ok);
     FetchAddArgs args;
     args.n = 1;
     for (size_t j = 0; j < count; j++) {
@@ -187,6 +194,7 @@ TEST_F(EngineCAPITestBase, Hash) {
   LaunchNThreads(num_threads, HashModify);
   char* resp_data;
   size_t resp_len;
+  ASSERT_EQ(KVDKRegisterAccessThread(engine), KVDKStatus::Ok);
   ASSERT_EQ(KVDKHashGet(engine, key.data(), key.size(), counter.data(),
                         counter.size(), &resp_data, &resp_len),
             KVDKStatus::Ok);

--- a/tests/c_api_test_list.cpp
+++ b/tests/c_api_test_list.cpp
@@ -15,6 +15,7 @@ void ConcatStrings(char const* elem_data, size_t elem_len, void* arg) {
 }
 
 TEST_F(EngineCAPITestBase, List) {
+  ASSERT_EQ(KVDKRegisterAccessThread(engine), KVDKStatus::Ok);
   size_t num_threads = 16;
   size_t count = 1000;
 
@@ -32,6 +33,8 @@ TEST_F(EngineCAPITestBase, List) {
   std::vector<std::list<std::string>> list_copy_vec(num_threads);
 
   auto ListIteratorGetValue = [&](KVDKListIterator* iter) {
+    KVDKStatus s = KVDKRegisterAccessThread(engine);
+    assert(s == KVDKStatus::Ok);
     char* value;
     size_t sz;
     // Read the value at the ListIterator
@@ -42,25 +45,29 @@ TEST_F(EngineCAPITestBase, List) {
   };
 
   auto ListPopFront = [&](std::string const& key) {
+    KVDKStatus s = KVDKRegisterAccessThread(engine);
+    assert(s == KVDKStatus::Ok);
     char* value;
     size_t sz;
-    KVDKStatus s =
-        KVDKListPopFront(engine, key.data(), key.size(), &value, &sz);
+    s = KVDKListPopFront(engine, key.data(), key.size(), &value, &sz);
     std::string ret{value, sz};
     free(value);
     return std::make_pair(s, ret);
   };
 
   auto ListPopBack = [&](std::string const& key) {
+    KVDKStatus s = KVDKRegisterAccessThread(engine);
+    assert(s == KVDKStatus::Ok);
     char* value;
     size_t sz;
-    KVDKStatus s = KVDKListPopBack(engine, key.data(), key.size(), &value, &sz);
+    s = KVDKListPopBack(engine, key.data(), key.size(), &value, &sz);
     std::string ret{value, sz};
     free(value);
     return std::make_pair(s, ret);
   };
 
   auto LPush = [&](size_t tid) {
+    ASSERT_EQ(KVDKRegisterAccessThread(engine), KVDKStatus::Ok);
     auto const& key = list_vec[tid];
     auto const& elems = elems_vec[tid];
     auto& list_copy = list_copy_vec[tid];
@@ -77,6 +84,7 @@ TEST_F(EngineCAPITestBase, List) {
   };
 
   auto RPush = [&](size_t tid) {
+    ASSERT_EQ(KVDKRegisterAccessThread(engine), KVDKStatus::Ok);
     auto const& key = list_vec[tid];
     auto const& elems = elems_vec[tid];
     auto& list_copy = list_copy_vec[tid];
@@ -93,6 +101,7 @@ TEST_F(EngineCAPITestBase, List) {
   };
 
   auto LPop = [&](size_t tid) {
+    ASSERT_EQ(KVDKRegisterAccessThread(engine), KVDKStatus::Ok);
     auto const& key = list_vec[tid];
     auto& list_copy = list_copy_vec[tid];
     size_t len;
@@ -111,6 +120,7 @@ TEST_F(EngineCAPITestBase, List) {
   };
 
   auto RPop = [&](size_t tid) {
+    ASSERT_EQ(KVDKRegisterAccessThread(engine), KVDKStatus::Ok);
     auto const& key = list_vec[tid];
     auto& list_copy = list_copy_vec[tid];
     size_t len;
@@ -129,6 +139,7 @@ TEST_F(EngineCAPITestBase, List) {
   };
 
   auto ListIterate = [&](size_t tid) {
+    ASSERT_EQ(KVDKRegisterAccessThread(engine), KVDKStatus::Ok);
     auto const& key = list_vec[tid];
     auto& list_copy = list_copy_vec[tid];
 
@@ -164,6 +175,7 @@ TEST_F(EngineCAPITestBase, List) {
   };
 
   auto ListInsertPutRemove = [&](size_t tid) {
+    ASSERT_EQ(KVDKRegisterAccessThread(engine), KVDKStatus::Ok);
     auto const& list_name = list_vec[tid];
     auto& list_copy = list_copy_vec[tid];
     size_t len;
@@ -233,6 +245,7 @@ TEST_F(EngineCAPITestBase, List) {
   };
 
   auto LBatchPush = [&](size_t tid) {
+    ASSERT_EQ(KVDKRegisterAccessThread(engine), KVDKStatus::Ok);
     auto const& key = list_vec[tid];
     auto const& elems = elems_vec[tid];
     auto& list_copy = list_copy_vec[tid];
@@ -251,6 +264,7 @@ TEST_F(EngineCAPITestBase, List) {
   };
 
   auto RBatchPush = [&](size_t tid) {
+    ASSERT_EQ(KVDKRegisterAccessThread(engine), KVDKStatus::Ok);
     auto const& key = list_vec[tid];
     auto const& elems = elems_vec[tid];
     auto& list_copy = list_copy_vec[tid];
@@ -269,6 +283,7 @@ TEST_F(EngineCAPITestBase, List) {
   };
 
   auto LBatchPop = [&](size_t tid) {
+    ASSERT_EQ(KVDKRegisterAccessThread(engine), KVDKStatus::Ok);
     auto const& key = list_vec[tid];
     auto& list_copy = list_copy_vec[tid];
     std::string buffer1;
@@ -289,6 +304,7 @@ TEST_F(EngineCAPITestBase, List) {
   };
 
   auto RBatchPop = [&](size_t tid) {
+    ASSERT_EQ(KVDKRegisterAccessThread(engine), KVDKStatus::Ok);
     auto const& key = list_vec[tid];
     auto& list_copy = list_copy_vec[tid];
     std::string buffer1;
@@ -308,6 +324,7 @@ TEST_F(EngineCAPITestBase, List) {
   };
 
   auto RPushLPop = [&](size_t tid) {
+    ASSERT_EQ(KVDKRegisterAccessThread(engine), KVDKStatus::Ok);
     auto const& key = list_vec[tid];
     auto& list_copy = list_copy_vec[tid];
 

--- a/tests/stress_test.cpp
+++ b/tests/stress_test.cpp
@@ -505,6 +505,7 @@ class EngineTestBase : public testing::Test {
   void HashesAllHSet(std::string const& collection_name) {
     ShuffleAllKeysValuesWithinThread();
     auto ModifyEngine = [&](int tid) {
+      ASSERT_EQ(engine->RegisterAccessThread(), kvdk::Status::Ok);
       shadow_hashes_engines[collection_name]->EvenXSetOddXSet(
           tid, grouped_keys[tid], grouped_values[tid]);
     };
@@ -518,6 +519,7 @@ class EngineTestBase : public testing::Test {
   void HashesEvenHSetOddHDelete(std::string const& collection_name) {
     ShuffleAllKeysValuesWithinThread();
     auto ModifyEngine = [&](int tid) {
+      ASSERT_EQ(engine->RegisterAccessThread(), kvdk::Status::Ok);
       shadow_hashes_engines[collection_name]->EvenXSetOddXDelete(
           tid, grouped_keys[tid], grouped_values[tid]);
     };
@@ -531,6 +533,7 @@ class EngineTestBase : public testing::Test {
   void SortedAllPut(std::string const& collection_name) {
     ShuffleAllKeysValuesWithinThread();
     auto ModifyEngine = [&](int tid) {
+      ASSERT_EQ(engine->RegisterAccessThread(), kvdk::Status::Ok);
       shadow_sorted_engines[collection_name]->EvenXSetOddXSet(
           tid, grouped_keys[tid], grouped_values[tid]);
     };
@@ -544,6 +547,7 @@ class EngineTestBase : public testing::Test {
   void SortedEvenPutOddDelete(std::string const& collection_name) {
     ShuffleAllKeysValuesWithinThread();
     auto ModifyEngine = [&](int tid) {
+      ASSERT_EQ(engine->RegisterAccessThread(), kvdk::Status::Ok);
       shadow_sorted_engines[collection_name]->EvenXSetOddXDelete(
           tid, grouped_keys[tid], grouped_values[tid]);
     };
@@ -557,6 +561,7 @@ class EngineTestBase : public testing::Test {
   void StringAllSet() {
     ShuffleAllKeysValuesWithinThread();
     auto ModifyEngine = [&](int tid) {
+      ASSERT_EQ(engine->RegisterAccessThread(), kvdk::Status::Ok);
       shadow_string_engine->EvenXSetOddXSet(tid, grouped_keys[tid],
                                             grouped_values[tid]);
     };
@@ -569,6 +574,7 @@ class EngineTestBase : public testing::Test {
   void StringEvenSetOddDelete() {
     ShuffleAllKeysValuesWithinThread();
     auto ModifyEngine = [&](int tid) {
+      ASSERT_EQ(engine->RegisterAccessThread(), kvdk::Status::Ok);
       shadow_string_engine->EvenXSetOddXDelete(tid, grouped_keys[tid],
                                                grouped_values[tid]);
     };
@@ -579,6 +585,7 @@ class EngineTestBase : public testing::Test {
   }
 
   void CheckHashesCollection(std::string collection_name) {
+    ASSERT_EQ(engine->RegisterAccessThread(), kvdk::Status::Ok);
     std::cout << "[Testing] Checking Hashes Collection: " << collection_name
               << std::endl;
     shadow_hashes_engines[collection_name]->CheckGetter();
@@ -591,6 +598,7 @@ class EngineTestBase : public testing::Test {
   }
 
   void CheckSortedCollection(std::string collection_name) {
+    ASSERT_EQ(engine->RegisterAccessThread(), kvdk::Status::Ok);
     std::cout << "[Testing] Checking Sorted Collection: " << collection_name
               << std::endl;
     shadow_sorted_engines[collection_name]->CheckGetter();
@@ -603,6 +611,7 @@ class EngineTestBase : public testing::Test {
   }
 
   void CheckStrings() {
+    ASSERT_EQ(engine->RegisterAccessThread(), kvdk::Status::Ok);
     std::cout << "[Testing] Checking strings." << std::endl;
     shadow_string_engine->CheckGetter();
   }
@@ -719,6 +728,7 @@ class EngineStressTest : public EngineTestBase {
 };
 
 TEST_F(EngineStressTest, HashesHSetOnly) {
+  ASSERT_EQ(engine->RegisterAccessThread(), kvdk::Status::Ok);
   std::string global_collection_name{"HashesCollection"};
   InitializeHashes(global_collection_name);
   ASSERT_EQ(engine->HashCreate(global_collection_name), kvdk::Status::Ok);
@@ -739,6 +749,7 @@ TEST_F(EngineStressTest, HashesHSetOnly) {
 TEST_F(EngineStressTest, HashesHSetAndHDelete) {
   std::string global_collection_name{"HashesCollection"};
   InitializeHashes(global_collection_name);
+  ASSERT_EQ(engine->RegisterAccessThread(), kvdk::Status::Ok);
   ASSERT_EQ(engine->HashCreate(global_collection_name), kvdk::Status::Ok);
 
   std::cout << "[Testing] Modify, check, reboot and check engine for "
@@ -755,6 +766,7 @@ TEST_F(EngineStressTest, HashesHSetAndHDelete) {
 }
 
 TEST_F(EngineStressTest, SortedPutOnly) {
+  ASSERT_EQ(engine->RegisterAccessThread(), kvdk::Status::Ok);
   for (int index_with_hashtable : {0, 1}) {
     std::string global_collection_name{"SortedCollection" +
                                        index_with_hashtable};
@@ -782,6 +794,7 @@ TEST_F(EngineStressTest, SortedPutOnly) {
 }
 
 TEST_F(EngineStressTest, SortedPutAndDelete) {
+  ASSERT_EQ(engine->RegisterAccessThread(), kvdk::Status::Ok);
   for (int index_with_hashtable : {0, 1}) {
     std::string global_collection_name{"SortedCollection" +
                                        index_with_hashtable};
@@ -870,6 +883,7 @@ class EngineHotspotTest : public EngineTestBase {
 };
 
 TEST_F(EngineHotspotTest, HashesMultipleHotspot) {
+  ASSERT_EQ(engine->RegisterAccessThread(), kvdk::Status::Ok);
   std::string global_collection_name{"HashesCollection"};
   InitializeHashes(global_collection_name);
   ASSERT_EQ(engine->HashCreate(global_collection_name), kvdk::Status::Ok);
@@ -891,6 +905,7 @@ TEST_F(EngineHotspotTest, HashesMultipleHotspot) {
 }
 
 TEST_F(EngineHotspotTest, SortedMultipleHotspot) {
+  ASSERT_EQ(engine->RegisterAccessThread(), kvdk::Status::Ok);
   for (int index_with_hashtable : {0, 1}) {
     std::string global_collection_name{"SortedCollection" +
                                        index_with_hashtable};
@@ -949,6 +964,7 @@ TEST_F(EngineStressTest, BackgroundCleanerTest) {
   std::cout << "[Testing] Modify, check, reboot and check engine for "
             << n_reboot << " times." << std::endl;
   for (size_t i = 0; i < n_reboot; i++) {
+    ASSERT_EQ(engine->RegisterAccessThread(), kvdk::Status::Ok);
     InitializeSorted(global_sorted_collection_name);
     InitializeHashes(global_hash_collection_name);
     InitializeStrings();

--- a/tests/test_pmem_allocator.cpp
+++ b/tests/test_pmem_allocator.cpp
@@ -76,7 +76,7 @@ TEST_F(EnginePMemAllocatorTest, TestBasicAlloc) {
         // Test function: allocate all pmem, and free all under multi-threaded
         // scenario.
         auto TestPmemAlloc = [&](size_t) {
-          thread_manager_->MaybeInitThread(access_thread);
+          thread_manager_->MaybeRegisterThread(access_thread);
           std::vector<SpaceEntry> records;
           for (uint64_t j = 0; j < num_segment_block; ++j) {
             auto space_entry = pmem_alloc->Allocate(alloc_size);
@@ -95,7 +95,7 @@ TEST_F(EnginePMemAllocatorTest, TestBasicAlloc) {
         access_thread.Release();
 
         // Then allocate all pmem.
-        thread_manager_->MaybeInitThread(access_thread);
+        thread_manager_->MaybeRegisterThread(access_thread);
         int alloc_cnt = 0;
         while (true) {
           SpaceEntry space_entry = pmem_alloc->Allocate(alloc_size);
@@ -127,7 +127,7 @@ TEST_F(EnginePMemAllocatorTest, TestPMemFragmentation) {
    * | 8 | 8 | 16 | 32 | 8 | 8 | 16 | 32 | 8 | 8 | 16 | 32 | 8 | 8 | 16 | 32 |
    */
   std::vector<SpaceEntry> records(num_thread);
-  thread_manager_->MaybeInitThread(access_thread);
+  thread_manager_->MaybeRegisterThread(access_thread);
   for (uint32_t i = 0; i < records.size(); ++i) {
     SpaceEntry space_entry = pmem_alloc->Allocate(alloc_size[i % 4]);
     records[i] = space_entry;
@@ -141,7 +141,7 @@ TEST_F(EnginePMemAllocatorTest, TestPMemFragmentation) {
    */
   // Notice threads (more than one) may share the same list of space pool.
   auto TestPmemFree = [&](uint64_t id) {
-    thread_manager_->MaybeInitThread(access_thread);
+    thread_manager_->MaybeRegisterThread(access_thread);
     if ((id + 1) % 4 != 0) {
       pmem_alloc->Free(records[id]);
     }
@@ -153,7 +153,7 @@ TEST_F(EnginePMemAllocatorTest, TestPMemFragmentation) {
   free_list->MoveCachedEntriesToPool();
   free_list->MergeSpaceInPool();
   // Test merge free memory
-  thread_manager_->MaybeInitThread(access_thread);
+  thread_manager_->MaybeRegisterThread(access_thread);
   for (uint32_t id = 0; id < num_thread / 4; ++id) {
     SpaceEntry space_entry = pmem_alloc->Allocate(alloc_size[3]);
     ASSERT_NE(space_entry.size, 0);
@@ -174,7 +174,7 @@ TEST_F(EnginePMemAllocatorTest, TestPMemAllocFreeList) {
       false, nullptr);
   ASSERT_NE(pmem_alloc, nullptr);
 
-  thread_manager_->MaybeInitThread(access_thread);
+  thread_manager_->MaybeRegisterThread(access_thread);
   // allocate 1024 bytes
   records.push_back(pmem_alloc->Allocate(1024ULL));
   ASSERT_EQ(pmem_alloc->PMemUsageInBytes(), 1024LL);

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -1092,6 +1092,7 @@ TEST_F(BatchWriteTest, Hash) {
   }
 
   auto Put = [&](size_t tid) {
+    ASSERT_EQ(engine->RegisterAccessThread(), Status::Ok);
     for (size_t i = 0; i < count; i++) {
       values[tid][i] = GetRandomString(120);
       ASSERT_EQ(engine->HashPut(key, fields[tid][i], values[tid][i]),
@@ -1100,6 +1101,7 @@ TEST_F(BatchWriteTest, Hash) {
   };
 
   auto BatchWrite = [&](size_t tid) {
+    ASSERT_EQ(engine->RegisterAccessThread(), Status::Ok);
     auto batch = engine->WriteBatchCreate();
     for (size_t i = 0; i < count; i++) {
       if (i % 2 == 0) {
@@ -1119,6 +1121,7 @@ TEST_F(BatchWriteTest, Hash) {
   };
 
   auto Check = [&](size_t tid) {
+    ASSERT_EQ(engine->RegisterAccessThread(), Status::Ok);
     for (size_t i = 0; i < count; i++) {
       std::string val_resp;
       if (values[tid][i].empty()) {
@@ -2902,26 +2905,32 @@ TEST_F(BatchWriteTest, ListBatchOperationRollback) {
   Check();
 
   Reboot();
+  ASSERT_EQ(engine->RegisterAccessThread(), Status::Ok);
   Check();
 
   LBatchPush();
   Reboot();
+  ASSERT_EQ(engine->RegisterAccessThread(), Status::Ok);
   Check();
 
   LBatchPop();
   Reboot();
+  ASSERT_EQ(engine->RegisterAccessThread(), Status::Ok);
   Check();
 
   RBatchPush();
   Reboot();
+  ASSERT_EQ(engine->RegisterAccessThread(), Status::Ok);
   Check();
 
   RBatchPop();
   Reboot();
+  ASSERT_EQ(engine->RegisterAccessThread(), Status::Ok);
   Check();
 
   RPushLPop();
   Reboot();
+  ASSERT_EQ(engine->RegisterAccessThread(), Status::Ok);
   Check();
 
   SyncPoint::GetInstance()->DisableProcessing();


### PR DESCRIPTION
### What is changed and how it works?

KVDK limits max access threads, in current impl, a thread will be implicitly registered to kvdk instance while calling any of read/write function. Meanwhile, it is required for access thread to manually release resource from the instance, which can be obscure.
In  this patch, we make thread register explicit. A thread must call function RegisterAccessThread() before accessing a kvdk instance, the occupied thread resource will be released  while calling ReleaseAccessThread() or terminating the thread.

Tests <!-- At least one of them must be included. -->

- Unit test
- Stress test

Side effects

No
