### PR TITLE
Basic transaction implementation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,6 +48,7 @@ endif()
 set(SOURCES
         engine/c/kvdk_basic_op.cpp
         engine/c/kvdk_batch.cpp
+        engine/c/kvdk_transaction.cpp
         engine/c/kvdk_hash.cpp
         engine/c/kvdk_list.cpp
         engine/c/kvdk_sorted.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,6 +68,7 @@ set(SOURCES
         engine/hash_collection/hash_list.cpp
         engine/list_collection/list.cpp
         engine/write_batch_impl.cpp
+        engine/transaction_impl.cpp
         engine/dram_allocator.cpp
         engine/pmem_allocator/pmem_allocator.cpp
         engine/thread_manager.cpp

--- a/engine/c/kvdk_c.hpp
+++ b/engine/c/kvdk_c.hpp
@@ -12,6 +12,7 @@
 #include "kvdk/engine.h"
 #include "kvdk/engine.hpp"
 #include "kvdk/iterator.hpp"
+#include "kvdk/transaction.hpp"
 #include "kvdk/write_batch.hpp"
 
 using kvdk::StringView;
@@ -23,6 +24,7 @@ using kvdk::ListIterator;
 using kvdk::Snapshot;
 using kvdk::SortedCollectionConfigs;
 using kvdk::SortedIterator;
+using kvdk::Transaction;
 using kvdk::WriteBatch;
 using kvdk::WriteOptions;
 
@@ -38,6 +40,10 @@ struct KVDKEngine {
 
 struct KVDKWriteBatch {
   std::unique_ptr<WriteBatch> rep;
+};
+
+struct KVDKTransaction {
+  std::unique_ptr<Transaction> rep;
 };
 
 struct KVDKSortedIterator {

--- a/engine/c/kvdk_transaction.cpp
+++ b/engine/c/kvdk_transaction.cpp
@@ -1,0 +1,63 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright(c) 2021-2022 Intel Corporation
+ */
+
+#include "kvdk_c.hpp"
+
+extern "C" {
+KVDKTransaction* KVDKTransactionCreate(KVDKEngine* engine) {
+  KVDKTransaction* txn = new KVDKTransaction{};
+  txn->rep = engine->rep->TransactionCreate();
+  return txn;
+}
+void KVDKTransactionDestory(KVDKTransaction* txn) { delete txn; }
+KVDKStatus KVDKTransactionStringPut(KVDKTransaction* txn, char const* key_data,
+                                    size_t key_len, char const* val_data,
+                                    size_t val_len) {
+  return txn->rep->StringPut(std::string(key_data, key_len),
+                             std::string(val_data, val_len));
+}
+KVDKStatus KVDKTransactionStringDelete(KVDKTransaction* txn,
+                                       char const* key_data, size_t key_len) {
+  return txn->rep->StringDelete(std::string(key_data, key_len));
+}
+KVDKStatus KVDKTransactionSortedPut(KVDKTransaction* txn,
+                                    char const* collection,
+                                    size_t collection_len, char const* key_data,
+                                    size_t key_len, char const* val_data,
+                                    size_t val_len) {
+  return txn->rep->SortedPut(std::string(collection, collection_len),
+                             std::string(key_data, key_len),
+                             std::string(val_data, val_len));
+}
+
+KVDKStatus KVDKTransactionSortedDelete(KVDKTransaction* txn,
+                                       char const* collection,
+                                       size_t collection_len,
+                                       char const* key_data, size_t key_len) {
+  return txn->rep->SortedDelete(std::string(collection, collection_len),
+                                std::string(key_data, key_len));
+}
+KVDKStatus KVDKTransactionHashPut(KVDKTransaction* txn, char const* collection,
+                                  size_t collection_len, char const* key_data,
+                                  size_t key_len, char const* val_data,
+                                  size_t val_len) {
+  return txn->rep->HashPut(std::string(collection, collection_len),
+                           std::string(key_data, key_len),
+                           std::string(val_data, val_len));
+}
+KVDKStatus KVDKTransactionHashDelete(KVDKTransaction* txn,
+                                     char const* collection,
+                                     size_t collection_len,
+                                     char const* key_data, size_t key_len) {
+  return txn->rep->HashDelete(std::string(collection, collection_len),
+                              std::string(key_data, key_len));
+}
+KVDKStatus KVDKTransactionCommit(KVDKTransaction* txn) {
+  return txn->rep->Commit();
+}
+void KVDKTransactionRollback(KVDKTransaction* txn) {
+  return txn->rep->Rollback();
+}
+
+}  // extern "C"

--- a/engine/data_record.hpp
+++ b/engine/data_record.hpp
@@ -17,11 +17,11 @@ namespace KVDK_NAMESPACE {
 enum RecordType : uint8_t {
   Empty = 0,
   String = (1 << 0),
-  SortedHeader = (1 << 1),
+  SortedRecord = (1 << 1),
   SortedElem = (1 << 2),
-  HashHeader = (1 << 3),
+  HashRecord = (1 << 3),
   HashElem = (1 << 4),
-  ListHeader = (1 << 5),
+  ListRecord = (1 << 5),
   ListElem = (1 << 6),
 };
 
@@ -35,8 +35,8 @@ enum class RecordStatus : uint8_t {
 };
 
 const uint8_t ExpirableRecordType =
-    (RecordType::String | RecordType::SortedHeader | RecordType::HashHeader |
-     RecordType::ListHeader);
+    (RecordType::String | RecordType::SortedRecord | RecordType::HashRecord |
+     RecordType::ListRecord);
 
 const uint8_t PrimaryRecordType = ExpirableRecordType;
 
@@ -44,8 +44,8 @@ const uint8_t ElemType =
     (RecordType::SortedElem | RecordType::HashElem | RecordType::ListElem);
 
 const uint8_t CollectionType =
-    (RecordType::SortedHeader | RecordType::HashHeader |
-     RecordType::ListHeader);
+    (RecordType::SortedRecord | RecordType::HashRecord |
+     RecordType::ListRecord);
 
 struct DataHeader {
   DataHeader() = default;
@@ -365,9 +365,9 @@ struct DLRecord {
         prev(_prev),
         next(_next),
         expired_time(_expired_time) {
-    kvdk_assert(_type & (RecordType::SortedElem | RecordType::SortedHeader |
-                         RecordType::HashElem | RecordType::HashHeader |
-                         RecordType::ListElem | RecordType::ListHeader),
+    kvdk_assert(_type & (RecordType::SortedElem | RecordType::SortedRecord |
+                         RecordType::HashElem | RecordType::HashRecord |
+                         RecordType::ListElem | RecordType::ListRecord),
                 "");
     memcpy(data, _key.data(), _key.size());
     memcpy(data + _key.size(), _value.data(), _value.size());

--- a/engine/hash_collection/hash_list.cpp
+++ b/engine/hash_collection/hash_list.cpp
@@ -218,7 +218,7 @@ HashList::WriteResult HashList::SetExpireTime(ExpireTimeType expired_time,
   }
   DLRecord* pmem_record = DLRecord::PersistDLRecord(
       pmem_allocator_->offset2addr_checked(space.offset), space.size, timestamp,
-      RecordType::HashHeader, RecordStatus::Normal,
+      RecordType::HashRecord, RecordStatus::Normal,
       pmem_allocator_->addr2offset_checked(header), header->prev, header->next,
       header->Key(), header->Value(), expired_time);
   bool success = dl_list_.Replace(header, pmem_record);
@@ -265,7 +265,7 @@ CollectionIDType HashList::FetchID(const DLRecord* record) {
   switch (record->GetRecordType()) {
     case RecordType::HashElem:
       return ExtractID(record->Key());
-    case RecordType::HashHeader:
+    case RecordType::HashRecord:
       return DecodeID(record->Value());
     default:
       GlobalLogger.Error("Wrong record type %u in HashListID",

--- a/engine/hash_collection/hash_list.hpp
+++ b/engine/hash_collection/hash_list.hpp
@@ -162,7 +162,7 @@ class HashList : public Collection {
 
   static bool MatchType(const DLRecord* record) {
     RecordType type = record->GetRecordType();
-    return type == RecordType::HashElem || type == RecordType::HashHeader;
+    return type == RecordType::HashElem || type == RecordType::HashRecord;
   }
 
  private:

--- a/engine/hash_collection/rebuilder.hpp
+++ b/engine/hash_collection/rebuilder.hpp
@@ -209,7 +209,7 @@ class HashListRebuilder {
 
         if (!outdated) {
           auto lookup_result = hash_table_->Insert(
-              collection_name, RecordType::HashHeader, RecordStatus::Normal,
+              collection_name, RecordType::HashRecord, RecordStatus::Normal,
               hlist.get(), PointerType::HashList);
           switch (lookup_result.s) {
             case Status::Ok: {

--- a/engine/hash_table.hpp
+++ b/engine/hash_table.hpp
@@ -184,6 +184,8 @@ class HashTable {
     return std::unique_lock<SpinMutex>{*getHint(key).spin};
   }
 
+  SpinMutex* GetLock(StringView const& key) { return getHint(key).spin; }
+
   HashTableIterator GetIterator(uint64_t start_slot_idx, uint64_t end_slot_idx);
 
   size_t GetSlotsNum() { return slots_.size(); }

--- a/engine/kv_engine.hpp
+++ b/engine/kv_engine.hpp
@@ -308,10 +308,10 @@ class KVEngine : public Engine {
                       std::is_same<CollectionType, HashList>::value,
                   "Invalid type!");
     return std::is_same<CollectionType, Skiplist>::value
-               ? RecordType::SortedHeader
-           : std::is_same<CollectionType, List>::value ? RecordType::ListHeader
+               ? RecordType::SortedRecord
+           : std::is_same<CollectionType, List>::value ? RecordType::ListRecord
            : std::is_same<CollectionType, HashList>::value
-               ? RecordType::HashHeader
+               ? RecordType::HashRecord
                : RecordType::Empty;
   }
 
@@ -327,13 +327,13 @@ class KVEngine : public Engine {
         kvdk_assert(false, "Not supported!");
         return PointerType::Invalid;
       }
-      case RecordType::SortedHeader: {
+      case RecordType::SortedRecord: {
         return PointerType::Skiplist;
       }
-      case RecordType::ListHeader: {
+      case RecordType::ListRecord: {
         return PointerType::List;
       }
-      case RecordType::HashHeader: {
+      case RecordType::HashRecord: {
         return PointerType::HashList;
       }
       case RecordType::HashElem: {

--- a/engine/kv_engine.hpp
+++ b/engine/kv_engine.hpp
@@ -356,10 +356,11 @@ class KVEngine : public Engine {
                   "Invalid type!");
     return std::is_same<CollectionType, Skiplist>::value
                ? RecordType::SortedRecord
-           : std::is_same<CollectionType, List>::value ? RecordType::ListRecord
-           : std::is_same<CollectionType, HashList>::value
-               ? RecordType::HashRecord
-               : RecordType::Empty;
+               : std::is_same<CollectionType, List>::value
+                     ? RecordType::ListRecord
+                     : std::is_same<CollectionType, HashList>::value
+                           ? RecordType::HashRecord
+                           : RecordType::Empty;
   }
 
   static PointerType pointerType(RecordType rtype) {

--- a/engine/kv_engine.hpp
+++ b/engine/kv_engine.hpp
@@ -325,10 +325,11 @@ class KVEngine : public Engine {
                   "Invalid type!");
     return std::is_same<CollectionType, Skiplist>::value
                ? RecordType::SortedRecord
-           : std::is_same<CollectionType, List>::value ? RecordType::ListRecord
-           : std::is_same<CollectionType, HashList>::value
-               ? RecordType::HashRecord
-               : RecordType::Empty;
+               : std::is_same<CollectionType, List>::value
+                     ? RecordType::ListRecord
+                     : std::is_same<CollectionType, HashList>::value
+                           ? RecordType::HashRecord
+                           : RecordType::Empty;
   }
 
   static PointerType pointerType(RecordType rtype) {

--- a/engine/kv_engine_cleaner.cpp
+++ b/engine/kv_engine_cleaner.cpp
@@ -158,7 +158,7 @@ void KVEngine::purgeAndFreeDLRecords(
           }
           break;
         }
-        case RecordType::SortedHeader: {
+        case RecordType::SortedRecord: {
           if (record_status != RecordStatus::Outdated &&
               !pmem_record->HasExpired()) {
             entries.emplace_back(
@@ -181,7 +181,7 @@ void KVEngine::purgeAndFreeDLRecords(
           }
           break;
         }
-        case RecordType::HashHeader: {
+        case RecordType::HashRecord: {
           if (record_status != RecordStatus::Outdated &&
               !pmem_record->HasExpired()) {
             entries.emplace_back(
@@ -204,7 +204,7 @@ void KVEngine::purgeAndFreeDLRecords(
           }
           break;
         }
-        case RecordType::ListHeader: {
+        case RecordType::ListRecord: {
           if (record_status != RecordStatus::Outdated &&
               !pmem_record->HasExpired()) {
             entries.emplace_back(
@@ -758,7 +758,7 @@ void Cleaner::FetchOutdatedCollections(
       auto skiplist_iter = outdated_collections_.skiplists.begin();
       if (skiplist_iter->second < min_snapshot_ts) {
         outdated_collection = skiplist_iter->first;
-        record_type = RecordType::SortedHeader;
+        record_type = RecordType::SortedRecord;
         outdated_collections_.skiplists.erase(skiplist_iter);
       }
     }
@@ -767,7 +767,7 @@ void Cleaner::FetchOutdatedCollections(
       auto list_iter = outdated_collections_.lists.begin();
       if (list_iter->second < min_snapshot_ts) {
         outdated_collection = list_iter->first;
-        record_type = RecordType::ListHeader;
+        record_type = RecordType::ListRecord;
         outdated_collections_.lists.erase(list_iter);
       }
     }
@@ -776,7 +776,7 @@ void Cleaner::FetchOutdatedCollections(
       auto hash_list_iter = outdated_collections_.hashlists.begin();
       if (hash_list_iter->second < min_snapshot_ts) {
         outdated_collection = hash_list_iter->first;
-        record_type = RecordType::HashHeader;
+        record_type = RecordType::HashRecord;
         outdated_collections_.hashlists.erase(hash_list_iter);
       }
     }

--- a/engine/kv_engine_hash.cpp
+++ b/engine/kv_engine_hash.cpp
@@ -28,6 +28,7 @@ Status KVEngine::buildHashlist(const StringView& collection,
   auto lookup_result = lookupKey<true>(collection, RecordType::HashRecord);
   if (lookup_result.s == Status::NotFound ||
       lookup_result.s == Status::Outdated) {
+    auto create_token = acquireCollectionCreateOrDestroyLock();
     DLRecord* existing_header =
         lookup_result.s == Outdated
             ? lookup_result.entry.GetIndex().hlist->HeaderRecord()
@@ -76,6 +77,7 @@ Status KVEngine::HashDestroy(StringView collection) {
   HashList* hlist;
   s = hashListFind(collection, &hlist);
   if (s == Status::Ok) {
+    auto destroy = acquireCollectionCreateOrDestroyLock();
     DLRecord* header = hlist->HeaderRecord();
     kvdk_assert(header->GetRecordType() == RecordType::HashRecord, "");
     StringView value = header->Value();

--- a/engine/kv_engine_list.cpp
+++ b/engine/kv_engine_list.cpp
@@ -25,6 +25,7 @@ Status KVEngine::buildList(const StringView& list_name,
   auto lookup_result = lookupKey<true>(list_name, RecordType::ListRecord);
   if (lookup_result.s == Status::NotFound ||
       lookup_result.s == Status::Outdated) {
+    auto create_token = acquireCollectionCreateOrDestroyLock();
     DLRecord* existing_header =
         lookup_result.s == Outdated
             ? lookup_result.entry.GetIndex().hlist->HeaderRecord()
@@ -69,6 +70,7 @@ Status KVEngine::ListDestroy(StringView collection) {
   List* list;
   Status s = listFind(collection, &list);
   if (s == Status::Ok) {
+    auto destroy_token = acquireCollectionCreateOrDestroyLock();
     DLRecord* header = list->HeaderRecord();
     kvdk_assert(header->GetRecordType() == RecordType::ListRecord, "");
     StringView value = header->Value();

--- a/engine/kv_engine_list.cpp
+++ b/engine/kv_engine_list.cpp
@@ -22,7 +22,7 @@ Status KVEngine::buildList(const StringView& list_name,
   auto ul = hash_table_->AcquireLock(list_name);
   auto holder = version_controller_.GetLocalSnapshotHolder();
   TimestampType new_ts = holder.Timestamp();
-  auto lookup_result = lookupKey<true>(list_name, RecordType::ListHeader);
+  auto lookup_result = lookupKey<true>(list_name, RecordType::ListRecord);
   if (lookup_result.s == Status::NotFound ||
       lookup_result.s == Status::Outdated) {
     DLRecord* existing_header =
@@ -40,14 +40,14 @@ Status KVEngine::buildList(const StringView& list_name,
     // header point to itself
     DLRecord* pmem_record = DLRecord::PersistDLRecord(
         pmem_allocator_->offset2addr_checked(space.offset), space.size, new_ts,
-        RecordType::ListHeader, RecordStatus::Normal,
+        RecordType::ListRecord, RecordStatus::Normal,
         pmem_allocator_->addr2offset(existing_header), space.offset,
         space.offset, list_name, value_str);
     list = std::make_shared<List>(pmem_record, list_name, id,
                                   pmem_allocator_.get(), dllist_locks_.get());
     kvdk_assert(list != nullptr, "");
     addListToMap(list);
-    insertKeyOrElem(lookup_result, RecordType::ListHeader, RecordStatus::Normal,
+    insertKeyOrElem(lookup_result, RecordType::ListRecord, RecordStatus::Normal,
                     list.get());
     return Status::Ok;
   } else {
@@ -70,7 +70,7 @@ Status KVEngine::ListDestroy(StringView collection) {
   Status s = listFind(collection, &list);
   if (s == Status::Ok) {
     DLRecord* header = list->HeaderRecord();
-    kvdk_assert(header->GetRecordType() == RecordType::ListHeader, "");
+    kvdk_assert(header->GetRecordType() == RecordType::ListRecord, "");
     StringView value = header->Value();
     auto request_size = DLRecord::RecordSize(collection, value);
     SpaceEntry space = pmem_allocator_->Allocate(request_size);
@@ -79,12 +79,12 @@ Status KVEngine::ListDestroy(StringView collection) {
     }
     DLRecord* pmem_record = DLRecord::PersistDLRecord(
         pmem_allocator_->offset2addr_checked(space.offset), space.size, new_ts,
-        RecordType::ListHeader, RecordStatus::Outdated,
+        RecordType::ListRecord, RecordStatus::Outdated,
         pmem_allocator_->addr2offset_checked(header), header->prev,
         header->next, collection, value);
     bool success = list->Replace(header, pmem_record);
     kvdk_assert(success, "existing header should be linked on its list");
-    hash_table_->Insert(collection, RecordType::ListHeader,
+    hash_table_->Insert(collection, RecordType::ListRecord,
                         RecordStatus::Outdated, list, PointerType::List);
     {
       std::unique_lock<std::mutex> list_lock(lists_mu_);
@@ -563,7 +563,7 @@ Status KVEngine::listRestoreList(DLRecord* pmp_record) {
 }
 
 Status KVEngine::listFind(StringView list_name, List** list) {
-  auto result = lookupKey<false>(list_name, RecordType::ListHeader);
+  auto result = lookupKey<false>(list_name, RecordType::ListRecord);
   if (result.s == Status::Outdated) {
     return Status::NotFound;
   }

--- a/engine/kv_engine_sorted.cpp
+++ b/engine/kv_engine_sorted.cpp
@@ -32,6 +32,7 @@ Status KVEngine::buildSkiplist(const StringView& collection_name,
   auto lookup_result =
       lookupKey<true>(collection_name, RecordType::SortedRecord);
   if (lookup_result.s == NotFound || lookup_result.s == Outdated) {
+    auto create_token = acquireCollectionCreateOrDestroyLock();
     DLRecord* existing_header =
         lookup_result.s == Outdated
             ? lookup_result.entry.GetIndex().skiplist->HeaderRecord()
@@ -85,6 +86,7 @@ Status KVEngine::SortedDestroy(const StringView collection_name) {
   auto lookup_result =
       lookupKey<false>(collection_name, RecordType::SortedRecord);
   if (lookup_result.s == Status::Ok) {
+    auto destroy_token = acquireCollectionCreateOrDestroyLock();
     Skiplist* skiplist = lookup_result.entry.GetIndex().skiplist;
     DLRecord* header = skiplist->HeaderRecord();
     assert(header->GetRecordType() == RecordType::SortedRecord);

--- a/engine/kv_engine_sorted.cpp
+++ b/engine/kv_engine_sorted.cpp
@@ -30,7 +30,7 @@ Status KVEngine::buildSkiplist(const StringView& collection_name,
   auto holder = version_controller_.GetLocalSnapshotHolder();
   TimestampType new_ts = holder.Timestamp();
   auto lookup_result =
-      lookupKey<true>(collection_name, RecordType::SortedHeader);
+      lookupKey<true>(collection_name, RecordType::SortedRecord);
   if (lookup_result.s == NotFound || lookup_result.s == Outdated) {
     DLRecord* existing_header =
         lookup_result.s == Outdated
@@ -56,7 +56,7 @@ Status KVEngine::buildSkiplist(const StringView& collection_name,
     // header point to itself
     DLRecord* pmem_record = DLRecord::PersistDLRecord(
         pmem_allocator_->offset2addr(space_entry.offset), space_entry.size,
-        new_ts, RecordType::SortedHeader, RecordStatus::Normal,
+        new_ts, RecordType::SortedRecord, RecordStatus::Normal,
         pmem_allocator_->addr2offset(existing_header), space_entry.offset,
         space_entry.offset, collection_name, value_str);
 
@@ -65,7 +65,7 @@ Status KVEngine::buildSkiplist(const StringView& collection_name,
         pmem_allocator_.get(), hash_table_.get(), dllist_locks_.get(),
         s_configs.index_with_hashtable);
     addSkiplistToMap(skiplist);
-    insertKeyOrElem(lookup_result, RecordType::SortedHeader,
+    insertKeyOrElem(lookup_result, RecordType::SortedRecord,
                     RecordStatus::Normal, skiplist.get());
   } else {
     return lookup_result.s == Status::Ok ? Status::Existed : lookup_result.s;
@@ -83,11 +83,11 @@ Status KVEngine::SortedDestroy(const StringView collection_name) {
   auto snapshot_holder = version_controller_.GetLocalSnapshotHolder();
   auto new_ts = snapshot_holder.Timestamp();
   auto lookup_result =
-      lookupKey<false>(collection_name, RecordType::SortedHeader);
+      lookupKey<false>(collection_name, RecordType::SortedRecord);
   if (lookup_result.s == Status::Ok) {
     Skiplist* skiplist = lookup_result.entry.GetIndex().skiplist;
     DLRecord* header = skiplist->HeaderRecord();
-    assert(header->GetRecordType() == RecordType::SortedHeader);
+    assert(header->GetRecordType() == RecordType::SortedRecord);
     StringView value = header->Value();
     auto request_size =
         sizeof(DLRecord) + collection_name.size() + value.size();
@@ -97,14 +97,14 @@ Status KVEngine::SortedDestroy(const StringView collection_name) {
     }
     DLRecord* pmem_record = DLRecord::PersistDLRecord(
         pmem_allocator_->offset2addr_checked(space_entry.offset),
-        space_entry.size, new_ts, RecordType::SortedHeader,
+        space_entry.size, new_ts, RecordType::SortedRecord,
         RecordStatus::Outdated, pmem_allocator_->addr2offset_checked(header),
         header->prev, header->next, collection_name, value, 0);
     bool success =
         Skiplist::Replace(header, pmem_record, skiplist->HeaderNode(),
                           pmem_allocator_.get(), dllist_locks_.get());
     kvdk_assert(success, "existing header should be linked on its skiplist");
-    insertKeyOrElem(lookup_result, RecordType::SortedHeader,
+    insertKeyOrElem(lookup_result, RecordType::SortedRecord,
                     RecordStatus::Outdated, skiplist);
     {
       std::unique_lock<std::mutex> skiplist_lock(skiplists_mu_);
@@ -127,7 +127,7 @@ Status KVEngine::SortedSize(const StringView collection, size_t* size) {
   auto holder = version_controller_.GetLocalSnapshotHolder();
 
   Skiplist* skiplist = nullptr;
-  auto ret = lookupKey<false>(collection, RecordType::SortedHeader);
+  auto ret = lookupKey<false>(collection, RecordType::SortedRecord);
   if (ret.s != Status::Ok) {
     return ret.s == Status::Outdated ? Status::NotFound : ret.s;
   }
@@ -151,7 +151,7 @@ Status KVEngine::SortedGet(const StringView collection,
   auto holder = version_controller_.GetLocalSnapshotHolder();
 
   Skiplist* skiplist = nullptr;
-  auto ret = lookupKey<false>(collection, RecordType::SortedHeader);
+  auto ret = lookupKey<false>(collection, RecordType::SortedRecord);
   if (ret.s != Status::Ok) {
     return ret.s == Status::Outdated ? Status::NotFound : ret.s;
   }
@@ -175,7 +175,7 @@ Status KVEngine::SortedPut(const StringView collection,
 
   Skiplist* skiplist = nullptr;
 
-  auto ret = lookupKey<false>(collection, RecordType::SortedHeader);
+  auto ret = lookupKey<false>(collection, RecordType::SortedRecord);
   if (ret.s != Status::Ok) {
     return ret.s == Status::Outdated ? Status::NotFound : ret.s;
   }
@@ -196,7 +196,7 @@ Status KVEngine::SortedDelete(const StringView collection,
   auto holder = version_controller_.GetLocalSnapshotHolder();
 
   Skiplist* skiplist = nullptr;
-  auto ret = lookupKey<false>(collection, RecordType::SortedHeader);
+  auto ret = lookupKey<false>(collection, RecordType::SortedRecord);
   if (ret.s != Status::Ok) {
     return (ret.s == Status::Outdated || ret.s == Status::NotFound)
                ? Status::NotFound
@@ -218,7 +218,7 @@ SortedIterator* KVEngine::SortedIteratorCreate(const StringView collection,
     snapshot = GetSnapshot(false);
   }
   // find collection
-  auto res = lookupKey<false>(collection, RecordType::SortedHeader);
+  auto res = lookupKey<false>(collection, RecordType::SortedRecord);
   if (s != nullptr) {
     *s = (res.s == Status::Outdated) ? Status::NotFound : res.s;
   }

--- a/engine/list_collection/list.cpp
+++ b/engine/list_collection/list.cpp
@@ -17,7 +17,7 @@ List::WriteResult List::SetExpireTime(ExpireTimeType expired_time,
   }
   DLRecord* pmem_record = DLRecord::PersistDLRecord(
       pmem_allocator_->offset2addr_checked(space.offset), space.size, timestamp,
-      RecordType::ListHeader, RecordStatus::Normal,
+      RecordType::ListRecord, RecordStatus::Normal,
       pmem_allocator_->addr2offset_checked(header), header->prev, header->next,
       header->Key(), header->Value(), expired_time);
   bool success = dl_list_.Replace(header, pmem_record);

--- a/engine/list_collection/list.hpp
+++ b/engine/list_collection/list.hpp
@@ -128,7 +128,7 @@ class List : public Collection {
     switch (record->GetRecordType()) {
       case RecordType::ListElem:
         return ExtractID(record->Key());
-      case RecordType::ListHeader:
+      case RecordType::ListRecord:
         return DecodeID(record->Value());
       default:
         GlobalLogger.Error("Wrong record type %u in ListID",
@@ -140,7 +140,7 @@ class List : public Collection {
 
   static bool MatchType(const DLRecord* record) {
     RecordType type = record->GetRecordType();
-    return type == RecordType::ListElem || type == RecordType::ListHeader;
+    return type == RecordType::ListElem || type == RecordType::ListRecord;
   }
 
  private:

--- a/engine/list_collection/rebuilder.hpp
+++ b/engine/list_collection/rebuilder.hpp
@@ -173,7 +173,7 @@ class ListRebuilder {
 
         if (!outdated) {
           auto lookup_result = hash_table_->Insert(
-              collection_name, RecordType::ListHeader, RecordStatus::Normal,
+              collection_name, RecordType::ListRecord, RecordStatus::Normal,
               list.get(), PointerType::List);
           switch (lookup_result.s) {
             case Status::Ok: {

--- a/engine/sorted_collection/rebuilder.cpp
+++ b/engine/sorted_collection/rebuilder.cpp
@@ -40,7 +40,7 @@ SortedCollectionRebuilder::RebuildResult SortedCollectionRebuilder::Rebuild() {
 }
 
 Status SortedCollectionRebuilder::AddHeader(DLRecord* header_record) {
-  assert(header_record->GetRecordType() == RecordType::SortedHeader);
+  assert(header_record->GetRecordType() == RecordType::SortedRecord);
 
   bool linked_record = recovery_utils_.CheckAndRepairLinkage(header_record);
   if (!linked_record) {
@@ -649,12 +649,12 @@ Status SortedCollectionRebuilder::insertHashIndex(const StringView& key,
             RecordType::SortedElem,
         "");
   } else if (index_type == PointerType::Skiplist) {
-    record_type = RecordType::SortedHeader;
+    record_type = RecordType::SortedRecord;
     record_status =
         static_cast<Skiplist*>(index_ptr)->HeaderRecord()->GetRecordStatus();
     kvdk_assert(
         static_cast<Skiplist*>(index_ptr)->HeaderRecord()->GetRecordType() ==
-            RecordType::SortedHeader,
+            RecordType::SortedRecord,
         "");
   } else {
     kvdk_assert(false, "Wrong type in sorted collection rebuilder");

--- a/engine/sorted_collection/skiplist.cpp
+++ b/engine/sorted_collection/skiplist.cpp
@@ -65,7 +65,7 @@ Skiplist::WriteResult Skiplist::SetExpireTime(ExpireTimeType expired_time,
   }
   DLRecord* pmem_record = DLRecord::PersistDLRecord(
       pmem_allocator_->offset2addr_checked(space_entry.offset),
-      space_entry.size, timestamp, RecordType::SortedHeader,
+      space_entry.size, timestamp, RecordType::SortedRecord,
       RecordStatus::Normal, pmem_allocator_->addr2offset_checked(header),
       header->prev, header->next, header->Key(), header->Value(), expired_time);
   bool success = Skiplist::Replace(header, pmem_record, HeaderNode(),
@@ -310,10 +310,10 @@ bool Skiplist::lockInsertPosition(const StringView& inserting_key,
   auto check_order = [&]() {
     bool res =
         /*check next*/ (next_record->GetRecordType() ==
-                            RecordType::SortedHeader ||
+                            RecordType::SortedRecord ||
                         Compare(inserting_key, UserKey(next_record)) <= 0) &&
         /*check prev*/ (prev_record->GetRecordType() ==
-                            RecordType::SortedHeader ||
+                            RecordType::SortedRecord ||
                         Compare(inserting_key, UserKey(prev_record)) > 0);
     return res;
   };

--- a/engine/sorted_collection/skiplist.hpp
+++ b/engine/sorted_collection/skiplist.hpp
@@ -305,7 +305,7 @@ class Skiplist : public Collection {
 
   static bool MatchType(DLRecord* record) {
     RecordType type = record->GetRecordType();
-    return type == RecordType::SortedElem || type == RecordType::SortedHeader;
+    return type == RecordType::SortedElem || type == RecordType::SortedRecord;
   }
 
   // Remove a dl record from its skiplist by unlinking
@@ -377,7 +377,7 @@ class Skiplist : public Collection {
       case RecordType::SortedElem:
         return ExtractID(record->Key());
         break;
-      case RecordType::SortedHeader:
+      case RecordType::SortedRecord:
         return DecodeID(record->Value());
       default:
         GlobalLogger.Error("Wrong record type %u in SkiplistID",

--- a/engine/transaction_impl.cpp
+++ b/engine/transaction_impl.cpp
@@ -21,7 +21,7 @@ TransactionImpl::TransactionImpl(KVEngine* engine) : engine_(engine) {
 Status TransactionImpl::StringPut(const std::string& key,
                                   const std::string& value) {
   auto hash_table = engine_->GetHashTable();
-  if (!TryLock(hash_table->GetLock(key))) {
+  if (!tryLock(hash_table->GetLock(key))) {
     status_ = Status::Timeout;
     return status_;
   }
@@ -32,7 +32,7 @@ Status TransactionImpl::StringPut(const std::string& key,
 
 Status TransactionImpl::StringDelete(const std::string& key) {
   auto hash_table = engine_->GetHashTable();
-  if (!TryLock(hash_table->GetLock(key))) {
+  if (!tryLock(hash_table->GetLock(key))) {
     status_ = Status::Timeout;
     return status_;
   }
@@ -42,12 +42,6 @@ Status TransactionImpl::StringDelete(const std::string& key) {
 }
 
 Status TransactionImpl::StringGet(const std::string& key, std::string* value) {
-  auto hash_table = engine_->GetHashTable();
-  if (!TryLock(hash_table->GetLock(key))) {
-    status_ = Status::Timeout;
-    return status_;
-  }
-
   auto op = batch_->StringGet(key);
   if (op != nullptr) {
     if (op->op == WriteOp::Delete) {
@@ -57,24 +51,137 @@ Status TransactionImpl::StringGet(const std::string& key, std::string* value) {
       return Status::Ok;
     }
   } else {
+    auto hash_table = engine_->GetHashTable();
+    if (!tryLock(hash_table->GetLock(key))) {
+      status_ = Status::Timeout;
+      return status_;
+    }
     return engine_->Get(key, value);
   }
 }
 
-bool TransactionImpl::TryLock(SpinMutex* spin) {
+Status TransactionImpl::SortedPut(const std::string& collection,
+                                  const std::string& key,
+                                  const std::string& value) {
+  auto hash_table = engine_->GetHashTable();
+  // TODO not hold collection lock in transaciton(r/w lock?)
+  if (!tryLock(hash_table->GetLock(collection))) {
+    status_ = Status::Timeout;
+    return status_;
+  }
+  auto lookup_result =
+      hash_table->Lookup<false>(collection, RecordType::HashHeader);
+  if (lookup_result.s != Status::Ok) {
+    kvdk_assert(lookup_result.s == Status::NotFound, "");
+    return lookup_result.s;
+  }
+  Skiplist* skiplist = lookup_result.entry.GetIndex().skiplist;
+  auto internal_key = skiplist->InternalKey(key);
+  if (!tryLock(hash_table->GetLock(internal_key))) {
+    status_ = Status::Timeout;
+    return status_;
+  }
+
+  batch_->SortedPut(collection, key, value);
+  return Status::Ok;
+}
+
+Status TransactionImpl::SortedDelete(const std::string& collection,
+                                     const std::string& key) {
+  auto hash_table = engine_->GetHashTable();
+  // TODO not hold collection lock in transaciton(r/w lock?)
+  if (!tryLock(hash_table->GetLock(collection))) {
+    status_ = Status::Timeout;
+    return status_;
+  }
+  auto lookup_result =
+      hash_table->Lookup<false>(collection, RecordType::HashHeader);
+  if (lookup_result.s != Status::Ok) {
+    kvdk_assert(lookup_result.s == Status::NotFound, "");
+    return Status::Ok;
+  }
+  Skiplist* skiplist = lookup_result.entry.GetIndex().skiplist;
+  auto internal_key = skiplist->InternalKey(key);
+  if (!tryLock(hash_table->GetLock(internal_key))) {
+    status_ = Status::Timeout;
+    return status_;
+  }
+
+  batch_->SortedDelete(collection, key);
+  return Status::Ok;
+}
+
+Status TransactionImpl::SortedGet(const std::string& collection,
+                                  const std::string& key, std::string* value) {
+  auto op = batch_->SortedGet(collection, key);
+  if (op != nullptr) {
+    if (op->op == WriteOp::Delete) {
+      return Status::NotFound;
+    } else {
+      value->assign(op->value);
+      return Status::Ok;
+    }
+  } else {
+    auto hash_table = engine_->GetHashTable();
+    // TODO not hold collection lock in transaciton(r/w lock?)
+    if (!tryLock(hash_table->GetLock(collection))) {
+      status_ = Status::Timeout;
+      return status_;
+    }
+    auto lookup_result =
+        hash_table->Lookup<false>(collection, RecordType::HashHeader);
+    if (lookup_result.s != Status::Ok) {
+      kvdk_assert(lookup_result.s == Status::NotFound, "");
+      return lookup_result.s;
+    }
+    Skiplist* skiplist = lookup_result.entry.GetIndex().skiplist;
+    auto internal_key = skiplist->InternalKey(key);
+    if (!tryLock(hash_table->GetLock(internal_key))) {
+      status_ = Status::Timeout;
+      return status_;
+    }
+
+    return skiplist->Get(key, value);
+  }
+}
+
+Status TransactionImpl::HashPut(const std::string& collection,
+                                const std::string& key,
+                                const std::string& value) {
+  return Status::Ok;
+}
+
+Status TransactionImpl::HashDelete(const std::string& collection,
+                                   const std::string& key) {
+  return Status::Ok;
+}
+
+Status TransactionImpl::HashGet(const std::string& collection,
+                                const std::string& key, std::string* value) {
+  return Status::Ok;
+}
+
+bool TransactionImpl::tryLock(SpinMutex* spin) {
   auto iter = locked_.find(spin);
   if (iter == locked_.end()) {
-    auto now = TimeUtils::millisecond_time();
-    while (!spin->try_lock()) {
-      if (TimeUtils::millisecond_time() - now > kLockTimeoutMilliseconds) {
-        return false;
-      }
+    if (tryLockImpl(spin)) {
+      locked_.insert(spin);
+      return true;
     }
-    locked_.insert(spin);
-    return true;
+    return false;
   } else {
     return true;
   }
+}
+
+bool TransactionImpl::tryLockImpl(SpinMutex* spin) {
+  auto now = TimeUtils::millisecond_time();
+  while (!spin->try_lock()) {
+    if (TimeUtils::millisecond_time() - now > kLockTimeoutMilliseconds) {
+      return false;
+    }
+  }
+  return true;
 }
 
 Status TransactionImpl::Commit() { return engine_->CommitTransaction(this); }

--- a/engine/transaction_impl.cpp
+++ b/engine/transaction_impl.cpp
@@ -98,7 +98,7 @@ Status TransactionImpl::SortedDelete(const std::string& collection,
       hash_table->Lookup<false>(collection, RecordType::SortedRecord);
   if (lookup_result.s != Status::Ok) {
     kvdk_assert(lookup_result.s == Status::NotFound, "");
-    return Status::Ok;
+    return lookup_result.s;
   }
   Skiplist* skiplist = lookup_result.entry.GetIndex().skiplist;
   auto internal_key = skiplist->InternalKey(key);
@@ -184,7 +184,7 @@ Status TransactionImpl::HashDelete(const std::string& collection,
       hash_table->Lookup<false>(collection, RecordType::HashRecord);
   if (lookup_result.s != Status::Ok) {
     kvdk_assert(lookup_result.s == Status::NotFound, "");
-    return Status::Ok;
+    return lookup_result.s;
   }
   HashList* hlist = lookup_result.entry.GetIndex().hlist;
   auto internal_key = hlist->InternalKey(key);
@@ -217,7 +217,6 @@ Status TransactionImpl::HashGet(const std::string& collection,
     auto lookup_result =
         hash_table->Lookup<false>(collection, RecordType::HashRecord);
     if (lookup_result.s != Status::Ok) {
-      GlobalLogger.Debug("collection not found\n");
       kvdk_assert(lookup_result.s == Status::NotFound, "");
       return lookup_result.s;
     }
@@ -260,6 +259,7 @@ Status TransactionImpl::Commit() {
   Rollback();
   return s;
 }
+
 void TransactionImpl::Rollback() {
   for (SpinMutex* s : locked_) {
     s->unlock();

--- a/engine/transaction_impl.cpp
+++ b/engine/transaction_impl.cpp
@@ -7,8 +7,87 @@
 #include "kv_engine.hpp"
 
 namespace KVDK_NAMESPACE {
+// To avoid deadlock in transaction, we abort lock key in
+// kLockTimeoutMilliseconds and return Timeout in write operations
+constexpr int64_t kLockTimeoutMilliseconds = 10;
+
 TransactionImpl::TransactionImpl(KVEngine* engine) : engine_(engine) {
-  kvdk_assert(engine != nullptr, "");
-  batch_ = engine_->WriteBatchCreate();
+  kvdk_assert(engine_ != nullptr, "");
+  batch_.reset(
+      dynamic_cast<WriteBatchImpl*>(engine_->WriteBatchCreate().release()));
+  kvdk_assert(batch_ != nullptr, "");
+}
+
+Status TransactionImpl::StringPut(const std::string& key,
+                                  const std::string& value) {
+  auto hash_table = engine_->GetHashTable();
+  if (!TryLock(hash_table->GetLock(key))) {
+    status_ = Status::Timeout;
+    return status_;
+  }
+
+  batch_->StringPut(key, value);
+  return Status::Ok;
+}
+
+Status TransactionImpl::StringDelete(const std::string& key) {
+  auto hash_table = engine_->GetHashTable();
+  if (!TryLock(hash_table->GetLock(key))) {
+    status_ = Status::Timeout;
+    return status_;
+  }
+
+  batch_->StringDelete(key);
+  return Status::Ok;
+}
+
+Status TransactionImpl::StringGet(const std::string& key, std::string* value) {
+  auto hash_table = engine_->GetHashTable();
+  if (!TryLock(hash_table->GetLock(key))) {
+    status_ = Status::Timeout;
+    return status_;
+  }
+
+  auto op = batch_->StringGet(key);
+  if (op != nullptr) {
+    if (op->op == WriteOp::Delete) {
+      return Status::NotFound;
+    } else {
+      value->assign(op->value);
+      return Status::Ok;
+    }
+  } else {
+    return engine_->Get(key, value);
+  }
+}
+
+bool TransactionImpl::TryLock(SpinMutex* spin) {
+  auto iter = locked_.find(spin);
+  if (iter == locked_.end()) {
+    auto now = TimeUtils::millisecond_time();
+    while (!spin->try_lock()) {
+      if (TimeUtils::millisecond_time() - now > kLockTimeoutMilliseconds) {
+        return false;
+      }
+    }
+    locked_.insert(spin);
+    return true;
+  } else {
+    return true;
+  }
+}
+
+Status TransactionImpl::Commit() { return engine_->CommitTransaction(this); }
+void TransactionImpl::Rollback() {
+  for (SpinMutex* kv : locked_) {
+    kv->unlock();
+  }
+  for (SpinMutex* s : locked_) {
+    s->unlock();
+  }
+  locked_.clear();
+  string_kv_.clear();
+  sorted_kv_.clear();
+  hash_kv_.clear();
 }
 }  // namespace KVDK_NAMESPACE

--- a/engine/transaction_impl.cpp
+++ b/engine/transaction_impl.cpp
@@ -124,7 +124,6 @@ Status TransactionImpl::SortedGet(const std::string& collection,
     auto lookup_result =
         hash_table->Lookup<false>(collection, RecordType::SortedRecord);
     if (lookup_result.s != Status::Ok) {
-      GlobalLogger.Debug("collection not found\n");
       kvdk_assert(lookup_result.s == Status::NotFound, "");
       return lookup_result.s;
     }
@@ -255,6 +254,7 @@ void TransactionImpl::Rollback() {
   string_kv_.clear();
   sorted_kv_.clear();
   hash_kv_.clear();
+  batch_->Clear();
   ct_token_ = nullptr;
 }
 

--- a/engine/transaction_impl.cpp
+++ b/engine/transaction_impl.cpp
@@ -1,0 +1,14 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright(c) 2021 Intel Corporation
+ */
+
+#include "transaction_impl.hpp"
+
+#include "kv_engine.hpp"
+
+namespace KVDK_NAMESPACE {
+TransactionImpl::TransactionImpl(KVEngine* engine) : engine_(engine) {
+  kvdk_assert(engine != nullptr, "");
+  batch_ = engine_->WriteBatchCreate();
+}
+}  // namespace KVDK_NAMESPACE

--- a/engine/transaction_impl.cpp
+++ b/engine/transaction_impl.cpp
@@ -70,7 +70,7 @@ Status TransactionImpl::SortedPut(const std::string& collection,
     return status_;
   }
   auto lookup_result =
-      hash_table->Lookup<false>(collection, RecordType::HashHeader);
+      hash_table->Lookup<false>(collection, RecordType::SortedRecord);
   if (lookup_result.s != Status::Ok) {
     kvdk_assert(lookup_result.s == Status::NotFound, "");
     return lookup_result.s;
@@ -95,7 +95,7 @@ Status TransactionImpl::SortedDelete(const std::string& collection,
     return status_;
   }
   auto lookup_result =
-      hash_table->Lookup<false>(collection, RecordType::HashHeader);
+      hash_table->Lookup<false>(collection, RecordType::SortedRecord);
   if (lookup_result.s != Status::Ok) {
     kvdk_assert(lookup_result.s == Status::NotFound, "");
     return Status::Ok;
@@ -129,8 +129,9 @@ Status TransactionImpl::SortedGet(const std::string& collection,
       return status_;
     }
     auto lookup_result =
-        hash_table->Lookup<false>(collection, RecordType::HashHeader);
+        hash_table->Lookup<false>(collection, RecordType::SortedRecord);
     if (lookup_result.s != Status::Ok) {
+      GlobalLogger.Debug("collection not found\n");
       kvdk_assert(lookup_result.s == Status::NotFound, "");
       return lookup_result.s;
     }
@@ -141,6 +142,7 @@ Status TransactionImpl::SortedGet(const std::string& collection,
       return status_;
     }
 
+    GlobalLogger.Debug("skiplist get\n");
     return skiplist->Get(key, value);
   }
 }

--- a/engine/transaction_impl.hpp
+++ b/engine/transaction_impl.hpp
@@ -122,6 +122,10 @@ class TransactionImpl final : public Transaction {
   // This used by kv engine
   WriteBatchImpl* GetBatch() { return batch_.get(); }
 
+  // Set lock time out while acquiring a key lock in transaction, if <0,
+  // operations will immediately return timeout while failed to lock a key
+  void SetLockTimeout(int64_t micro_seconds);
+
  private:
   struct KVOp {
     WriteOp op;
@@ -131,6 +135,7 @@ class TransactionImpl final : public Transaction {
   bool tryLock(SpinMutex* spin);
   bool tryLockImpl(SpinMutex* spin);
   void acquireCollectionTransaction();
+  int64_t randomTimeout();
 
   KVEngine* engine_;
   Status status_;
@@ -143,5 +148,6 @@ class TransactionImpl final : public Transaction {
   // TODO use std::unique_lock
   std::unordered_set<SpinMutex*> locked_;
   std::unique_ptr<CollectionTransactionCV::TransactionToken> ct_token_;
+  int64_t timeout_;
 };
 }  // namespace KVDK_NAMESPACE

--- a/engine/transaction_impl.hpp
+++ b/engine/transaction_impl.hpp
@@ -1,0 +1,25 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright(c) 2021 Intel Corporation
+ */
+
+#pragma once
+
+#include <memory>
+
+#include "kvdk/transaction.hpp"
+#include "kvdk/write_batch.hpp"
+
+class KVEngine;
+
+namespace KVDK_NAMESPACE {
+class TransactionImpl final : public Transaction {
+ public:
+  TransactionImpl(KVEngine* engine);
+  void StringPut(const std::string& key, const std::string& value) final;
+  void StringDelete(const std::string& key) final;
+
+ private:
+  std::unique_ptr<WriteBatch> batch_;
+  KVEngine* engine_;
+};
+}  // namespace KVDK_NAMESPACE

--- a/engine/transaction_impl.hpp
+++ b/engine/transaction_impl.hpp
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <condition_variable>
 #include <memory>
 #include <unordered_map>
 
@@ -12,11 +13,93 @@
 #include "write_batch_impl.hpp"
 
 namespace KVDK_NAMESPACE {
+
 class KVEngine;
+
+// Collections of in processing transaction should not be created or
+// destroyed, we use this for communication between collection related
+// transactions and collection create/destroy threads
+class CollectionTransactionCV {
+ public:
+  struct TransactionToken {
+    TransactionToken(CollectionTransactionCV* cv) : cv_(cv) {
+      kvdk_assert(cv_ != nullptr, "");
+      cv_->AcquireTransaction();
+    }
+
+    TransactionToken(const TransactionToken&) = delete;
+    TransactionToken(TransactionToken&&) = delete;
+
+    ~TransactionToken() { cv_->FinishTransaction(); }
+
+   private:
+    CollectionTransactionCV* cv_;
+  };
+
+  struct CollectionToken {
+    CollectionToken(CollectionTransactionCV* cv) : cv_(cv) {
+      kvdk_assert(cv_ != nullptr, "");
+      cv_->AcquireCollection();
+    }
+
+    ~CollectionToken() { cv_->FinishCollection(); }
+
+    CollectionToken(const CollectionToken&) = delete;
+    CollectionToken(CollectionToken&&) = delete;
+
+   private:
+    CollectionTransactionCV* cv_;
+  };
+
+  CollectionTransactionCV() = default;
+
+  CollectionTransactionCV(const CollectionTransactionCV&) = delete;
+
+  void AcquireTransaction() {
+    std::unique_lock<SpinMutex> ul(spin_);
+    while (processing_collection_ > 0) {
+      cv_.wait(ul);
+    }
+    kvdk_assert(processing_collection_ == 0, "");
+    processing_transaction_++;
+  }
+
+  void AcquireCollection() {
+    std::unique_lock<SpinMutex> ul(spin_);
+    // collection create/destroy has higher priority than txn as it's faster,
+    // so we add processing cnt here to forbit hungry
+    processing_collection_++;
+    while (processing_transaction_ > 0) {
+      cv_.wait(ul);
+    }
+    kvdk_assert(processing_transaction_ == 0, "");
+  }
+
+  void FinishTransaction() {
+    std::unique_lock<SpinMutex> ul(spin_);
+    if (--processing_transaction_ == 0) {
+      cv_.notify_all();
+    }
+  }
+
+  void FinishCollection() {
+    std::unique_lock<SpinMutex> ul(spin_);
+    if (--processing_collection_ == 0) {
+      cv_.notify_all();
+    }
+  }
+
+ private:
+  std::condition_variable_any cv_;
+  SpinMutex spin_;
+  int processing_collection_ = 0;
+  int processing_transaction_ = 0;
+};
 
 class TransactionImpl final : public Transaction {
  public:
   TransactionImpl(KVEngine* engine);
+  ~TransactionImpl() final;
   Status StringPut(const std::string& key, const std::string& value) final;
   Status StringDelete(const std::string& key) final;
   Status StringGet(const std::string& key, std::string* value) final;
@@ -47,6 +130,7 @@ class TransactionImpl final : public Transaction {
 
   bool tryLock(SpinMutex* spin);
   bool tryLockImpl(SpinMutex* spin);
+  void acquireCollectionTransaction();
 
   KVEngine* engine_;
   Status status_;
@@ -58,5 +142,6 @@ class TransactionImpl final : public Transaction {
   std::unique_ptr<WriteBatchImpl> batch_;
   // TODO use std::unique_lock
   std::unordered_set<SpinMutex*> locked_;
+  std::unique_ptr<CollectionTransactionCV::TransactionToken> ct_token_;
 };
 }  // namespace KVDK_NAMESPACE

--- a/engine/transaction_impl.hpp
+++ b/engine/transaction_impl.hpp
@@ -20,6 +20,18 @@ class TransactionImpl final : public Transaction {
   Status StringPut(const std::string& key, const std::string& value) final;
   Status StringDelete(const std::string& key) final;
   Status StringGet(const std::string& key, std::string* value) final;
+  Status SortedPut(const std::string& collection, const std::string& key,
+                   const std::string& value) final;
+  Status SortedDelete(const std::string& collection,
+                      const std::string& key) final;
+  Status SortedGet(const std::string& collection, const std::string& key,
+                   std::string* value) final;
+  Status HashPut(const std::string& collection, const std::string& key,
+                 const std::string& value) final;
+  Status HashDelete(const std::string& collection,
+                    const std::string& key) final;
+  Status HashGet(const std::string& collection, const std::string& key,
+                 std::string* value) final;
   Status Commit() final;
   void Rollback() final;
   Status InternalStatus() final { return status_; }
@@ -33,7 +45,8 @@ class TransactionImpl final : public Transaction {
     std::string value;
   };
 
-  bool TryLock(SpinMutex* spin);
+  bool tryLock(SpinMutex* spin);
+  bool tryLockImpl(SpinMutex* spin);
 
   KVEngine* engine_;
   Status status_;

--- a/engine/utils/utils.hpp
+++ b/engine/utils/utils.hpp
@@ -512,6 +512,8 @@ inline UnixTimeType unix_time(void) {
 
 inline int64_t millisecond_time() { return unix_time() / 1000; }
 
+inline int64_t microseconds_time() { return unix_time(); }
+
 inline bool CheckIsExpired(ExpireTimeType expired_time) {
   if (expired_time >= 0 && expired_time <= millisecond_time()) {
     return true;

--- a/engine/write_batch_impl.hpp
+++ b/engine/write_batch_impl.hpp
@@ -96,6 +96,40 @@ class WriteBatchImpl final : public WriteBatch {
     hash_ops_.insert(op);
   }
 
+  // Get a string op from this batch
+  // if key not exist in this batch, return nullptr
+  const StringOp* StringGet(std::string const& key) {
+    StringOp op{WriteOp::Put, key, ""};
+    auto iter = string_ops_.find(op);
+    if (iter == string_ops_.end()) {
+      return nullptr;
+    }
+    return &(*iter);
+  }
+
+  // Get a sorted op from this batch
+  // if the collection key not exist in this batch, return nullptr
+  const SortedOp* SortedGet(std::string const& collection,
+                            std::string const& key) {
+    SortedOp op{WriteOp::Put, collection, key, ""};
+    auto iter = sorted_ops_.find(op);
+    if (iter == sorted_ops_.end()) {
+      return nullptr;
+    }
+    return &(*iter);
+  }
+
+  // Get a hash op from this batch
+  // if the collection key not exist in this batch, return nullptr
+  const HashOp* HashGet(std::string const& collection, std::string const& key) {
+    HashOp op{WriteOp::Put, collection, key, ""};
+    auto iter = hash_ops_.find(op);
+    if (iter == hash_ops_.end()) {
+      return nullptr;
+    }
+    return &(*iter);
+  }
+
   void Clear() final {
     string_ops_.clear();
     sorted_ops_.clear();

--- a/engine/write_batch_impl.hpp
+++ b/engine/write_batch_impl.hpp
@@ -14,8 +14,6 @@
 
 namespace KVDK_NAMESPACE {
 
-struct Splice;
-
 class WriteBatchImpl final : public WriteBatch {
  public:
   struct StringOp {
@@ -71,28 +69,29 @@ class WriteBatchImpl final : public WriteBatch {
     string_ops_.insert(op);
   }
 
-  void SortedPut(std::string const& key, std::string const& field,
+  void SortedPut(std::string const& collection, std::string const& key,
                  std::string const& value) final {
-    SortedOp op{WriteOp::Put, key, field, value};
+    SortedOp op{WriteOp::Put, collection, key, value};
     sorted_ops_.erase(op);
     sorted_ops_.insert(op);
   }
 
-  void SortedDelete(std::string const& key, std::string const& field) final {
-    SortedOp op{WriteOp::Delete, key, field, std::string{}};
+  void SortedDelete(std::string const& collection,
+                    std::string const& key) final {
+    SortedOp op{WriteOp::Delete, collection, key, std::string{}};
     sorted_ops_.erase(op);
     sorted_ops_.insert(op);
   }
 
-  void HashPut(std::string const& key, std::string const& field,
+  void HashPut(std::string const& collection, std::string const& key,
                std::string const& value) final {
-    HashOp op{WriteOp::Put, key, field, value};
+    HashOp op{WriteOp::Put, collection, key, value};
     hash_ops_.erase(op);
     hash_ops_.insert(op);
   }
 
-  void HashDelete(std::string const& key, std::string const& field) final {
-    HashOp op{WriteOp::Delete, key, field, std::string{}};
+  void HashDelete(std::string const& collection, std::string const& key) final {
+    HashOp op{WriteOp::Delete, collection, key, std::string{}};
     hash_ops_.erase(op);
     hash_ops_.insert(op);
   }

--- a/engine/write_batch_impl.hpp
+++ b/engine/write_batch_impl.hpp
@@ -108,9 +108,9 @@ class WriteBatchImpl final : public WriteBatch {
   }
 
   // Get a sorted op from this batch
-  // if the collection key not exist in this batch, return nullptr
-  const SortedOp* SortedGet(std::string const& collection,
-                            std::string const& key) {
+  // if collection key not exist in this batch, return nullptr
+  const SortedOp* SortedGet(const std::string& collection,
+                            const std::string& key) {
     SortedOp op{WriteOp::Put, collection, key, ""};
     auto iter = sorted_ops_.find(op);
     if (iter == sorted_ops_.end()) {

--- a/include/kvdk/engine.h
+++ b/include/kvdk/engine.h
@@ -18,6 +18,7 @@ typedef struct KVDKEngine KVDKEngine;
 typedef struct KVDKConfigs KVDKConfigs;
 typedef struct KVDKWriteOptions KVDKWriteOptions;
 typedef struct KVDKWriteBatch KVDKWriteBatch;
+typedef struct KVDKTransaction KVDKTransaction;
 typedef struct KVDKSortedIterator KVDKSortedIterator;
 typedef struct KVDKListIterator KVDKListIterator;
 typedef struct KVDKHashIterator KVDKHashIterator;
@@ -102,7 +103,38 @@ extern void KVDKWriteBatchHashDelete(KVDKWriteBatch* batch,
 extern KVDKStatus KVDKBatchWrite(KVDKEngine* engine,
                                  KVDKWriteBatch const* batch);
 
-// For Anonymous Global Collection
+// For Transactions
+extern KVDKTransaction* KVDKTransactionCreate(KVDKEngine* engine);
+extern void KVDKTransactionDestory(KVDKTransaction* txn);
+extern KVDKStatus KVDKTransactionStringPut(KVDKTransaction* txn,
+                                           char const* key_data, size_t key_len,
+                                           char const* val_data,
+                                           size_t val_len);
+extern KVDKStatus KVDKTransactionStringDelete(KVDKTransaction* txn,
+                                              char const* key_data,
+                                              size_t key_len);
+extern KVDKStatus KVDKTransactionSortedPut(
+    KVDKTransaction* txn, char const* collection, size_t collection_len,
+    char const* key_data, size_t key_len, char const* val_data, size_t val_len);
+extern KVDKStatus KVDKTransactionSortedDelete(KVDKTransaction* txn,
+                                              char const* collection,
+                                              size_t collection_len,
+                                              char const* key_data,
+                                              size_t key_len);
+extern KVDKStatus KVDKTransactionHashPut(KVDKTransaction* txn,
+                                         char const* collection,
+                                         size_t collection_len,
+                                         char const* key_data, size_t key_len,
+                                         char const* val_data, size_t val_len);
+extern KVDKStatus KVDKTransactionHashDelete(KVDKTransaction* txn,
+                                            char const* collection,
+                                            size_t collection_len,
+                                            char const* key_data,
+                                            size_t key_len);
+extern KVDKStatus KVDKTransactionCommit(KVDKTransaction* txn);
+extern void KVDKTransactionRollback(KVDKTransaction* txn);
+
+// For String KV
 extern KVDKStatus KVDKGet(KVDKEngine* engine, const char* key, size_t key_len,
                           size_t* val_len, char** val);
 extern KVDKStatus KVDKPut(KVDKEngine* engine, const char* key, size_t key_len,

--- a/include/kvdk/engine.hpp
+++ b/include/kvdk/engine.hpp
@@ -10,6 +10,7 @@
 #include "comparator.hpp"
 #include "configs.hpp"
 #include "iterator.hpp"
+#include "transaction.hpp"
 #include "types.hpp"
 #include "write_batch.hpp"
 
@@ -77,6 +78,8 @@ class Engine {
   virtual Status BatchWrite(std::unique_ptr<WriteBatch> const& batch) = 0;
 
   virtual std::unique_ptr<WriteBatch> WriteBatchCreate() = 0;
+
+  virtual std::unique_ptr<Transaction> TransactionCreate() = 0;
 
   // Search the STRING-type KV of "key" and store the corresponding value to
   // *value on success. If the "key" does not exist, return NotFound.

--- a/include/kvdk/transaction.hpp
+++ b/include/kvdk/transaction.hpp
@@ -1,0 +1,23 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright(c) 2021 Intel Corporation
+ */
+
+#pragma once
+
+#include <string>
+
+#include "types.hpp"
+
+namespace KVDK_NAMESPACE {
+class Transaction {
+ public:
+  // TODO: use StringView instead of std::string
+  virtual void StringPut(const std::string& key, const std::string& value) = 0;
+  virtual void StringDelete(const std::string& key) = 0;
+
+  virtual Status Commit() = 0;
+  virtual Status Rollback() = 0;
+  virtual Status InternalStatus() = 0;
+  virtual ~Transaction() = default;
+};
+}  // namespace KVDK_NAMESPACE

--- a/include/kvdk/transaction.hpp
+++ b/include/kvdk/transaction.hpp
@@ -12,11 +12,13 @@ namespace KVDK_NAMESPACE {
 class Transaction {
  public:
   // TODO: use StringView instead of std::string
-  virtual void StringPut(const std::string& key, const std::string& value) = 0;
-  virtual void StringDelete(const std::string& key) = 0;
+  virtual Status StringPut(const std::string& key,
+                           const std::string& value) = 0;
+  virtual Status StringDelete(const std::string& key) = 0;
+  virtual Status StringGet(const std::string& key, std::string* value) = 0;
 
   virtual Status Commit() = 0;
-  virtual Status Rollback() = 0;
+  virtual void Rollback() = 0;
   virtual Status InternalStatus() = 0;
   virtual ~Transaction() = default;
 };

--- a/include/kvdk/transaction.hpp
+++ b/include/kvdk/transaction.hpp
@@ -16,6 +16,19 @@ class Transaction {
                            const std::string& value) = 0;
   virtual Status StringDelete(const std::string& key) = 0;
   virtual Status StringGet(const std::string& key, std::string* value) = 0;
+  virtual Status SortedPut(const std::string& collection,
+                           const std::string& key,
+                           const std::string& value) = 0;
+  virtual Status SortedDelete(const std::string& collection,
+                              const std::string& key) = 0;
+  virtual Status SortedGet(const std::string& collection,
+                           const std::string& key, std::string* value) = 0;
+  virtual Status HashPut(const std::string& collection, const std::string& key,
+                         const std::string& value) = 0;
+  virtual Status HashDelete(const std::string& collection,
+                            const std::string& key) = 0;
+  virtual Status HashGet(const std::string& collection, const std::string& key,
+                         std::string* value) = 0;
 
   virtual Status Commit() = 0;
   virtual void Rollback() = 0;

--- a/include/kvdk/types.h
+++ b/include/kvdk/types.h
@@ -71,6 +71,7 @@ __attribute__((unused)) static char const* KVDKValueTypeString[] = {
   GEN(IOError)              \
   GEN(InvalidConfiguration) \
   GEN(Fail)                 \
+  GEN(Timeout)              \
   GEN(Abort)
 
 typedef enum { KVDK_STATUS(GENERATE_ENUM) } KVDKStatus;

--- a/include/kvdk/write_batch.hpp
+++ b/include/kvdk/write_batch.hpp
@@ -15,14 +15,15 @@ class WriteBatch {
   virtual void StringPut(std::string const& key, std::string const& value) = 0;
   virtual void StringDelete(std::string const& key) = 0;
 
-  virtual void SortedPut(std::string const& key, std::string const& field,
+  virtual void SortedPut(std::string const& collection, std::string const& key,
                          std::string const& value) = 0;
-  virtual void SortedDelete(std::string const& key,
-                            std::string const& field) = 0;
+  virtual void SortedDelete(std::string const& collection,
+                            std::string const& key) = 0;
 
-  virtual void HashPut(std::string const& key, std::string const& field,
+  virtual void HashPut(std::string const& collection, std::string const& key,
                        std::string const& value) = 0;
-  virtual void HashDelete(std::string const& key, std::string const& field) = 0;
+  virtual void HashDelete(std::string const& collection,
+                          std::string const& key) = 0;
 
   virtual void Clear() = 0;
 

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -2467,41 +2467,87 @@ TEST_F(TrasactionTest, StringTransactionBasic) {
   auto transfer_txn = [&](size_t) {
     std::string pay = "Jack";
     std::string receive = "Tom";
-    int pay_balance = 500;
-    int receive_balance = 500;
-    std::string pay_balance_str = std::to_string(pay_balance);
-    std::string receive_balance_str = std::to_string(receive_balance);
-    int amount = 200;
-    ASSERT_EQ(engine->Put(pay, pay_balance_str), Status::Ok);
-    ASSERT_EQ(engine->Put(receive, receive_balance_str), Status::Ok);
+    {  // string
+      int pay_balance = 500;
+      int receive_balance = 500;
+      std::string pay_balance_str = std::to_string(pay_balance);
+      std::string receive_balance_str = std::to_string(receive_balance);
+      int amount = 200;
+      ASSERT_EQ(engine->Put(pay, pay_balance_str), Status::Ok);
+      ASSERT_EQ(engine->Put(receive, receive_balance_str), Status::Ok);
 
-    auto txn = engine->TransactionCreate();
-    ASSERT_TRUE(txn != nullptr);
-    std::string value;
-    ASSERT_EQ(txn->StringGet(pay, &value), Status::Ok);
-    ASSERT_EQ(pay_balance_str, value);
-    std::string pay_balance_after_transfer =
-        std::to_string(pay_balance - amount);
-    ASSERT_EQ(txn->StringPut(pay, pay_balance_after_transfer), Status::Ok);
-    // Un-commited change should be visible by this transaction, but invisible
-    // outsider the transaction
-    ASSERT_EQ(txn->StringGet(pay, &value), Status::Ok);
-    ASSERT_EQ(pay_balance_after_transfer, value);
-    ASSERT_EQ(engine->Get(pay, &value), Status::Ok);
-    ASSERT_EQ(pay_balance_str, value);
+      auto txn = engine->TransactionCreate();
+      ASSERT_TRUE(txn != nullptr);
+      std::string value;
+      ASSERT_EQ(txn->StringGet(pay, &value), Status::Ok);
+      ASSERT_EQ(pay_balance_str, value);
+      std::string pay_balance_after_transfer =
+          std::to_string(pay_balance - amount);
+      ASSERT_EQ(txn->StringPut(pay, pay_balance_after_transfer), Status::Ok);
+      // Un-commited change should be visible by this transaction, but invisible
+      // outsider the transaction
+      ASSERT_EQ(txn->StringGet(pay, &value), Status::Ok);
+      ASSERT_EQ(pay_balance_after_transfer, value);
+      ASSERT_EQ(engine->Get(pay, &value), Status::Ok);
+      ASSERT_EQ(pay_balance_str, value);
 
-    ASSERT_EQ(txn->StringGet(receive, &value), Status::Ok);
-    ASSERT_EQ(receive_balance_str, value);
-    std::string receive_balance_after_transfer =
-        std::to_string(receive_balance + amount);
-    ASSERT_EQ(txn->StringPut(receive, receive_balance_after_transfer),
-              Status::Ok);
-    ASSERT_EQ(txn->Commit(), Status::Ok);
+      ASSERT_EQ(txn->StringGet(receive, &value), Status::Ok);
+      ASSERT_EQ(receive_balance_str, value);
+      std::string receive_balance_after_transfer =
+          std::to_string(receive_balance + amount);
+      ASSERT_EQ(txn->StringPut(receive, receive_balance_after_transfer),
+                Status::Ok);
+      ASSERT_EQ(txn->Commit(), Status::Ok);
 
-    ASSERT_EQ(engine->Get(pay, &value), Status::Ok);
-    ASSERT_EQ(value, pay_balance_after_transfer);
-    ASSERT_EQ(engine->Get(receive, &value), Status::Ok);
-    ASSERT_EQ(value, receive_balance_after_transfer);
+      ASSERT_EQ(engine->Get(pay, &value), Status::Ok);
+      ASSERT_EQ(value, pay_balance_after_transfer);
+      ASSERT_EQ(engine->Get(receive, &value), Status::Ok);
+      ASSERT_EQ(value, receive_balance_after_transfer);
+    }
+
+    {  // sorted
+      int pay_balance = 500;
+      int receive_balance = 500;
+      std::string pay_balance_str = std::to_string(pay_balance);
+      std::string receive_balance_str = std::to_string(receive_balance);
+      std::string collection = "bank";
+      int amount = 200;
+      ASSERT_EQ(engine->SortedCreate(collection), Status::Ok);
+      ASSERT_EQ(engine->SortedPut(collection, pay, pay_balance_str),
+                Status::Ok);
+      ASSERT_EQ(engine->SortedPut(collection, receive, receive_balance_str),
+                Status::Ok);
+
+      auto txn = engine->TransactionCreate();
+      ASSERT_TRUE(txn != nullptr);
+      std::string value;
+      ASSERT_EQ(txn->SortedGet(collection, pay, &value), Status::Ok);
+      ASSERT_EQ(pay_balance_str, value);
+      std::string pay_balance_after_transfer =
+          std::to_string(pay_balance - amount);
+      ASSERT_EQ(txn->SortedPut(collection, pay, pay_balance_after_transfer),
+                Status::Ok);
+      // Un-commited change should be visible by this transaction, but invisible
+      // outsider the transaction
+      ASSERT_EQ(txn->SortedGet(collection, pay, &value), Status::Ok);
+      ASSERT_EQ(pay_balance_after_transfer, value);
+      ASSERT_EQ(engine->SortedGet(collection, pay, &value), Status::Ok);
+      ASSERT_EQ(pay_balance_str, value);
+
+      ASSERT_EQ(txn->SortedGet(collection, receive, &value), Status::Ok);
+      ASSERT_EQ(receive_balance_str, value);
+      std::string receive_balance_after_transfer =
+          std::to_string(receive_balance + amount);
+      ASSERT_EQ(
+          txn->SortedPut(collection, receive, receive_balance_after_transfer),
+          Status::Ok);
+      ASSERT_EQ(txn->Commit(), Status::Ok);
+
+      ASSERT_EQ(engine->SortedGet(collection, pay, &value), Status::Ok);
+      ASSERT_EQ(value, pay_balance_after_transfer);
+      ASSERT_EQ(engine->SortedGet(collection, receive, &value), Status::Ok);
+      ASSERT_EQ(value, receive_balance_after_transfer);
+    }
   };
 
   LaunchNThreads(1, transfer_txn);

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -2474,9 +2474,9 @@ TEST_F(TrasactionTest, TransactionBasic) {
   ASSERT_EQ(engine->SortedCreate(sorted_bank), Status::Ok);
   ASSERT_EQ(engine->HashCreate(hash_bank), Status::Ok);
 
-  auto string_transfer_txn = [&](size_t tid) {
+  auto string_transfer_txn = [&](size_t) {
     int cnt = round;
-    while (round--) {
+    while (cnt--) {
       std::string payer;
       std::string receiver;
       if (fast_random_64() % 2 == 0) {
@@ -2560,9 +2560,9 @@ TEST_F(TrasactionTest, TransactionBasic) {
     }
   };
 
-  auto sorted_transfer_txn = [&](size_t tid) {
+  auto sorted_transfer_txn = [&](size_t) {
     int cnt = round;
-    while (round--) {
+    while (cnt--) {
       std::string payer;
       std::string receiver;
       if (fast_random_64() % 2 == 0) {
@@ -2652,9 +2652,9 @@ TEST_F(TrasactionTest, TransactionBasic) {
     }
   };
 
-  auto hash_transfer_txn = [&](size_t tid) {
+  auto hash_transfer_txn = [&](size_t) {
     int cnt = round;
-    while (round--) {
+    while (cnt--) {
       std::string payer;
       std::string receiver;
       if (fast_random_64() % 2 == 0) {

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -2797,28 +2797,28 @@ TEST_F(TrasactionTest, Conflict) {
     auto txn = engine->TransactionCreate();
     ASSERT_TRUE(txn != nullptr);
     ASSERT_EQ(txn->StringPut(key, val), expected_return);
-    ASSERT_EQ(txn->StringDelete(key), expected_return);
     ASSERT_EQ(txn->StringGet(key, &got_val), expected_return);
     if (expected_return == Status::Ok) {
       ASSERT_EQ(got_val, val);
     }
+    ASSERT_EQ(txn->StringDelete(key), expected_return);
     txn->Rollback();
 
     ASSERT_EQ(txn->SortedPut(sorted_collection, key, val), expected_return);
-    ASSERT_EQ(txn->SortedDelete(sorted_collection, key), expected_return);
     ASSERT_EQ(txn->SortedGet(sorted_collection, key, &got_val),
               expected_return);
     if (expected_return == Status::Ok) {
       ASSERT_EQ(got_val, val);
     }
+    ASSERT_EQ(txn->SortedDelete(sorted_collection, key), expected_return);
     txn->Rollback();
 
     ASSERT_EQ(txn->HashPut(hash_collection, key, val), expected_return);
-    ASSERT_EQ(txn->HashDelete(hash_collection, key), expected_return);
     ASSERT_EQ(txn->HashGet(hash_collection, key, &got_val), expected_return);
     if (expected_return == Status::Ok) {
       ASSERT_EQ(got_val, val);
     }
+    ASSERT_EQ(txn->HashDelete(hash_collection, key), expected_return);
     txn->Rollback();
   };
 
@@ -2841,8 +2841,8 @@ TEST_F(TrasactionTest, Conflict) {
 
   expected_return = Status::Ok;
   LaunchNThreads(1, operation_thread);
-  expected_return = Status::Timeout;
 
+  expected_return = Status::Timeout;
   ASSERT_EQ(txn->StringDelete(key), Status::Ok);
   ASSERT_EQ(txn->SortedDelete(sorted_collection, key), Status::Ok);
   ASSERT_EQ(txn->HashDelete(hash_collection, key), Status::Ok);


### PR DESCRIPTION
### What is changed and how it works?

Implement basic transaction for string, sorted and hash types.

Transaction API is separate with normal access APIs. Example:
``` C++
auto txn = engine->TransactionCreate();
Status s = txn->Sortedxxx()/Stringxxx()/Hashxxx();
if(s==Status::Timeout){
txn->Rollback(); // Conflict with other thread
} else {
s = txn->Commit();
if(s==Status::Ok){ //  Success
    // ...
    }
}
```

The transaction is implemented with pessimistic locking, so any operation may conflict with other access thread and compete locks. We return Timeout in this case to avoid dead lock.

A thread should not call normal write APIs while a transaction of it has not been committed or rollbacked, otherwise the thread may deadlock as the transaction may holding locks required by normal write operations.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

WIP:
- adding more tests
- allowing concurrent transaction in a collection
