### PR TITLE
Fix compare_string_view with unsigned char comparison

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,9 @@ jobs:
         uses: lukka/get-cmake@v3.19.2
 
       - name: Install packages
-        run: sudo apt install make clang-format-9 pkg-config g++ autoconf libtool asciidoctor libkmod-dev libudev-dev uuid-dev libjson-c-dev libkeyutils-dev pandoc libhwloc-dev libgflags-dev libtext-diff-perl bash-completion systemd wget git
+        run: |
+          sudo apt update
+          sudo apt install make clang-format-9 pkg-config g++ autoconf libtool asciidoctor libkmod-dev libudev-dev uuid-dev libjson-c-dev libkeyutils-dev pandoc libhwloc-dev libgflags-dev libtext-diff-perl bash-completion systemd wget git
 
       - name: Install ndctl
         run: |

--- a/engine/utils/utils.hpp
+++ b/engine/utils/utils.hpp
@@ -155,7 +155,7 @@ inline int compare_string_view(const StringView& src,
   auto size = std::min(src.size(), target.size());
   for (uint32_t i = 0; i < size; i++) {
     if (src[i] != target[i]) {
-      return src[i] - target[i];
+      return (unsigned char)src[i] - (unsigned char)target[i];
     }
   }
   return src.size() - target.size();

--- a/engine/utils/utils.hpp
+++ b/engine/utils/utils.hpp
@@ -153,11 +153,12 @@ inline std::string string_view_2_string(const StringView& src) {
 inline int compare_string_view(const StringView& src,
                                const StringView& target) {
   auto size = std::min(src.size(), target.size());
-  int r = memcmp(src.data(), target.data(), size);
-  if (r == 0) {
-    return src.size() - target.size();
+  for (uint32_t i = 0; i < size; i++) {
+    if (src[i] != target[i]) {
+      return (unsigned char)src[i] - (unsigned char)target[i];
+    }
   }
-  return r;
+  return src.size() - target.size();
 }
 
 inline bool equal_string_view(const StringView& src, const StringView& target) {

--- a/engine/utils/utils.hpp
+++ b/engine/utils/utils.hpp
@@ -153,12 +153,11 @@ inline std::string string_view_2_string(const StringView& src) {
 inline int compare_string_view(const StringView& src,
                                const StringView& target) {
   auto size = std::min(src.size(), target.size());
-  for (uint32_t i = 0; i < size; i++) {
-    if (src[i] != target[i]) {
-      return (unsigned char)src[i] - (unsigned char)target[i];
-    }
+  int r = memcmp(src.data(), target.data(), size);
+  if (r == 0) {
+    return src.size() - target.size();
   }
-  return src.size() - target.size();
+  return r;
 }
 
 inline bool equal_string_view(const StringView& src, const StringView& target) {


### PR DESCRIPTION
Signed-off-by: Yu, Peng <peng.yu@intel.com>

<!--
Thank you for contributing to KVDK.

PR Title Format:
1. module [, module2, module3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Problem Summary:  
The lexicographic byte comparator should apply unsinged char interpretation. The default string comparator should be fixed or it shows different behaviors from other KV stores.

### What is changed and how it works?

What's Changed: 
Fix `compare_string_view` with unsigned char comparison

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

Side effects

- None
