### PR TITLE
Refactor access thread, remove limitation on foreground thread and instance number

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,8 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mavx512f -mrdseed -mrdrnd -mclwb -mclfl
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS}")
 
 if (CMAKE_BUILD_TYPE STREQUAL "Release")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O2")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -O2")
 elseif (CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo")
 elseif (CMAKE_BUILD_TYPE STREQUAL "MinSizeRel")
 elseif (CMAKE_BUILD_TYPE STREQUAL "Debug")

--- a/benchmark/bench.cpp
+++ b/benchmark/bench.cpp
@@ -460,8 +460,8 @@ void ProcessBenchmarkConfigs() {
   if (FLAGS_fill) {
     assert(FLAGS_read_ratio == 0);
     key_dist = KeyDistribution::Range;
-    operations_per_thread = FLAGS_num_kv / FLAGS_max_access_threads + 1;
-    for (int i = 0; i < FLAGS_max_access_threads; i++) {
+    operations_per_thread = FLAGS_num_kv / FLAGS_threads + 1;
+    for (int i = 0; i < FLAGS_threads; i++) {
       ranges.emplace_back(i * operations_per_thread,
                           (i + 1) * operations_per_thread);
     }
@@ -535,7 +535,6 @@ int main(int argc, char** argv) {
           throw std::runtime_error{"Fail to create Sorted collection"};
         }
       }
-      engine->ReleaseAccessThread();
       break;
     }
     case DataType::Hashes: {
@@ -545,7 +544,6 @@ int main(int argc, char** argv) {
           throw std::runtime_error{"Fail to create Hashset"};
         }
       }
-      engine->ReleaseAccessThread();
       break;
     }
     case DataType::List: {
@@ -555,7 +553,6 @@ int main(int argc, char** argv) {
           throw std::runtime_error{"Fail to create List"};
         }
       }
-      engine->ReleaseAccessThread();
       break;
     }
     default: {

--- a/benchmark/bench.cpp
+++ b/benchmark/bench.cpp
@@ -78,7 +78,7 @@ DEFINE_bool(
     "Populate pmem space while creating a new instance. This can improve write "
     "performance in runtime, but will take long time to init the instance");
 
-DEFINE_uint64(max_access_threads, 32, "Max access threads of the instance");
+DEFINE_uint64(max_access_threads, 64, "Max access threads of the instance");
 
 DEFINE_uint64(space, (256ULL << 30), "Max usable PMem space of the instance");
 
@@ -460,8 +460,8 @@ void ProcessBenchmarkConfigs() {
   if (FLAGS_fill) {
     assert(FLAGS_read_ratio == 0);
     key_dist = KeyDistribution::Range;
-    operations_per_thread = FLAGS_num_kv / FLAGS_max_access_threads + 1;
-    for (size_t i = 0; i < FLAGS_max_access_threads; i++) {
+    operations_per_thread = FLAGS_num_kv / FLAGS_threads + 1;
+    for (size_t i = 0; i < FLAGS_threads; i++) {
       ranges.emplace_back(i * operations_per_thread,
                           (i + 1) * operations_per_thread);
     }

--- a/benchmark/bench.cpp
+++ b/benchmark/bench.cpp
@@ -78,7 +78,7 @@ DEFINE_bool(
     "Populate pmem space while creating a new instance. This can improve write "
     "performance in runtime, but will take long time to init the instance");
 
-DEFINE_int32(max_access_threads, 32, "Max access threads of the instance");
+DEFINE_uint64(max_access_threads, 32, "Max access threads of the instance");
 
 DEFINE_uint64(space, (256ULL << 30), "Max usable PMem space of the instance");
 
@@ -460,8 +460,8 @@ void ProcessBenchmarkConfigs() {
   if (FLAGS_fill) {
     assert(FLAGS_read_ratio == 0);
     key_dist = KeyDistribution::Range;
-    operations_per_thread = FLAGS_num_kv / FLAGS_threads + 1;
-    for (int i = 0; i < FLAGS_threads; i++) {
+    operations_per_thread = FLAGS_num_kv / FLAGS_max_access_threads + 1;
+    for (size_t i = 0; i < FLAGS_max_access_threads; i++) {
       ranges.emplace_back(i * operations_per_thread,
                           (i + 1) * operations_per_thread);
     }

--- a/engine/c/kvdk_basic_op.cpp
+++ b/engine/c/kvdk_basic_op.cpp
@@ -96,10 +96,6 @@ KVDKStatus KVDKRestore(const char* name, const char* backup_log,
   return s;
 }
 
-void KVDKReleaseAccessThread(KVDKEngine* engine) {
-  engine->rep->ReleaseAccessThread();
-}
-
 KVDKSnapshot* KVDKGetSnapshot(KVDKEngine* engine, int make_checkpoint) {
   KVDKSnapshot* snapshot = new KVDKSnapshot;
   snapshot->rep = engine->rep->GetSnapshot(make_checkpoint);

--- a/engine/dram_allocator.cpp
+++ b/engine/dram_allocator.cpp
@@ -13,10 +13,10 @@ void ChunkBasedAllocator::Free(const SpaceEntry&) {
 }
 
 SpaceEntry ChunkBasedAllocator::Allocate(uint64_t size) {
-  kvdk_assert(access_thread.id >= 0, "");
+  kvdk_assert(ThreadManager::ThreadID() >= 0, "");
   SpaceEntry entry;
   auto& tc =
-      dalloc_thread_cache_[access_thread.id % dalloc_thread_cache_.size()];
+      dalloc_thread_cache_[ThreadManager::ThreadID() % dalloc_thread_cache_.size()];
   if (size > chunk_size_) {
     void* addr = aligned_alloc(64, size);
     if (addr != nullptr) {

--- a/engine/dram_allocator.cpp
+++ b/engine/dram_allocator.cpp
@@ -13,31 +13,34 @@ void ChunkBasedAllocator::Free(const SpaceEntry&) {
 }
 
 SpaceEntry ChunkBasedAllocator::Allocate(uint64_t size) {
+  kvdk_assert(access_thread.id >= 0, "");
   SpaceEntry entry;
+  auto& tc =
+      dalloc_thread_cache_[access_thread.id % dalloc_thread_cache_.size()];
   if (size > chunk_size_) {
     void* addr = aligned_alloc(64, size);
     if (addr != nullptr) {
       entry.size = chunk_size_;
       entry.offset = addr2offset(addr);
-      dalloc_thread_cache_[access_thread.id].allocated_chunks.push_back(addr);
+      tc.allocated_chunks.push_back(addr);
     }
     return entry;
   }
 
-  if (dalloc_thread_cache_[access_thread.id].usable_bytes < size) {
+  if (tc.usable_bytes < size) {
     void* addr = aligned_alloc(64, chunk_size_);
     if (addr == nullptr) {
       return entry;
     }
-    dalloc_thread_cache_[access_thread.id].chunk_addr = (char*)addr;
-    dalloc_thread_cache_[access_thread.id].usable_bytes = chunk_size_;
-    dalloc_thread_cache_[access_thread.id].allocated_chunks.push_back(addr);
+    tc.chunk_addr = (char*)addr;
+    tc.usable_bytes = chunk_size_;
+    tc.allocated_chunks.push_back(addr);
   }
 
   entry.size = size;
-  entry.offset = addr2offset(dalloc_thread_cache_[access_thread.id].chunk_addr);
-  dalloc_thread_cache_[access_thread.id].chunk_addr += size;
-  dalloc_thread_cache_[access_thread.id].usable_bytes -= size;
+  entry.offset = addr2offset(tc.chunk_addr);
+  tc.chunk_addr += size;
+  tc.usable_bytes -= size;
   return entry;
 }
 }  // namespace KVDK_NAMESPACE

--- a/engine/dram_allocator.cpp
+++ b/engine/dram_allocator.cpp
@@ -15,8 +15,8 @@ void ChunkBasedAllocator::Free(const SpaceEntry&) {
 SpaceEntry ChunkBasedAllocator::Allocate(uint64_t size) {
   kvdk_assert(ThreadManager::ThreadID() >= 0, "");
   SpaceEntry entry;
-  auto& tc =
-      dalloc_thread_cache_[ThreadManager::ThreadID() % dalloc_thread_cache_.size()];
+  auto& tc = dalloc_thread_cache_[ThreadManager::ThreadID() %
+                                  dalloc_thread_cache_.size()];
   if (size > chunk_size_) {
     void* addr = aligned_alloc(64, size);
     if (addr != nullptr) {

--- a/engine/hash_collection/rebuilder.hpp
+++ b/engine/hash_collection/rebuilder.hpp
@@ -23,14 +23,13 @@ class HashListRebuilder {
   };
 
   HashListRebuilder(PMEMAllocator* pmem_allocator, HashTable* hash_table,
-                    LockTable* lock_table, ThreadManager* thread_manager,
-                    uint64_t num_rebuild_threads, const CheckPoint& checkpoint)
+                    LockTable* lock_table, uint64_t num_rebuild_threads,
+                    const CheckPoint& checkpoint)
       : recovery_utils_(pmem_allocator),
         rebuilder_thread_cache_(num_rebuild_threads),
         pmem_allocator_(pmem_allocator),
         hash_table_(hash_table),
         lock_table_(lock_table),
-        thread_manager_(thread_manager),
         num_rebuild_threads_(num_rebuild_threads),
         checkpoint_(checkpoint) {}
 
@@ -122,11 +121,6 @@ class HashListRebuilder {
   bool recoverToCheckPoint() { return checkpoint_.Valid(); }
 
   Status initRebuildLists() {
-    Status s = thread_manager_->MaybeInitThread(access_thread);
-    if (s != Status::Ok) {
-      return s;
-    }
-
     // Keep headers with same id together for recognize outdated ones
     auto cmp = [](const DLRecord* header1, const DLRecord* header2) {
       auto id1 = HashList::FetchID(header1);
@@ -258,8 +252,6 @@ class HashListRebuilder {
   }
 
   Status rebuildIndex(HashList* hlist) {
-    thread_manager_->MaybeInitThread(access_thread);
-
     size_t num_elems = 0;
 
     auto iter = hlist->GetDLList()->GetRecordIterator();
@@ -311,8 +303,9 @@ class HashListRebuilder {
   }
 
   void addUnlinkedRecord(DLRecord* pmem_record) {
-    kvdk_assert(access_thread.id >= 0, "");
-    rebuilder_thread_cache_[access_thread.id % rebuilder_thread_cache_.size()]
+    kvdk_assert(ThreadManager::ThreadID() >= 0, "");
+    rebuilder_thread_cache_[ThreadManager::ThreadID() %
+                            rebuilder_thread_cache_.size()]
         .unlinked_records.push_back(pmem_record);
   }
 
@@ -351,7 +344,6 @@ class HashListRebuilder {
   PMEMAllocator* pmem_allocator_;
   HashTable* hash_table_;
   LockTable* lock_table_;
-  ThreadManager* thread_manager_;
   const size_t num_rebuild_threads_;
   CheckPoint checkpoint_;
   SpinMutex lock_;

--- a/engine/hash_collection/rebuilder.hpp
+++ b/engine/hash_collection/rebuilder.hpp
@@ -252,6 +252,8 @@ class HashListRebuilder {
   }
 
   Status rebuildIndex(HashList* hlist) {
+    this_thread.id = next_tid_.fetch_add(1);
+
     size_t num_elems = 0;
 
     auto iter = hlist->GetDLList()->GetRecordIterator();
@@ -352,5 +354,10 @@ class HashListRebuilder {
   std::unordered_map<CollectionIDType, std::shared_ptr<HashList>>
       rebuild_hlists_;
   CollectionIDType max_recovered_id_;
+
+  // We manually allocate recovery thread id for no conflict in multi-thread
+  // recovering
+  // Todo: do not hard code
+  std::atomic<uint64_t> next_tid_{0};
 };
 }  // namespace KVDK_NAMESPACE

--- a/engine/hash_collection/rebuilder.hpp
+++ b/engine/hash_collection/rebuilder.hpp
@@ -258,11 +258,8 @@ class HashListRebuilder {
   }
 
   Status rebuildIndex(HashList* hlist) {
-    Status s = thread_manager_->MaybeInitThread(access_thread);
-    if (s != Status::Ok) {
-      return s;
-    }
-    defer(thread_manager_->Release(access_thread));
+    thread_manager_->MaybeInitThread(access_thread);
+
     size_t num_elems = 0;
 
     auto iter = hlist->GetDLList()->GetRecordIterator();

--- a/engine/hash_collection/rebuilder.hpp
+++ b/engine/hash_collection/rebuilder.hpp
@@ -314,9 +314,9 @@ class HashListRebuilder {
   }
 
   void addUnlinkedRecord(DLRecord* pmem_record) {
-    assert(access_thread.id >= 0);
-    rebuilder_thread_cache_[access_thread.id].unlinked_records.push_back(
-        pmem_record);
+    kvdk_assert(access_thread.id >= 0, "");
+    rebuilder_thread_cache_[access_thread.id % rebuilder_thread_cache_.size()]
+        .unlinked_records.push_back(pmem_record);
   }
 
   void cleanInvalidRecords() {

--- a/engine/hash_table.cpp
+++ b/engine/hash_table.cpp
@@ -174,10 +174,10 @@ HashTable::LookupResult HashTable::Insert(const StringView& key,
 }
 
 Status HashTable::allocateEntry(HashBucketIterator& bucket_iter) {
-  kvdk_assert(bucket_iter.hash_table_ == this &&
-                  bucket_iter.entry_idx_ ==
-                      hash_bucket_entries_[bucket_iter.bucket_idx_],
-              "Only allocate new hash entry at end of hash bucket");
+  kvdk_assert(bucket_iter.hash_table_ == this, "");
+  kvdk_assert(
+      bucket_iter.entry_idx_ == hash_bucket_entries_[bucket_iter.bucket_idx_],
+      "Only allocate new hash entry at end of hash bucket");
   assert(bucket_iter.bucket_ptr_ != nullptr);
   if (hash_bucket_entries_[bucket_iter.bucket_idx_] > 0 &&
       hash_bucket_entries_[bucket_iter.bucket_idx_] % kNumEntryPerBucket == 0) {

--- a/engine/kv_engine.cpp
+++ b/engine/kv_engine.cpp
@@ -189,14 +189,12 @@ Status KVEngine::init(const std::string& name, const Configs& configs) {
       configs_.pmem_block_size, configs_.max_access_threads,
       configs_.populate_pmem_space, configs_.use_devdax_mode,
       &version_controller_));
-  thread_manager_.reset(new (std::nothrow)
-                            ThreadManager(configs_.max_access_threads));
   hash_table_.reset(HashTable::NewHashTable(
       configs_.hash_bucket_num, configs_.num_buckets_per_slot,
       pmem_allocator_.get(), configs_.max_access_threads));
   dllist_locks_.reset(new LockTable{1UL << 20});
   if (pmem_allocator_ == nullptr || hash_table_ == nullptr ||
-      thread_manager_ == nullptr || dllist_locks_ == nullptr) {
+      dllist_locks_ == nullptr) {
     GlobalLogger.Error("Init kvdk basic components error\n");
     return Status::Abort;
   }
@@ -208,16 +206,14 @@ Status KVEngine::init(const std::string& name, const Configs& configs) {
 }
 
 Status KVEngine::restoreData() {
-  Status s = maybeInitAccessThread();
-  if (s != Status::Ok) {
-    return s;
-  }
+  thread_manager_->MaybeInitThread(access_thread);
   EngineThreadCache& engine_thread_cache =
-      engine_thread_cache_[access_thread.id];
+      engine_thread_cache_[access_thread.id % configs_.max_access_threads];
 
   SpaceEntry segment_recovering;
   DataEntry data_entry_cached;
   uint64_t cnt = 0;
+  Status s;
   while (true) {
     if (segment_recovering.size == 0) {
       if (!pmem_allocator_->FetchSegment(&segment_recovering)) {
@@ -342,7 +338,6 @@ Status KVEngine::restoreData() {
     }
   }
   restored_.fetch_add(cnt);
-  ReleaseAccessThread();
   return s;
 }
 
@@ -548,13 +543,10 @@ Status KVEngine::initOrRestoreCheckpoint() {
 
 Status KVEngine::restoreDataFromBackup(const std::string& backup_log) {
   // TODO: make this multi-thread
-  Status s = maybeInitAccessThread();
-  if (s != Status::Ok) {
-    return s;
-  }
-  defer(ReleaseAccessThread());
+  thread_manager_->MaybeInitThread(access_thread);
+
   BackupLog backup;
-  s = backup.Open(backup_log);
+  Status s = backup.Open(backup_log);
   if (s != Status::Ok) {
     return s;
   }
@@ -715,20 +707,17 @@ Status KVEngine::restoreDataFromBackup(const std::string& backup_log) {
 }
 
 Status KVEngine::restoreExistingData() {
-  access_thread.id = 0;
-  defer(access_thread.id = -1);
+  thread_manager_->MaybeInitThread(access_thread);
 
   sorted_rebuilder_.reset(new SortedCollectionRebuilder(
       this, configs_.opt_large_sorted_collection_recovery,
       configs_.max_access_threads, *persist_checkpoint_));
-  hash_rebuilder_.reset(
-      new HashListRebuilder(pmem_allocator_.get(), hash_table_.get(),
-                            dllist_locks_.get(), thread_manager_.get(),
-                            configs_.max_access_threads, *persist_checkpoint_));
-  list_rebuilder_.reset(
-      new ListRebuilder(pmem_allocator_.get(), hash_table_.get(),
-                        dllist_locks_.get(), thread_manager_.get(),
-                        configs_.max_access_threads, *persist_checkpoint_));
+  hash_rebuilder_.reset(new HashListRebuilder(
+      pmem_allocator_.get(), hash_table_.get(), dllist_locks_.get(),
+      thread_manager_, configs_.max_access_threads, *persist_checkpoint_));
+  list_rebuilder_.reset(new ListRebuilder(
+      pmem_allocator_.get(), hash_table_.get(), dllist_locks_.get(),
+      thread_manager_, configs_.max_access_threads, *persist_checkpoint_));
 
   Status s = batchWriteRollbackLogs();
   if (s != Status::Ok) {
@@ -883,12 +872,13 @@ Status KVEngine::checkConfigs(const Configs& configs) {
 }
 
 Status KVEngine::maybeInitBatchLogFile() {
-  auto& tc = engine_thread_cache_[access_thread.id];
+  kvdk_assert(access_thread.id >= 0, "");
+  auto work_id = access_thread.id % configs_.max_access_threads;
+  auto& tc = engine_thread_cache_[work_id];
   if (tc.batch_log == nullptr) {
     int is_pmem;
     size_t mapped_len;
-    std::string log_file_name =
-        batch_log_dir_ + std::to_string(access_thread.id);
+    std::string log_file_name = batch_log_dir_ + std::to_string(work_id);
     void* addr = pmem_map_file(log_file_name.c_str(), BatchWriteLog::MaxBytes(),
                                PMEM_FILE_CREATE, 0666, &mapped_len, &is_pmem);
     if (addr == NULL) {
@@ -916,12 +906,9 @@ Status KVEngine::batchWriteImpl(WriteBatchImpl const& batch) {
     return Status::InvalidBatchSize;
   }
 
-  Status s = maybeInitAccessThread();
-  if (s != Status::Ok) {
-    return s;
-  }
+  auto thread_holder = AcquireAccessThread();
 
-  s = maybeInitBatchLogFile();
+  Status s = maybeInitBatchLogFile();
   if (s != Status::Ok) {
     return s;
   }
@@ -1045,7 +1032,8 @@ Status KVEngine::batchWriteImpl(WriteBatchImpl const& batch) {
   // Preparation done. Persist BatchLog for rollback.
   BatchWriteLog log;
   log.SetTimestamp(bw_token.Timestamp());
-  auto& tc = engine_thread_cache_[access_thread.id];
+  auto& tc =
+      engine_thread_cache_[access_thread.id % configs_.max_access_threads];
   for (auto& args : string_args) {
     if (args.space.size == 0) {
       continue;
@@ -1291,10 +1279,7 @@ Status KVEngine::TypeOf(StringView key, ValueType* type) {
 }
 
 Status KVEngine::Expire(const StringView str, TTLType ttl_time) {
-  Status s = maybeInitAccessThread();
-  if (s != Status::Ok) {
-    return s;
-  }
+  auto thread_holder = AcquireAccessThread();
 
   int64_t base_time = TimeUtils::millisecond_time();
   if (!TimeUtils::CheckTTL(ttl_time, base_time)) {

--- a/engine/kv_engine.cpp
+++ b/engine/kv_engine.cpp
@@ -206,6 +206,8 @@ Status KVEngine::init(const std::string& name, const Configs& configs) {
 }
 
 Status KVEngine::restoreData() {
+  this_thread.id = next_recovery_tid_.fetch_add(1);
+
   EngineThreadCache& engine_thread_cache =
       engine_thread_cache_[ThreadManager::ThreadID() %
                            configs_.max_access_threads];

--- a/engine/kv_engine.hpp
+++ b/engine/kv_engine.hpp
@@ -651,6 +651,11 @@ class KVEngine : public Engine {
   BackgroundWorkSignals bg_work_signals_;
 
   std::atomic<int64_t> round_robin_id_{0};
+
+  // We manually allocate recovery thread id for no conflict in multi-thread
+  // recovering
+  // Todo: do not hard code
+  std::atomic<uint64_t> next_recovery_tid_{0};
 };
 
 }  // namespace KVDK_NAMESPACE

--- a/engine/kv_engine.hpp
+++ b/engine/kv_engine.hpp
@@ -333,10 +333,11 @@ class KVEngine : public Engine {
                   "Invalid type!");
     return std::is_same<CollectionType, Skiplist>::value
                ? RecordType::SortedHeader
-           : std::is_same<CollectionType, List>::value ? RecordType::ListHeader
-           : std::is_same<CollectionType, HashList>::value
-               ? RecordType::HashHeader
-               : RecordType::Empty;
+               : std::is_same<CollectionType, List>::value
+                     ? RecordType::ListHeader
+                     : std::is_same<CollectionType, HashList>::value
+                           ? RecordType::HashHeader
+                           : RecordType::Empty;
   }
 
   static PointerType pointerType(RecordType rtype) {

--- a/engine/kv_engine_cleaner.cpp
+++ b/engine/kv_engine_cleaner.cpp
@@ -45,8 +45,8 @@ void KVEngine::removeAndCacheOutdatedVersion(T* record) {
   static_assert(std::is_same<T, StringRecord>::value ||
                 std::is_same<T, DLRecord>::value);
   kvdk_assert(ThreadManager::ThreadID() >= 0, "");
-  auto& tc =
-      cleaner_thread_cache_[ThreadManager::ThreadID() % configs_.max_access_threads];
+  auto& tc = cleaner_thread_cache_[ThreadManager::ThreadID() %
+                                   configs_.max_access_threads];
   if (std::is_same<T, StringRecord>::value) {
     StringRecord* old_record = removeOutDatedVersion<StringRecord>(
         (StringRecord*)record, version_controller_.GlobalOldestSnapshotTs());
@@ -89,8 +89,8 @@ void KVEngine::cleanOutdatedRecordImpl(T* old_record) {
 
 void KVEngine::tryCleanCachedOutdatedRecord() {
   kvdk_assert(ThreadManager::ThreadID() >= 0, "");
-  auto& tc =
-      cleaner_thread_cache_[ThreadManager::ThreadID() % configs_.max_access_threads];
+  auto& tc = cleaner_thread_cache_[ThreadManager::ThreadID() %
+                                   configs_.max_access_threads];
   // Regularly update local oldest snapshot
   thread_local uint64_t round = 0;
   if (++round % kForegroundUpdateSnapshotInterval == 0) {

--- a/engine/kv_engine_cleaner.cpp
+++ b/engine/kv_engine_cleaner.cpp
@@ -45,7 +45,8 @@ void KVEngine::removeAndCacheOutdatedVersion(T* record) {
   static_assert(std::is_same<T, StringRecord>::value ||
                 std::is_same<T, DLRecord>::value);
   kvdk_assert(access_thread.id >= 0, "");
-  auto& tc = cleaner_thread_cache_[access_thread.id];
+  auto& tc =
+      cleaner_thread_cache_[access_thread.id % configs_.max_access_threads];
   if (std::is_same<T, StringRecord>::value) {
     StringRecord* old_record = removeOutDatedVersion<StringRecord>(
         (StringRecord*)record, version_controller_.GlobalOldestSnapshotTs());
@@ -88,7 +89,8 @@ void KVEngine::cleanOutdatedRecordImpl(T* old_record) {
 
 void KVEngine::tryCleanCachedOutdatedRecord() {
   kvdk_assert(access_thread.id >= 0, "");
-  auto& tc = cleaner_thread_cache_[access_thread.id];
+  auto& tc =
+      cleaner_thread_cache_[access_thread.id % configs_.max_access_threads];
   // Regularly update local oldest snapshot
   thread_local uint64_t round = 0;
   if (++round % kForegroundUpdateSnapshotInterval == 0) {

--- a/engine/kv_engine_cleaner.cpp
+++ b/engine/kv_engine_cleaner.cpp
@@ -44,9 +44,9 @@ template <typename T>
 void KVEngine::removeAndCacheOutdatedVersion(T* record) {
   static_assert(std::is_same<T, StringRecord>::value ||
                 std::is_same<T, DLRecord>::value);
-  kvdk_assert(access_thread.id >= 0, "");
+  kvdk_assert(ThreadManager::ThreadID() >= 0, "");
   auto& tc =
-      cleaner_thread_cache_[access_thread.id % configs_.max_access_threads];
+      cleaner_thread_cache_[ThreadManager::ThreadID() % configs_.max_access_threads];
   if (std::is_same<T, StringRecord>::value) {
     StringRecord* old_record = removeOutDatedVersion<StringRecord>(
         (StringRecord*)record, version_controller_.GlobalOldestSnapshotTs());
@@ -88,9 +88,9 @@ void KVEngine::cleanOutdatedRecordImpl(T* old_record) {
 }
 
 void KVEngine::tryCleanCachedOutdatedRecord() {
-  kvdk_assert(access_thread.id >= 0, "");
+  kvdk_assert(ThreadManager::ThreadID() >= 0, "");
   auto& tc =
-      cleaner_thread_cache_[access_thread.id % configs_.max_access_threads];
+      cleaner_thread_cache_[ThreadManager::ThreadID() % configs_.max_access_threads];
   // Regularly update local oldest snapshot
   thread_local uint64_t round = 0;
   if (++round % kForegroundUpdateSnapshotInterval == 0) {

--- a/engine/kv_engine_list.cpp
+++ b/engine/kv_engine_list.cpp
@@ -4,10 +4,7 @@
 
 namespace KVDK_NAMESPACE {
 Status KVEngine::ListCreate(StringView list_name) {
-  Status s = maybeInitAccessThread();
-  if (s != Status::Ok) {
-    return s;
-  }
+  auto thread_holder = AcquireAccessThread();
 
   if (!checkKeySize(list_name)) {
     return Status::InvalidDataSize;
@@ -59,9 +56,7 @@ Status KVEngine::ListDestroy(StringView collection) {
   if (!checkKeySize(collection)) {
     return Status::InvalidDataSize;
   }
-  if (maybeInitAccessThread() != Status::Ok) {
-    return Status::TooManyAccessThreads;
-  }
+  auto thread_holder = AcquireAccessThread();
 
   auto ul = hash_table_->AcquireLock(collection);
   auto snapshot_holder = version_controller_.GetLocalSnapshotHolder();
@@ -98,9 +93,7 @@ Status KVEngine::ListSize(StringView list_name, size_t* sz) {
   if (!checkKeySize(list_name)) {
     return Status::InvalidDataSize;
   }
-  if (maybeInitAccessThread() != Status::Ok) {
-    return Status::TooManyAccessThreads;
-  }
+  auto thread_holder = AcquireAccessThread();
 
   auto token = version_controller_.GetLocalSnapshotHolder();
 
@@ -118,9 +111,7 @@ Status KVEngine::ListPushFront(StringView collection, StringView elem) {
   if (!checkKeySize(collection) || !checkValueSize(elem)) {
     return Status::InvalidDataSize;
   }
-  if (maybeInitAccessThread() != Status::Ok) {
-    return Status::TooManyAccessThreads;
-  }
+  auto thread_holder = AcquireAccessThread();
 
   auto token = version_controller_.GetLocalSnapshotHolder();
   List* list;
@@ -137,9 +128,7 @@ Status KVEngine::ListPushBack(StringView list_name, StringView elem) {
   if (!checkKeySize(list_name) || !checkValueSize(elem)) {
     return Status::InvalidDataSize;
   }
-  if (maybeInitAccessThread() != Status::Ok) {
-    return Status::TooManyAccessThreads;
-  }
+  auto thread_holder = AcquireAccessThread();
 
   auto token = version_controller_.GetLocalSnapshotHolder();
   List* list;
@@ -156,9 +145,7 @@ Status KVEngine::ListPopFront(StringView list_name, std::string* elem) {
   if (!checkKeySize(list_name)) {
     return Status::InvalidDataSize;
   }
-  if (maybeInitAccessThread() != Status::Ok) {
-    return Status::TooManyAccessThreads;
-  }
+  auto thread_holder = AcquireAccessThread();
 
   auto token = version_controller_.GetLocalSnapshotHolder();
   List* list;
@@ -189,9 +176,7 @@ Status KVEngine::ListPopBack(StringView list_name, std::string* elem) {
   if (!checkKeySize(list_name)) {
     return Status::InvalidDataSize;
   }
-  if (maybeInitAccessThread() != Status::Ok) {
-    return Status::TooManyAccessThreads;
-  }
+  auto thread_holder = AcquireAccessThread();
 
   auto token = version_controller_.GetLocalSnapshotHolder();
   List* list;
@@ -242,11 +227,9 @@ Status KVEngine::ListBatchPushFront(StringView list_name,
       return Status::InvalidDataSize;
     }
   }
-  Status s = maybeInitAccessThread();
-  if (s != Status::Ok) {
-    return s;
-  }
-  s = maybeInitBatchLogFile();
+  auto thread_holder = AcquireAccessThread();
+
+  Status s = maybeInitBatchLogFile();
   if (s != Status::Ok) {
     return s;
   }
@@ -272,11 +255,9 @@ Status KVEngine::ListBatchPushBack(StringView list_name,
       return Status::InvalidDataSize;
     }
   }
-  Status s = maybeInitAccessThread();
-  if (s != Status::Ok) {
-    return s;
-  }
-  s = maybeInitBatchLogFile();
+  auto thread_holder = AcquireAccessThread();
+
+  Status s = maybeInitBatchLogFile();
   if (s != Status::Ok) {
     return s;
   }
@@ -288,11 +269,9 @@ Status KVEngine::ListBatchPopFront(StringView list_name, size_t n,
   if (!checkKeySize(list_name)) {
     return Status::InvalidDataSize;
   }
-  Status s = maybeInitAccessThread();
-  if (s != Status::Ok) {
-    return s;
-  }
-  s = maybeInitBatchLogFile();
+  auto thread_holder = AcquireAccessThread();
+
+  Status s = maybeInitBatchLogFile();
   if (s != Status::Ok) {
     return s;
   }
@@ -304,11 +283,8 @@ Status KVEngine::ListBatchPopBack(StringView list_name, size_t n,
   if (!checkKeySize(list_name)) {
     return Status::InvalidDataSize;
   }
-  Status s = maybeInitAccessThread();
-  if (s != Status::Ok) {
-    return s;
-  }
-  s = maybeInitBatchLogFile();
+  auto thread_holder = AcquireAccessThread();
+  Status s = maybeInitBatchLogFile();
   if (s != Status::Ok) {
     return s;
   }
@@ -321,12 +297,9 @@ Status KVEngine::ListMove(StringView src, ListPos src_pos, StringView dst,
   if (!checkKeySize(src) || !checkKeySize(dst)) {
     return Status::InvalidDataSize;
   }
-  Status s = maybeInitAccessThread();
-  if (s != Status::Ok) {
-    return s;
-  }
+  auto thread_holder = AcquireAccessThread();
 
-  s = maybeInitBatchLogFile();
+  Status s = maybeInitBatchLogFile();
   if (s != Status::Ok) {
     return s;
   }
@@ -390,7 +363,8 @@ Status KVEngine::ListMove(StringView src, ListPos src_pos, StringView dst,
 
   log.ListDelete(pop_args.spaces[0].offset);
   log.ListEmplace(push_args.spaces[0].offset);
-  auto& tc = engine_thread_cache_[access_thread.id];
+  auto& tc =
+      engine_thread_cache_[access_thread.id % configs_.max_access_threads];
   log.EncodeTo(tc.batch_log);
 
   BatchWriteLog::MarkProcessing(tc.batch_log);
@@ -410,9 +384,8 @@ Status KVEngine::ListInsertAt(StringView list_name, StringView elem,
   if (!checkValueSize(elem)) {
     return Status::InvalidDataSize;
   }
-  if (maybeInitAccessThread() != Status::Ok) {
-    return Status::TooManyAccessThreads;
-  }
+  auto thread_holder = AcquireAccessThread();
+
   auto token = version_controller_.GetLocalSnapshotHolder();
   List* list;
   Status s = listFind(list_name, &list);
@@ -429,9 +402,7 @@ Status KVEngine::ListInsertBefore(StringView list_name, StringView elem,
   if (!checkValueSize(elem)) {
     return Status::InvalidDataSize;
   }
-  if (maybeInitAccessThread() != Status::Ok) {
-    return Status::TooManyAccessThreads;
-  }
+  auto thread_holder = AcquireAccessThread();
 
   auto token = version_controller_.GetLocalSnapshotHolder();
   List* list;
@@ -451,9 +422,7 @@ Status KVEngine::ListInsertAfter(StringView collection, StringView elem,
   if (!checkValueSize(elem)) {
     return Status::InvalidDataSize;
   }
-  if (maybeInitAccessThread() != Status::Ok) {
-    return Status::TooManyAccessThreads;
-  }
+  auto thread_holder = AcquireAccessThread();
 
   auto token = version_controller_.GetLocalSnapshotHolder();
   List* list;
@@ -469,9 +438,7 @@ Status KVEngine::ListInsertAfter(StringView collection, StringView elem,
 
 Status KVEngine::ListErase(StringView list_name, long index,
                            std::string* elem) {
-  if (maybeInitAccessThread() != Status::Ok) {
-    return Status::TooManyAccessThreads;
-  }
+  auto thread_holder = AcquireAccessThread();
 
   auto token = version_controller_.GetLocalSnapshotHolder();
   List* list;
@@ -499,9 +466,7 @@ Status KVEngine::ListErase(StringView list_name, long index,
 // Replace the element at pos
 Status KVEngine::ListReplace(StringView collection, long index,
                              StringView elem) {
-  if (maybeInitAccessThread() != Status::Ok) {
-    return Status::TooManyAccessThreads;
-  }
+  auto thread_holder = AcquireAccessThread();
 
   auto token = version_controller_.GetLocalSnapshotHolder();
   List* list;
@@ -597,7 +562,8 @@ Status KVEngine::listBatchPushImpl(StringView list_name, ListPos pos,
     log.ListEmplace(space.offset);
   }
 
-  auto& tc = engine_thread_cache_[access_thread.id];
+  auto& tc =
+      engine_thread_cache_[access_thread.id % configs_.max_access_threads];
   log.EncodeTo(tc.batch_log);
   BatchWriteLog::MarkProcessing(tc.batch_log);
 
@@ -630,7 +596,8 @@ Status KVEngine::listBatchPopImpl(StringView list_name, ListPos pos, size_t n,
     log.ListDelete(space.offset);
   }
 
-  auto& tc = engine_thread_cache_[access_thread.id];
+  auto& tc =
+      engine_thread_cache_[access_thread.id % configs_.max_access_threads];
   log.EncodeTo(tc.batch_log);
   BatchWriteLog::MarkProcessing(tc.batch_log);
 

--- a/engine/kv_engine_list.cpp
+++ b/engine/kv_engine_list.cpp
@@ -364,7 +364,7 @@ Status KVEngine::ListMove(StringView src, ListPos src_pos, StringView dst,
   log.ListDelete(pop_args.spaces[0].offset);
   log.ListEmplace(push_args.spaces[0].offset);
   auto& tc =
-      engine_thread_cache_[access_thread.id % configs_.max_access_threads];
+      engine_thread_cache_[ThreadManager::ThreadID() % configs_.max_access_threads];
   log.EncodeTo(tc.batch_log);
 
   BatchWriteLog::MarkProcessing(tc.batch_log);
@@ -563,7 +563,7 @@ Status KVEngine::listBatchPushImpl(StringView list_name, ListPos pos,
   }
 
   auto& tc =
-      engine_thread_cache_[access_thread.id % configs_.max_access_threads];
+      engine_thread_cache_[ThreadManager::ThreadID() % configs_.max_access_threads];
   log.EncodeTo(tc.batch_log);
   BatchWriteLog::MarkProcessing(tc.batch_log);
 
@@ -597,7 +597,7 @@ Status KVEngine::listBatchPopImpl(StringView list_name, ListPos pos, size_t n,
   }
 
   auto& tc =
-      engine_thread_cache_[access_thread.id % configs_.max_access_threads];
+      engine_thread_cache_[ThreadManager::ThreadID() % configs_.max_access_threads];
   log.EncodeTo(tc.batch_log);
   BatchWriteLog::MarkProcessing(tc.batch_log);
 

--- a/engine/kv_engine_list.cpp
+++ b/engine/kv_engine_list.cpp
@@ -363,8 +363,8 @@ Status KVEngine::ListMove(StringView src, ListPos src_pos, StringView dst,
 
   log.ListDelete(pop_args.spaces[0].offset);
   log.ListEmplace(push_args.spaces[0].offset);
-  auto& tc =
-      engine_thread_cache_[ThreadManager::ThreadID() % configs_.max_access_threads];
+  auto& tc = engine_thread_cache_[ThreadManager::ThreadID() %
+                                  configs_.max_access_threads];
   log.EncodeTo(tc.batch_log);
 
   BatchWriteLog::MarkProcessing(tc.batch_log);
@@ -562,8 +562,8 @@ Status KVEngine::listBatchPushImpl(StringView list_name, ListPos pos,
     log.ListEmplace(space.offset);
   }
 
-  auto& tc =
-      engine_thread_cache_[ThreadManager::ThreadID() % configs_.max_access_threads];
+  auto& tc = engine_thread_cache_[ThreadManager::ThreadID() %
+                                  configs_.max_access_threads];
   log.EncodeTo(tc.batch_log);
   BatchWriteLog::MarkProcessing(tc.batch_log);
 
@@ -596,8 +596,8 @@ Status KVEngine::listBatchPopImpl(StringView list_name, ListPos pos, size_t n,
     log.ListDelete(space.offset);
   }
 
-  auto& tc =
-      engine_thread_cache_[ThreadManager::ThreadID() % configs_.max_access_threads];
+  auto& tc = engine_thread_cache_[ThreadManager::ThreadID() %
+                                  configs_.max_access_threads];
   log.EncodeTo(tc.batch_log);
   BatchWriteLog::MarkProcessing(tc.batch_log);
 

--- a/engine/kv_engine_sorted.cpp
+++ b/engine/kv_engine_sorted.cpp
@@ -8,11 +8,7 @@
 namespace KVDK_NAMESPACE {
 Status KVEngine::SortedCreate(const StringView collection_name,
                               const SortedCollectionConfigs& s_configs) {
-  Status s = maybeInitAccessThread();
-  defer(ReleaseAccessThread());
-  if (s != Status::Ok) {
-    return s;
-  }
+  auto thread_holder = AcquireAccessThread();
 
   if (!checkKeySize(collection_name)) {
     return Status::InvalidDataSize;
@@ -74,11 +70,8 @@ Status KVEngine::buildSkiplist(const StringView& collection_name,
 }
 
 Status KVEngine::SortedDestroy(const StringView collection_name) {
-  auto s = maybeInitAccessThread();
-  defer(ReleaseAccessThread());
-  if (s != Status::Ok) {
-    return s;
-  }
+  auto thread_holder = AcquireAccessThread();
+
   auto ul = hash_table_->AcquireLock(collection_name);
   auto snapshot_holder = version_controller_.GetLocalSnapshotHolder();
   auto new_ts = snapshot_holder.Timestamp();
@@ -118,11 +111,7 @@ Status KVEngine::SortedDestroy(const StringView collection_name) {
 }
 
 Status KVEngine::SortedSize(const StringView collection, size_t* size) {
-  Status s = maybeInitAccessThread();
-
-  if (s != Status::Ok) {
-    return s;
-  }
+  auto thread_holder = AcquireAccessThread();
 
   auto holder = version_controller_.GetLocalSnapshotHolder();
 
@@ -141,11 +130,7 @@ Status KVEngine::SortedSize(const StringView collection, size_t* size) {
 
 Status KVEngine::SortedGet(const StringView collection,
                            const StringView user_key, std::string* value) {
-  Status s = maybeInitAccessThread();
-
-  if (s != Status::Ok) {
-    return s;
-  }
+  auto thread_holder = AcquireAccessThread();
 
   // Hold current snapshot in this thread
   auto holder = version_controller_.GetLocalSnapshotHolder();
@@ -166,10 +151,7 @@ Status KVEngine::SortedGet(const StringView collection,
 
 Status KVEngine::SortedPut(const StringView collection,
                            const StringView user_key, const StringView value) {
-  Status s = maybeInitAccessThread();
-  if (s != Status::Ok) {
-    return s;
-  }
+  auto thread_holder = AcquireAccessThread();
 
   auto snapshot_holder = version_controller_.GetLocalSnapshotHolder();
 
@@ -188,10 +170,8 @@ Status KVEngine::SortedPut(const StringView collection,
 
 Status KVEngine::SortedDelete(const StringView collection,
                               const StringView user_key) {
-  Status s = maybeInitAccessThread();
-  if (s != Status::Ok) {
-    return s;
-  }
+  auto thread_holder = AcquireAccessThread();
+
   // Hold current snapshot in this thread
   auto holder = version_controller_.GetLocalSnapshotHolder();
 

--- a/engine/kv_engine_string.cpp
+++ b/engine/kv_engine_string.cpp
@@ -14,10 +14,7 @@ Status KVEngine::Modify(const StringView key, ModifyFunc modify_func,
     return Status::InvalidArgument;
   }
 
-  Status s = maybeInitAccessThread();
-  if (s != Status::Ok) {
-    return s;
-  }
+  auto thread_holder = AcquireAccessThread();
 
   auto ul = hash_table_->AcquireLock(key);
   auto holder = version_controller_.GetLocalSnapshotHolder();
@@ -106,10 +103,7 @@ Status KVEngine::Modify(const StringView key, ModifyFunc modify_func,
 
 Status KVEngine::Put(const StringView key, const StringView value,
                      const WriteOptions& options) {
-  Status s = maybeInitAccessThread();
-  if (s != Status::Ok) {
-    return s;
-  }
+  auto thread_holder = AcquireAccessThread();
 
   if (!checkKeySize(key) || !checkValueSize(value)) {
     return Status::InvalidDataSize;
@@ -119,11 +113,7 @@ Status KVEngine::Put(const StringView key, const StringView value,
 }
 
 Status KVEngine::Get(const StringView key, std::string* value) {
-  Status s = maybeInitAccessThread();
-
-  if (s != Status::Ok) {
-    return s;
-  }
+  auto thread_holder = AcquireAccessThread();
 
   if (!checkKeySize(key)) {
     return Status::InvalidDataSize;
@@ -144,11 +134,7 @@ Status KVEngine::Get(const StringView key, std::string* value) {
 }
 
 Status KVEngine::Delete(const StringView key) {
-  Status s = maybeInitAccessThread();
-
-  if (s != Status::Ok) {
-    return s;
-  }
+  auto thread_holder = AcquireAccessThread();
 
   if (!checkKeySize(key)) {
     return Status::InvalidDataSize;

--- a/engine/list_collection/rebuilder.hpp
+++ b/engine/list_collection/rebuilder.hpp
@@ -221,6 +221,8 @@ class ListRebuilder {
   }
 
   Status rebuildIndex(List* list) {
+    this_thread.id = next_tid_.fetch_add(1);
+
     auto ul = list->AcquireLock();
 
     auto iter = list->GetDLList()->GetRecordIterator();
@@ -298,5 +300,10 @@ class ListRebuilder {
   std::unordered_map<CollectionIDType, std::shared_ptr<List>> invalid_lists_;
   std::unordered_map<CollectionIDType, std::shared_ptr<List>> rebuild_lists_;
   CollectionIDType max_recovered_id_;
+
+  // We manually allocate recovery thread id for no conflict in multi-thread
+  // recovering
+  // Todo: do not hard code
+  std::atomic<uint64_t> next_tid_{0};
 };
 }  // namespace KVDK_NAMESPACE

--- a/engine/list_collection/rebuilder.hpp
+++ b/engine/list_collection/rebuilder.hpp
@@ -222,12 +222,9 @@ class ListRebuilder {
   }
 
   Status rebuildIndex(List* list) {
+    thread_manager_->MaybeInitThread(access_thread);
     auto ul = list->AcquireLock();
-    Status s = thread_manager_->MaybeInitThread(access_thread);
-    if (s != Status::Ok) {
-      return s;
-    }
-    defer(thread_manager_->Release(access_thread));
+
     auto iter = list->GetDLList()->GetRecordIterator();
     iter->SeekToFirst();
     while (iter->Valid()) {

--- a/engine/list_collection/rebuilder.hpp
+++ b/engine/list_collection/rebuilder.hpp
@@ -253,9 +253,9 @@ class ListRebuilder {
   }
 
   void addUnlinkedRecord(DLRecord* pmem_record) {
-    assert(access_thread.id >= 0);
-    rebuilder_thread_cache_[access_thread.id].unlinked_records.push_back(
-        pmem_record);
+    kvdk_assert(access_thread.id >= 0, "");
+    rebuilder_thread_cache_[access_thread.id % rebuilder_thread_cache_.size()]
+        .unlinked_records.push_back(pmem_record);
   }
 
   void cleanInvalidRecords() {

--- a/engine/pmem_allocator/free_list.cpp
+++ b/engine/pmem_allocator/free_list.cpp
@@ -280,7 +280,8 @@ void Freelist::Push(const SpaceEntry& entry) {
   auto b_offset = entry.offset / block_size_;
   space_map_.Set(b_offset, b_size);
 
-  auto& flist_thread_cache = flist_thread_cache_[access_thread.id];
+  auto& flist_thread_cache =
+      flist_thread_cache_[access_thread.id % flist_thread_cache_.size()];
   if (b_size >= flist_thread_cache.small_entry_offsets_.size()) {
     size_t size_index = blockSizeIndex(b_size);
     std::lock_guard<SpinMutex> lg(
@@ -387,7 +388,8 @@ void Freelist::MoveCachedEntriesToPool() {
 
 bool Freelist::getSmallEntry(uint32_t size, SpaceEntry* space_entry) {
   auto b_size = size / block_size_;
-  auto& flist_thread_cache = flist_thread_cache_[access_thread.id];
+  auto& flist_thread_cache =
+      flist_thread_cache_[access_thread.id % flist_thread_cache_.size()];
   for (uint32_t i = b_size; i < flist_thread_cache.small_entry_offsets_.size();
        i++) {
   search_entry:
@@ -418,7 +420,8 @@ bool Freelist::getSmallEntry(uint32_t size, SpaceEntry* space_entry) {
 
 bool Freelist::getLargeEntry(uint32_t size, SpaceEntry* space_entry) {
   auto b_size = size / block_size_;
-  auto& flist_thread_cache = flist_thread_cache_[access_thread.id];
+  auto& flist_thread_cache =
+      flist_thread_cache_[access_thread.id % flist_thread_cache_.size()];
 
   auto size_index = blockSizeIndex(b_size);
   for (size_t i = size_index; i < flist_thread_cache.large_entries_.size();

--- a/engine/pmem_allocator/free_list.cpp
+++ b/engine/pmem_allocator/free_list.cpp
@@ -281,7 +281,7 @@ void Freelist::Push(const SpaceEntry& entry) {
   space_map_.Set(b_offset, b_size);
 
   auto& flist_thread_cache =
-      flist_thread_cache_[access_thread.id % flist_thread_cache_.size()];
+      flist_thread_cache_[ThreadManager::ThreadID() % flist_thread_cache_.size()];
   if (b_size >= flist_thread_cache.small_entry_offsets_.size()) {
     size_t size_index = blockSizeIndex(b_size);
     std::lock_guard<SpinMutex> lg(
@@ -389,7 +389,7 @@ void Freelist::MoveCachedEntriesToPool() {
 bool Freelist::getSmallEntry(uint32_t size, SpaceEntry* space_entry) {
   auto b_size = size / block_size_;
   auto& flist_thread_cache =
-      flist_thread_cache_[access_thread.id % flist_thread_cache_.size()];
+      flist_thread_cache_[ThreadManager::ThreadID() % flist_thread_cache_.size()];
   for (uint32_t i = b_size; i < flist_thread_cache.small_entry_offsets_.size();
        i++) {
   search_entry:
@@ -421,7 +421,7 @@ bool Freelist::getSmallEntry(uint32_t size, SpaceEntry* space_entry) {
 bool Freelist::getLargeEntry(uint32_t size, SpaceEntry* space_entry) {
   auto b_size = size / block_size_;
   auto& flist_thread_cache =
-      flist_thread_cache_[access_thread.id % flist_thread_cache_.size()];
+      flist_thread_cache_[ThreadManager::ThreadID() % flist_thread_cache_.size()];
 
   auto size_index = blockSizeIndex(b_size);
   for (size_t i = size_index; i < flist_thread_cache.large_entries_.size();

--- a/engine/pmem_allocator/free_list.cpp
+++ b/engine/pmem_allocator/free_list.cpp
@@ -280,8 +280,8 @@ void Freelist::Push(const SpaceEntry& entry) {
   auto b_offset = entry.offset / block_size_;
   space_map_.Set(b_offset, b_size);
 
-  auto& flist_thread_cache =
-      flist_thread_cache_[ThreadManager::ThreadID() % flist_thread_cache_.size()];
+  auto& flist_thread_cache = flist_thread_cache_[ThreadManager::ThreadID() %
+                                                 flist_thread_cache_.size()];
   if (b_size >= flist_thread_cache.small_entry_offsets_.size()) {
     size_t size_index = blockSizeIndex(b_size);
     std::lock_guard<SpinMutex> lg(
@@ -388,8 +388,8 @@ void Freelist::MoveCachedEntriesToPool() {
 
 bool Freelist::getSmallEntry(uint32_t size, SpaceEntry* space_entry) {
   auto b_size = size / block_size_;
-  auto& flist_thread_cache =
-      flist_thread_cache_[ThreadManager::ThreadID() % flist_thread_cache_.size()];
+  auto& flist_thread_cache = flist_thread_cache_[ThreadManager::ThreadID() %
+                                                 flist_thread_cache_.size()];
   for (uint32_t i = b_size; i < flist_thread_cache.small_entry_offsets_.size();
        i++) {
   search_entry:
@@ -420,8 +420,8 @@ bool Freelist::getSmallEntry(uint32_t size, SpaceEntry* space_entry) {
 
 bool Freelist::getLargeEntry(uint32_t size, SpaceEntry* space_entry) {
   auto b_size = size / block_size_;
-  auto& flist_thread_cache =
-      flist_thread_cache_[ThreadManager::ThreadID() % flist_thread_cache_.size()];
+  auto& flist_thread_cache = flist_thread_cache_[ThreadManager::ThreadID() %
+                                                 flist_thread_cache_.size()];
 
   auto size_index = blockSizeIndex(b_size);
   for (size_t i = size_index; i < flist_thread_cache.large_entries_.size();

--- a/engine/pmem_allocator/pmem_allocator.cpp
+++ b/engine/pmem_allocator/pmem_allocator.cpp
@@ -237,7 +237,8 @@ SpaceEntry PMEMAllocator::Allocate(uint64_t size) {
   if (aligned_size > segment_size_) {
     return space_entry;
   }
-  auto& palloc_thread_cache = palloc_thread_cache_[access_thread.id];
+  auto& palloc_thread_cache =
+      palloc_thread_cache_[access_thread.id % palloc_thread_cache_.size()];
   while (palloc_thread_cache.segment_entry.size < aligned_size) {
     // allocate from free list space
     if (palloc_thread_cache.free_entry.size >= aligned_size) {

--- a/engine/pmem_allocator/pmem_allocator.cpp
+++ b/engine/pmem_allocator/pmem_allocator.cpp
@@ -237,8 +237,8 @@ SpaceEntry PMEMAllocator::Allocate(uint64_t size) {
   if (aligned_size > segment_size_) {
     return space_entry;
   }
-  auto& palloc_thread_cache =
-      palloc_thread_cache_[ThreadManager::ThreadID() % palloc_thread_cache_.size()];
+  auto& palloc_thread_cache = palloc_thread_cache_[ThreadManager::ThreadID() %
+                                                   palloc_thread_cache_.size()];
   while (palloc_thread_cache.segment_entry.size < aligned_size) {
     // allocate from free list space
     if (palloc_thread_cache.free_entry.size >= aligned_size) {
@@ -267,7 +267,8 @@ SpaceEntry PMEMAllocator::Allocate(uint64_t size) {
 
     if (palloc_thread_cache.free_entry.size > 0) {
       // Not a true free
-      LogAllocation(ThreadManager::ThreadID(), palloc_thread_cache.free_entry.size);
+      LogAllocation(ThreadManager::ThreadID(),
+                    palloc_thread_cache.free_entry.size);
       Free(palloc_thread_cache.free_entry);
       palloc_thread_cache.free_entry.size = 0;
     }
@@ -277,7 +278,8 @@ SpaceEntry PMEMAllocator::Allocate(uint64_t size) {
       continue;
     }
 
-    LogAllocation(ThreadManager::ThreadID(), palloc_thread_cache.segment_entry.size);
+    LogAllocation(ThreadManager::ThreadID(),
+                  palloc_thread_cache.segment_entry.size);
     Free(palloc_thread_cache.segment_entry);
     // allocate a new segment, add remainning space of the old one
     // to the free list

--- a/engine/pmem_allocator/pmem_allocator.hpp
+++ b/engine/pmem_allocator/pmem_allocator.hpp
@@ -116,21 +116,23 @@ class PMEMAllocator : public Allocator {
     }
   }
 
-  void LogAllocation(int tid, size_t sz) {
+  void LogAllocation(int64_t tid, size_t sz) {
     if (tid == -1) {
       global_allocated_size_.fetch_add(sz);
     } else {
       assert(tid >= 0);
-      palloc_thread_cache_[tid].allocated_sz += sz;
+      palloc_thread_cache_[tid % palloc_thread_cache_.size()].allocated_sz +=
+          sz;
     }
   }
 
-  void LogDeallocation(int tid, size_t sz) {
+  void LogDeallocation(int64_t tid, size_t sz) {
     if (tid == -1) {
       global_allocated_size_.fetch_sub(sz);
     } else {
       assert(tid >= 0);
-      palloc_thread_cache_[tid].allocated_sz -= sz;
+      palloc_thread_cache_[tid % palloc_thread_cache_.size()].allocated_sz -=
+          sz;
     }
   }
 

--- a/engine/pmem_allocator/pmem_allocator.hpp
+++ b/engine/pmem_allocator/pmem_allocator.hpp
@@ -112,7 +112,7 @@ class PMEMAllocator : public Allocator {
   void BatchFree(const std::vector<SpaceEntry>& entries) {
     if (entries.size() > 0) {
       uint64_t freed = free_list_.BatchPush(entries);
-      LogDeallocation(access_thread.id, freed);
+      LogDeallocation(ThreadManager::ThreadID(), freed);
     }
   }
 

--- a/engine/sorted_collection/rebuilder.cpp
+++ b/engine/sorted_collection/rebuilder.cpp
@@ -74,7 +74,7 @@ Status SortedCollectionRebuilder::AddElement(DLRecord* record) {
     }
   } else {
     if (segment_based_rebuild_ &&
-        ++rebuilder_thread_cache_[access_thread.id %
+        ++rebuilder_thread_cache_[ThreadManager::ThreadID() %
                                   rebuilder_thread_cache_.size()]
                     .visited_skiplists[Skiplist::FetchID(record)] %
                 kRestoreSkiplistStride ==
@@ -118,7 +118,6 @@ Status SortedCollectionRebuilder::Rollback(
 
 Status SortedCollectionRebuilder::initRebuildLists() {
   PMEMAllocator* pmem_allocator = kv_engine_->pmem_allocator_.get();
-  kv_engine_->thread_manager_->MaybeInitThread(access_thread);
 
   // Keep headers with same id together for recognize outdated ones
   auto cmp = [](const DLRecord* header1, const DLRecord* header2) {
@@ -251,7 +250,6 @@ Status SortedCollectionRebuilder::segmentBasedIndexRebuild() {
   std::vector<std::future<Status>> fs;
 
   auto rebuild_segments_index = [&]() -> Status {
-    kv_engine_->thread_manager_->MaybeInitThread(access_thread);
     for (auto iter = this->recovery_segments_.begin();
          iter != this->recovery_segments_.end(); iter++) {
       if (!iter->second.visited) {
@@ -486,7 +484,6 @@ Status SortedCollectionRebuilder::linkHighDramNodes(Skiplist* skiplist) {
 }
 
 Status SortedCollectionRebuilder::rebuildSkiplistIndex(Skiplist* skiplist) {
-  kv_engine_->thread_manager_->MaybeInitThread(access_thread);
   size_t num_elems = 0;
 
   Splice splice(skiplist);

--- a/engine/sorted_collection/rebuilder.cpp
+++ b/engine/sorted_collection/rebuilder.cpp
@@ -250,6 +250,7 @@ Status SortedCollectionRebuilder::segmentBasedIndexRebuild() {
   std::vector<std::future<Status>> fs;
 
   auto rebuild_segments_index = [&]() -> Status {
+    this_thread.id = next_tid_.fetch_add(1);
     for (auto iter = this->recovery_segments_.begin();
          iter != this->recovery_segments_.end(); iter++) {
       if (!iter->second.visited) {
@@ -459,6 +460,8 @@ void SortedCollectionRebuilder::linkSegmentDramNodes(SkiplistNode* start_node,
 }
 
 Status SortedCollectionRebuilder::linkHighDramNodes(Skiplist* skiplist) {
+  this_thread.id = next_tid_.fetch_add(1);
+
   Splice splice(skiplist);
   for (uint8_t i = 1; i <= kMaxHeight; i++) {
     splice.prevs[i] = skiplist->HeaderNode();
@@ -484,6 +487,7 @@ Status SortedCollectionRebuilder::linkHighDramNodes(Skiplist* skiplist) {
 }
 
 Status SortedCollectionRebuilder::rebuildSkiplistIndex(Skiplist* skiplist) {
+  this_thread.id = next_tid_.fetch_add(1);
   size_t num_elems = 0;
 
   Splice splice(skiplist);

--- a/engine/sorted_collection/rebuilder.hpp
+++ b/engine/sorted_collection/rebuilder.hpp
@@ -141,6 +141,12 @@ class SortedCollectionRebuilder {
   CollectionIDType max_recovered_id_ = 0;
   // Select elements as a segment start point for segment based rebuild every
   // kRestoreSkiplistStride elements per skiplist
+
+  // We manually allocate recovery thread id for no conflict in multi-thread
+  // recovering
+  // Todo: do not hard code
+  std::atomic<uint64_t> next_tid_{0};
+
   const uint64_t kRestoreSkiplistStride = 10000;
 };
 }  // namespace KVDK_NAMESPACE

--- a/engine/sorted_collection/rebuilder.hpp
+++ b/engine/sorted_collection/rebuilder.hpp
@@ -109,8 +109,8 @@ class SortedCollectionRebuilder {
 
   void addUnlinkedRecord(DLRecord* pmem_record) {
     assert(access_thread.id >= 0);
-    rebuilder_thread_cache_[access_thread.id].unlinked_records.push_back(
-        pmem_record);
+    rebuilder_thread_cache_[access_thread.id % rebuilder_thread_cache_.size()]
+        .unlinked_records.push_back(pmem_record);
   }
 
   struct ThreadCache {

--- a/engine/sorted_collection/rebuilder.hpp
+++ b/engine/sorted_collection/rebuilder.hpp
@@ -108,8 +108,8 @@ class SortedCollectionRebuilder {
                          PointerType index_type);
 
   void addUnlinkedRecord(DLRecord* pmem_record) {
-    assert(access_thread.id >= 0);
-    rebuilder_thread_cache_[access_thread.id % rebuilder_thread_cache_.size()]
+    assert(ThreadManager::ThreadID() >= 0);
+    rebuilder_thread_cache_[ThreadManager::ThreadID() % rebuilder_thread_cache_.size()]
         .unlinked_records.push_back(pmem_record);
   }
 

--- a/engine/sorted_collection/rebuilder.hpp
+++ b/engine/sorted_collection/rebuilder.hpp
@@ -109,7 +109,8 @@ class SortedCollectionRebuilder {
 
   void addUnlinkedRecord(DLRecord* pmem_record) {
     assert(ThreadManager::ThreadID() >= 0);
-    rebuilder_thread_cache_[ThreadManager::ThreadID() % rebuilder_thread_cache_.size()]
+    rebuilder_thread_cache_[ThreadManager::ThreadID() %
+                            rebuilder_thread_cache_.size()]
         .unlinked_records.push_back(pmem_record);
   }
 

--- a/engine/thread_manager.cpp
+++ b/engine/thread_manager.cpp
@@ -10,27 +10,15 @@ namespace KVDK_NAMESPACE {
 
 ThreadManager ThreadManager::manager_;
 
-void Thread::Release() {
-    id = -1;
-}
+void Thread::Release() { id = -1; }
 
 Thread::~Thread() { Release(); }
 
-Status ThreadManager::MaybeInitThread(Thread& t) {
+void ThreadManager::MaybeInitThread(Thread& t) {
   if (t.id < 0) {
-    if (!usable_id_.empty()) {
-      std::lock_guard<SpinMutex> lg(spin_);
-      if (!usable_id_.empty()) {
-        auto it = usable_id_.begin();
-        t.id = *it;
-        usable_id_.erase(it);
-        return Status::Ok;
-      }
-    }
     int id = ids_.fetch_add(1, std::memory_order_relaxed);
     t.id = id;
   }
-  return Status::Ok;
 }
 
 thread_local Thread access_thread;

--- a/engine/thread_manager.cpp
+++ b/engine/thread_manager.cpp
@@ -8,13 +8,42 @@
 
 namespace KVDK_NAMESPACE {
 
-ThreadManager ThreadManager::manager_;
+constexpr size_t kMaxRecycleID = 1024;
+
+std::shared_ptr<ThreadManager> ThreadManager::manager_(new ThreadManager);
+
+Thread::~Thread() {
+  if (manager != nullptr) {
+    manager->Release(*this);
+  }
+}
 
 void ThreadManager::MaybeInitThread(Thread& t) {
   if (t.id < 0) {
+    if (!recycle_id_.empty()) {
+      std::lock_guard<SpinMutex> lg(spin_);
+      if (recycle_id_.empty()) {
+        auto it = recycle_id_.begin();
+        t.manager = shared_from_this();
+        t.id = *it;
+        recycle_id_.erase(it);
+        return;
+      }
+    }
     int id = ids_.fetch_add(1, std::memory_order_relaxed);
+    t.manager = shared_from_this();
     t.id = id;
   }
+}
+
+void ThreadManager::Release(Thread& t) {
+  if (t.manager.get() == this && t.id >= 0 &&
+      recycle_id_.size() < kMaxRecycleID) {
+    std::lock_guard<SpinMutex> lg(spin_);
+    recycle_id_.insert(t.id);
+  }
+  t.id = -1;
+  t.manager = nullptr;
 }
 
 thread_local Thread this_thread;

--- a/engine/thread_manager.cpp
+++ b/engine/thread_manager.cpp
@@ -10,10 +10,6 @@ namespace KVDK_NAMESPACE {
 
 ThreadManager ThreadManager::manager_;
 
-void Thread::Release() { id = -1; }
-
-Thread::~Thread() { Release(); }
-
 void ThreadManager::MaybeInitThread(Thread& t) {
   if (t.id < 0) {
     int id = ids_.fetch_add(1, std::memory_order_relaxed);
@@ -21,6 +17,6 @@ void ThreadManager::MaybeInitThread(Thread& t) {
   }
 }
 
-thread_local Thread access_thread;
+thread_local Thread this_thread;
 
 }  // namespace KVDK_NAMESPACE

--- a/engine/thread_manager.cpp
+++ b/engine/thread_manager.cpp
@@ -8,13 +8,13 @@
 
 namespace KVDK_NAMESPACE {
 
+ThreadManager ThreadManager::manager_;
+
 void Thread::Release() {
-  assert(id == -1 || thread_manager != nullptr);
-  if (thread_manager) {
-    thread_manager->Release(*this);
-    thread_manager = nullptr;
+  if (id >= 0) {
+    ThreadManager::Get()->Release(*this);
+    id = -1;
   }
-  id = -1;
 }
 
 Thread::~Thread() { Release(); }
@@ -27,23 +27,17 @@ Status ThreadManager::MaybeInitThread(Thread& t) {
         auto it = usable_id_.begin();
         t.id = *it;
         usable_id_.erase(it);
-        t.thread_manager = shared_from_this();
         return Status::Ok;
       }
     }
     int id = ids_.fetch_add(1, std::memory_order_relaxed);
-    if (static_cast<unsigned>(id) >= max_threads_) {
-      return Status::TooManyAccessThreads;
-    }
     t.id = id;
-    t.thread_manager = shared_from_this();
   }
   return Status::Ok;
 }
 
 void ThreadManager::Release(const Thread& t) {
   if (t.id >= 0) {
-    assert(static_cast<unsigned>(t.id) < max_threads_);
     std::lock_guard<SpinMutex> lg(spin_);
     usable_id_.insert(t.id);
   }

--- a/engine/thread_manager.cpp
+++ b/engine/thread_manager.cpp
@@ -11,10 +11,7 @@ namespace KVDK_NAMESPACE {
 ThreadManager ThreadManager::manager_;
 
 void Thread::Release() {
-  if (id >= 0) {
-    ThreadManager::Get()->Release(*this);
     id = -1;
-  }
 }
 
 Thread::~Thread() { Release(); }
@@ -34,13 +31,6 @@ Status ThreadManager::MaybeInitThread(Thread& t) {
     t.id = id;
   }
   return Status::Ok;
-}
-
-void ThreadManager::Release(const Thread& t) {
-  if (t.id >= 0) {
-    std::lock_guard<SpinMutex> lg(spin_);
-    usable_id_.insert(t.id);
-  }
 }
 
 thread_local Thread access_thread;

--- a/engine/thread_manager.cpp
+++ b/engine/thread_manager.cpp
@@ -22,7 +22,7 @@ void ThreadManager::MaybeInitThread(Thread& t) {
   if (t.id < 0) {
     if (!recycle_id_.empty()) {
       std::lock_guard<SpinMutex> lg(spin_);
-      if (recycle_id_.empty()) {
+      if (!recycle_id_.empty()) {
         auto it = recycle_id_.begin();
         t.manager = shared_from_this();
         t.id = *it;

--- a/engine/thread_manager.hpp
+++ b/engine/thread_manager.hpp
@@ -23,22 +23,23 @@ struct Thread {
   int64_t id;
 };
 
+extern thread_local Thread access_thread;
+
 class ThreadManager : public std::enable_shared_from_this<ThreadManager> {
  public:
   static ThreadManager* Get() { return &manager_; }
-  Status MaybeInitThread(Thread& t);
-
-  void Release(const Thread& t);
+  static int64_t ThreadID() {
+    Get()->MaybeInitThread(access_thread);
+    return access_thread.id;
+  }
+  void MaybeInitThread(Thread& t);
 
  private:
   ThreadManager() : ids_(0) {}
 
   static ThreadManager manager_;
   std::atomic<int64_t> ids_;
-  std::unordered_set<int64_t> usable_id_;
   SpinMutex spin_;
 };
-
-extern thread_local Thread access_thread;
 
 }  // namespace KVDK_NAMESPACE

--- a/engine/thread_manager.hpp
+++ b/engine/thread_manager.hpp
@@ -18,19 +18,17 @@ class ThreadManager;
 struct Thread {
  public:
   Thread() : id(-1) {}
-  ~Thread();
-  void Release();
   int64_t id;
 };
 
-extern thread_local Thread access_thread;
+extern thread_local Thread this_thread;
 
 class ThreadManager : public std::enable_shared_from_this<ThreadManager> {
  public:
   static ThreadManager* Get() { return &manager_; }
   static int64_t ThreadID() {
-    Get()->MaybeInitThread(access_thread);
-    return access_thread.id;
+    Get()->MaybeInitThread(this_thread);
+    return this_thread.id;
   }
   void MaybeInitThread(Thread& t);
 

--- a/engine/thread_manager.hpp
+++ b/engine/thread_manager.hpp
@@ -17,26 +17,31 @@ class ThreadManager;
 
 struct Thread {
  public:
-  Thread() : id(-1) {}
+  Thread() : id(-1), manager(nullptr) {}
   int64_t id;
+  std::shared_ptr<ThreadManager> manager;
+
+  ~Thread();
 };
 
 extern thread_local Thread this_thread;
 
 class ThreadManager : public std::enable_shared_from_this<ThreadManager> {
  public:
-  static ThreadManager* Get() { return &manager_; }
+  static ThreadManager* Get() { return manager_.get(); }
   static int64_t ThreadID() {
     Get()->MaybeInitThread(this_thread);
     return this_thread.id;
   }
   void MaybeInitThread(Thread& t);
+  void Release(Thread& t);
 
  private:
-  ThreadManager() : ids_(0) {}
+  ThreadManager() : ids_(0), recycle_id_(), spin_() {}
 
-  static ThreadManager manager_;
+  static std::shared_ptr<ThreadManager> manager_;
   std::atomic<int64_t> ids_;
+  std::unordered_set<uint32_t> recycle_id_;
   SpinMutex spin_;
 };
 

--- a/engine/thread_manager.hpp
+++ b/engine/thread_manager.hpp
@@ -17,24 +17,25 @@ class ThreadManager;
 
 struct Thread {
  public:
-  Thread() : id(-1), thread_manager(nullptr) {}
+  Thread() : id(-1) {}
   ~Thread();
   void Release();
-  int id;
-  std::shared_ptr<ThreadManager> thread_manager;
+  int64_t id;
 };
 
 class ThreadManager : public std::enable_shared_from_this<ThreadManager> {
  public:
-  ThreadManager(uint32_t max_threads) : max_threads_(max_threads), ids_(0) {}
+  static ThreadManager* Get() { return &manager_; }
   Status MaybeInitThread(Thread& t);
 
   void Release(const Thread& t);
 
  private:
-  uint32_t max_threads_;
-  std::atomic<uint32_t> ids_;
-  std::unordered_set<uint32_t> usable_id_;
+  ThreadManager() : ids_(0) {}
+
+  static ThreadManager manager_;
+  std::atomic<int64_t> ids_;
+  std::unordered_set<int64_t> usable_id_;
   SpinMutex spin_;
 };
 

--- a/engine/version/version_controller.hpp
+++ b/engine/version/version_controller.hpp
@@ -204,18 +204,20 @@ class VersionController {
   inline void HoldLocalSnapshot() {
     kvdk_assert(ThreadManager::ThreadID() >= 0,
                 "Uninitialized thread in NewLocalSnapshot");
-    kvdk_assert(
-        version_thread_cache_[ThreadManager::ThreadID() % version_thread_cache_.size()]
-                .holding_snapshot.timestamp == kMaxTimestamp,
-        "Previous LocalSnapshot not released yet!");
-    version_thread_cache_[ThreadManager::ThreadID() % version_thread_cache_.size()]
+    kvdk_assert(version_thread_cache_[ThreadManager::ThreadID() %
+                                      version_thread_cache_.size()]
+                        .holding_snapshot.timestamp == kMaxTimestamp,
+                "Previous LocalSnapshot not released yet!");
+    version_thread_cache_[ThreadManager::ThreadID() %
+                          version_thread_cache_.size()]
         .holding_snapshot.timestamp = GetCurrentTimestamp();
   }
 
   inline void ReleaseLocalSnapshot() {
     kvdk_assert(ThreadManager::ThreadID() >= 0,
                 "Uninitialized thread in ReleaseLocalSnapshot");
-    version_thread_cache_[ThreadManager::ThreadID() % version_thread_cache_.size()]
+    version_thread_cache_[ThreadManager::ThreadID() %
+                          version_thread_cache_.size()]
         .holding_snapshot.timestamp = kMaxTimestamp;
   }
 

--- a/engine/version/version_controller.hpp
+++ b/engine/version/version_controller.hpp
@@ -82,7 +82,9 @@ class VersionController {
    public:
     LocalSnapshotHolder(VersionController* o) : owner_{o} {
       owner_->HoldLocalSnapshot();
-      ts_ = owner_->version_thread_cache_[access_thread.id]
+      ts_ = owner_
+                ->version_thread_cache_[access_thread.id %
+                                        owner_->version_thread_cache_.size()]
                 .holding_snapshot.timestamp;
     };
     LocalSnapshotHolder(LocalSnapshotHolder const&) = delete;
@@ -145,7 +147,9 @@ class VersionController {
     BatchWriteToken(VersionController* o)
         : owner_{o}, ts_{owner_->GetCurrentTimestamp()} {
       ts_ = owner_->GetCurrentTimestamp();
-      auto& tc = owner_->version_thread_cache_[access_thread.id];
+      auto& tc =
+          owner_->version_thread_cache_[access_thread.id %
+                                        owner_->version_thread_cache_.size()];
       kvdk_assert(tc.batch_write_ts == kMaxTimestamp, "");
       tc.batch_write_ts = ts_;
     }
@@ -158,7 +162,9 @@ class VersionController {
     }
     ~BatchWriteToken() {
       if (owner_ != nullptr) {
-        auto& tc = owner_->version_thread_cache_[access_thread.id];
+        auto& tc =
+            owner_->version_thread_cache_[access_thread.id %
+                                          owner_->version_thread_cache_.size()];
         tc.batch_write_ts = kMaxTimestamp;
       }
     }
@@ -196,23 +202,21 @@ class VersionController {
   }
 
   inline void HoldLocalSnapshot() {
-    kvdk_assert(access_thread.id >= 0 && static_cast<size_t>(access_thread.id) <
-                                             version_thread_cache_.size(),
+    kvdk_assert(access_thread.id >= 0,
                 "Uninitialized thread in NewLocalSnapshot");
     kvdk_assert(
-        version_thread_cache_[access_thread.id].holding_snapshot.timestamp ==
-            kMaxTimestamp,
+        version_thread_cache_[access_thread.id % version_thread_cache_.size()]
+                .holding_snapshot.timestamp == kMaxTimestamp,
         "Previous LocalSnapshot not released yet!");
-    version_thread_cache_[access_thread.id].holding_snapshot.timestamp =
-        GetCurrentTimestamp();
+    version_thread_cache_[access_thread.id % version_thread_cache_.size()]
+        .holding_snapshot.timestamp = GetCurrentTimestamp();
   }
 
   inline void ReleaseLocalSnapshot() {
-    kvdk_assert(access_thread.id >= 0 && static_cast<size_t>(access_thread.id) <
-                                             version_thread_cache_.size(),
+    kvdk_assert(access_thread.id >= 0,
                 "Uninitialized thread in ReleaseLocalSnapshot");
-    version_thread_cache_[access_thread.id].holding_snapshot.timestamp =
-        kMaxTimestamp;
+    version_thread_cache_[access_thread.id % version_thread_cache_.size()]
+        .holding_snapshot.timestamp = kMaxTimestamp;
   }
 
   inline const SnapshotImpl& GetLocalSnapshot(size_t thread_num) {
@@ -222,10 +226,11 @@ class VersionController {
   }
 
   inline const SnapshotImpl& GetLocalSnapshot() {
-    kvdk_assert(access_thread.id >= 0 && static_cast<size_t>(access_thread.id) <
-                                             version_thread_cache_.size(),
+    kvdk_assert(access_thread.id >= 0,
                 "Uninitialized thread in GetLocalSnapshot");
-    return version_thread_cache_[access_thread.id].holding_snapshot;
+    return version_thread_cache_[access_thread.id %
+                                 version_thread_cache_.size()]
+        .holding_snapshot;
   }
 
   // Create a new global snapshot

--- a/include/kvdk/configs.hpp
+++ b/include/kvdk/configs.hpp
@@ -31,11 +31,13 @@ struct SortedCollectionConfigs {
 };
 
 struct Configs {
-  // Max number of access threads to read/write data to kvdk instance.
+  // Max number of concurrent threads read/write the kvdk instance internally.
+  // Set it >= your CPU core number to get best performance
   //
-  // Notice that the allocated resources of a access thread would be released
-  // only if the thread exited or call KVEngine::ReleaseAccessThread().
-  uint64_t max_access_threads = 48;
+  // Notice:  you can call KVDK API with any number of threads, but if your
+  // parallel threads more than max_access_threads, the performance will be
+  // damaged due to synchronization cost
+  uint64_t max_access_threads = 64;
 
   // Size of PMem space to store KV data, this is not scalable in current
   // edition.

--- a/include/kvdk/engine.h
+++ b/include/kvdk/engine.h
@@ -63,7 +63,6 @@ extern KVDKStatus KVDKBackup(KVDKEngine* engine, const char* backup_path,
 extern KVDKStatus KVDKRestore(const char* name, const char* backup_log,
                               const KVDKConfigs* config, FILE* log_file,
                               KVDKEngine** engine);
-extern void KVDKReleaseAccessThread(KVDKEngine* engine);
 extern void KVDKCloseEngine(KVDKEngine* engine);
 extern void KVDKRemovePMemContents(const char* name);
 extern KVDKSnapshot* KVDKGetSnapshot(KVDKEngine* engine, int make_checkpoint);

--- a/include/kvdk/engine.hpp
+++ b/include/kvdk/engine.hpp
@@ -374,10 +374,6 @@ class Engine {
   // Release a sorted iterator
   virtual void SortedIteratorRelease(SortedIterator*) = 0;
 
-  // Release resources occupied by this access thread so new thread can take
-  // part. New write requests of this thread need to re-request write resources.
-  virtual void ReleaseAccessThread() = 0;
-
   // Register a customized comparator to the engine on runtime
   //
   // Return true on success, return false if a comparator of comparator_name

--- a/include/kvdk/types.h
+++ b/include/kvdk/types.h
@@ -65,7 +65,6 @@ __attribute__((unused)) static char const* KVDKValueTypeString[] = {
   GEN(NotSupported)         \
   GEN(PMemMapFileError)     \
   GEN(InvalidBatchSize)     \
-  GEN(TooManyAccessThreads) \
   GEN(InvalidDataSize)      \
   GEN(InvalidArgument)      \
   GEN(IOError)              \

--- a/java/benchmark/src/main/java/io/pmem/kvdk/benchmark/KVDKBenchmark.java
+++ b/java/benchmark/src/main/java/io/pmem/kvdk/benchmark/KVDKBenchmark.java
@@ -275,7 +275,6 @@ public class KVDKBenchmark {
             closeableObjects.add(nameHandle);
             kvdkEngine.sortedCreate(nameHandle);
         }
-        kvdkEngine.releaseAccessThread();
     }
 
     private void startTasks() {

--- a/java/kvdkjni/engine.cc
+++ b/java/kvdkjni/engine.cc
@@ -436,14 +436,3 @@ void Java_io_pmem_kvdk_Engine_batchWrite(JNIEnv* env, jobject,
     KVDK_NAMESPACE::KVDKExceptionJni::ThrowNew(env, s);
   }
 }
-
-/*
- * Class:     io_pmem_kvdk_Engine
- * Method:    releaseAccessThread
- * Signature: (JJ)V
- */
-void Java_io_pmem_kvdk_Engine_releaseAccessThread(JNIEnv*, jobject,
-                                                  jlong engine_handle) {
-  auto* engine = reinterpret_cast<KVDK_NAMESPACE::Engine*>(engine_handle);
-  engine->ReleaseAccessThread();
-}

--- a/java/kvdkjni/kvdkjni.h
+++ b/java/kvdkjni/kvdkjni.h
@@ -116,20 +116,18 @@ class StatusJni : public JavaClass {
         return 0xA;
       case KVDK_NAMESPACE::Status::InvalidBatchSize:
         return 0xB;
-      case KVDK_NAMESPACE::Status::TooManyAccessThreads:
-        return 0xC;
       case KVDK_NAMESPACE::Status::InvalidDataSize:
-        return 0xD;
+        return 0xC;
       case KVDK_NAMESPACE::Status::InvalidArgument:
-        return 0xE;
+        return 0xD;
       case KVDK_NAMESPACE::Status::IOError:
-        return 0xF;
+        return 0xE;
       case KVDK_NAMESPACE::Status::InvalidConfiguration:
-        return 0x10;
+        return 0xF;
       case KVDK_NAMESPACE::Status::Fail:
-        return 0x11;
+        return 0x10;
       case KVDK_NAMESPACE::Status::Abort:
-        return 0x12;
+        return 0x11;
       default:
         return 0x7F;  // undefined
     }

--- a/java/src/main/java/io/pmem/kvdk/Engine.java
+++ b/java/src/main/java/io/pmem/kvdk/Engine.java
@@ -10,295 +10,417 @@ import java.util.concurrent.atomic.AtomicReference;
 
 /** The KVDK engine, providing the APIs for Key-Value operations. */
 public class Engine extends KVDKObject {
-  private static final String atomicLibraryFileName = "libatomic.so.1";
-  private static final String stdLibraryFileName = "libstdc++.so.6";
-  private static final String jniLibraryFileName = System.mapLibraryName("kvdkjni");
+    private static final String atomicLibraryFileName = "libatomic.so.1";
+    private static final String stdLibraryFileName = "libstdc++.so.6";
+    private static final String jniLibraryFileName = System.mapLibraryName("kvdkjni");
 
-  /**
-   * Current state of loading native library. This must be defined before calling loading
-   * loadLibrary().
-   */
-  private static final AtomicReference<LibraryState> libraryLoaded =
-      new AtomicReference<>(LibraryState.NOT_LOADED);
+    /**
+     * Current state of loading native library. This must be defined before calling loading
+     * loadLibrary().
+     */
+    private static final AtomicReference<LibraryState> libraryLoaded =
+            new AtomicReference<>(LibraryState.NOT_LOADED);
 
-  static {
-    Engine.loadLibrary();
-  }
-
-  protected Engine(final long nativeHandle) {
-    super(nativeHandle);
-  }
-
-  /**
-   * Open a KVDK engine instance.
-   *
-   * @param path A directory to PMem
-   * @param configs KVDK engine configs
-   * @return
-   * @throws KVDKException
-   */
-  public static Engine open(final String path, final Configs configs) throws KVDKException {
-    final Engine engine = new Engine(open(path, configs.getNativeHandle()));
-    return engine;
-  }
-
-  public void put(final byte[] key, final byte[] value) throws KVDKException {
-    WriteOptions defaulWriteOptions = new WriteOptions();
-    put(nativeHandle_, key, 0, key.length, value, 0, value.length,
-        defaulWriteOptions.getTtlInMillis(), defaulWriteOptions.isUpdateTtlIfExisted());
-  }
-
-  public void put(final byte[] key, int keyOffset, int keyLength, final byte[] value,
-      int valueOffset, int valueLength) throws KVDKException {
-    WriteOptions defaulWriteOptions = new WriteOptions();
-    put(nativeHandle_, key, keyOffset, keyLength, value, valueOffset, valueLength,
-        defaulWriteOptions.getTtlInMillis(), defaulWriteOptions.isUpdateTtlIfExisted());
-  }
-
-  public void put(final byte[] key, final byte[] value, final WriteOptions wOptions)
-      throws KVDKException {
-    put(nativeHandle_, key, 0, key.length, value, 0, value.length, wOptions.getTtlInMillis(),
-        wOptions.isUpdateTtlIfExisted());
-  }
-
-  public void put(final byte[] key, int keyOffset, int keyLength, final byte[] value,
-      int valueOffset, int valueLength, final WriteOptions wOptions) throws KVDKException {
-    put(nativeHandle_, key, keyOffset, keyLength, value, valueOffset, valueLength,
-        wOptions.getTtlInMillis(), wOptions.isUpdateTtlIfExisted());
-  }
-
-  public void expire(final byte[] key, final long ttlInMillis) throws KVDKException {
-    expire(nativeHandle_, key, 0, key.length, ttlInMillis);
-  }
-
-  public void expire(final byte[] key, int keyOffset, int keyLength, final long ttlInMillis)
-      throws KVDKException {
-    expire(nativeHandle_, key, keyOffset, keyLength, ttlInMillis);
-  }
-
-  public void expire(final NativeBytesHandle nameHandle, final long ttlInMillis)
-      throws KVDKException {
-    expire(nativeHandle_, nameHandle.getNativeHandle(), nameHandle.getLength(), ttlInMillis);
-  }
-
-  /**
-   * @param key
-   * @return Value as byte array, null if the specified key doesn't exist.
-   * @throws KVDKException
-   */
-  public byte[] get(final byte[] key) throws KVDKException {
-    return get(nativeHandle_, key, 0, key.length);
-  }
-
-  /**
-   * @param key
-   * @return Value as byte array, null if the specified key doesn't exist.
-   * @throws KVDKException
-   */
-  public byte[] get(final byte[] key, int keyOffset, int keyLength) throws KVDKException {
-    return get(nativeHandle_, key, keyOffset, keyLength);
-  }
-
-  public void delete(final byte[] key) throws KVDKException {
-    delete(nativeHandle_, key, 0, key.length);
-  }
-
-  public void delete(final byte[] key, int keyOffset, int keyLength) throws KVDKException {
-    delete(nativeHandle_, key, keyOffset, keyLength);
-  }
-
-  public void sortedCreate(final NativeBytesHandle nameHandle) throws KVDKException {
-    sortedCreate(nativeHandle_, nameHandle.getNativeHandle(), nameHandle.getLength());
-  }
-
-  public void sortedDestroy(final NativeBytesHandle nameHandle) throws KVDKException {
-    sortedDestroy(nativeHandle_, nameHandle.getNativeHandle(), nameHandle.getLength());
-  }
-
-  public long sortedSize(final NativeBytesHandle nameHandle) throws KVDKException {
-    return sortedSize(nativeHandle_, nameHandle.getNativeHandle(), nameHandle.getLength());
-  }
-
-  public void sortedPut(final NativeBytesHandle nameHandle, final byte[] key, final byte[] value)
-      throws KVDKException {
-    sortedPut(nativeHandle_, nameHandle.getNativeHandle(), nameHandle.getLength(), key, 0,
-        key.length, value, 0, value.length);
-  }
-
-  public void sortedPut(final NativeBytesHandle nameHandle, final byte[] key, int keyOffset,
-      int keyLength, final byte[] value, int valueOffset, int valueLength) throws KVDKException {
-    sortedPut(nativeHandle_, nameHandle.getNativeHandle(), nameHandle.getLength(), key, keyOffset,
-        keyLength, value, valueOffset, valueLength);
-  }
-
-  /**
-   * @param nameHandle
-   * @param key
-   * @return Value as byte array, null if the specified key doesn't exist.
-   * @throws KVDKException
-   */
-  public byte[] sortedGet(final NativeBytesHandle nameHandle, final byte[] key)
-      throws KVDKException {
-    return sortedGet(
-        nativeHandle_, nameHandle.getNativeHandle(), nameHandle.getLength(), key, 0, key.length);
-  }
-
-  /**
-   * @param nameHandle
-   * @param key
-   * @return Value as byte array, null if the specified key doesn't exist.
-   * @throws KVDKException
-   */
-  public byte[] sortedGet(final NativeBytesHandle nameHandle, final byte[] key, int keyOffset,
-      int keyLength) throws KVDKException {
-    return sortedGet(nativeHandle_, nameHandle.getNativeHandle(), nameHandle.getLength(), key,
-        keyOffset, keyLength);
-  }
-
-  public void sortedDelete(final NativeBytesHandle nameHandle, final byte[] key)
-      throws KVDKException {
-    sortedDelete(
-        nativeHandle_, nameHandle.getNativeHandle(), nameHandle.getLength(), key, 0, key.length);
-  }
-
-  public void sortedDelete(final NativeBytesHandle nameHandle, final byte[] key, int keyOffset,
-      int keyLength) throws KVDKException {
-    sortedDelete(nativeHandle_, nameHandle.getNativeHandle(), nameHandle.getLength(), key,
-        keyOffset, keyLength);
-  }
-
-  public Iterator sortedIteratorCreate(final NativeBytesHandle nameHandle) throws KVDKException {
-    long iteratorHandle =
-        sortedIteratorCreate(nativeHandle_, nameHandle.getNativeHandle(), nameHandle.getLength());
-
-    return new Iterator(iteratorHandle, nativeHandle_);
-  }
-
-  public void sortedIteratorRelease(final Iterator iterator) throws KVDKException {
-    iterator.close();
-  }
-
-  public WriteBatch writeBatchCreate() {
-    long batchHandle = writeBatchCreate(nativeHandle_);
-    return new WriteBatch(batchHandle);
-  }
-
-  public void batchWrite(WriteBatch batch) throws KVDKException {
-    batchWrite(nativeHandle_, batch.getNativeHandle());
-  }
-
-  // Native methods
-  @Override protected final native void closeInternal(long handle);
-
-  private static native long open(final String path, final long cfg_handle) throws KVDKException;
-
-  private native void put(long handle, byte[] key, int keyOffset, int keyLength, byte[] value,
-      int valueOffset, int valueLength, long ttl, boolean updateTtlIfExisted);
-
-  private native void expire(
-      long handle, byte[] key, int keyOffset, int keyLength, long ttlInMillis);
-
-  private native void expire(long handle, long nameHandle, int nameLenth, long ttlInMillis);
-
-  private native byte[] get(long handle, byte[] key, int keyOffset, int keyLength);
-
-  private native void delete(long handle, byte[] key, int keyOffset, int keyLength);
-
-  private native void sortedCreate(long engineHandle, long nameHandle, int nameLenth);
-
-  private native void sortedDestroy(long engineHandle, long nameHandle, int nameLenth);
-
-  private native long sortedSize(long engineHandle, long nameHandle, int nameLenth);
-
-  private native void sortedPut(long engineHandle, long nameHandle, int nameLenth, byte[] key,
-      int keyOffset, int keyLength, byte[] value, int valueOffset, int valueLength);
-
-  private native byte[] sortedGet(
-      long engineHandle, long nameHandle, int nameLenth, byte[] key, int keyOffset, int keyLength);
-
-  private native void sortedDelete(
-      long engineHandle, long nameHandle, int nameLenth, byte[] key, int keyOffset, int keyLength);
-
-  private native long sortedIteratorCreate(long engineHandle, long nameHandle, int nameLenth);
-
-  private native long writeBatchCreate(long handle);
-
-  private native void batchWrite(long engineHandle, long batchHandle);
-
-  private enum LibraryState { NOT_LOADED, LOADING, LOADED }
-
-  /**
-   * Loads the necessary library files. Calling this method twice will have no effect. By default
-   * the method extracts the shared library for loading at java.io.tmpdir, however, you can
-   * override this temporary location by setting the environment variable KVDK_SHARED_LIB_DIR.
-   */
-  public static void loadLibrary() {
-    if (libraryLoaded.get() == LibraryState.LOADED) {
-      return;
+    static {
+        Engine.loadLibrary();
     }
 
-    if (libraryLoaded.compareAndSet(LibraryState.NOT_LOADED, LibraryState.LOADING)) {
-      final String tmpDir = System.getenv("KVDK_SHARED_LIB_DIR");
-
-      try {
-        NativeLibraryLoader.getInstance().loadLibrary(tmpDir);
-      } catch (final IOException e) {
-        libraryLoaded.set(LibraryState.NOT_LOADED);
-        throw new RuntimeException("Unable to load the KVDK shared library", e);
-      }
-
-      libraryLoaded.set(LibraryState.LOADED);
-      return;
+    protected Engine(final long nativeHandle) {
+        super(nativeHandle);
     }
 
-    while (libraryLoaded.get() == LibraryState.LOADING) {
-      try {
-        Thread.sleep(10);
-      } catch (final InterruptedException e) {
-        // ignore
-      }
-    }
-  }
-
-  /**
-   * Tries to load the necessary library files from the given list of directories.
-   *
-   * @param paths a list of strings where each describes a directory of a library.
-   */
-  public static void loadLibrary(final List<String> paths) {
-    if (libraryLoaded.get() == LibraryState.LOADED) {
-      return;
+    /**
+     * Open a KVDK engine instance.
+     *
+     * @param path A directory to PMem
+     * @param configs KVDK engine configs
+     * @return
+     * @throws KVDKException
+     */
+    public static Engine open(final String path, final Configs configs) throws KVDKException {
+        final Engine engine = new Engine(open(path, configs.getNativeHandle()));
+        return engine;
     }
 
-    if (libraryLoaded.compareAndSet(LibraryState.NOT_LOADED, LibraryState.LOADING)) {
-      boolean success = false;
-      UnsatisfiedLinkError err = null;
-      for (final String path : paths) {
-        try {
-          System.load(path + "/" + atomicLibraryFileName);
-          System.load(path + "/" + stdLibraryFileName);
-          System.load(path + "/" + jniLibraryFileName);
-          success = true;
-          break;
-        } catch (final UnsatisfiedLinkError e) {
-          err = e;
+    public void put(final byte[] key, final byte[] value) throws KVDKException {
+        WriteOptions defaulWriteOptions = new WriteOptions();
+        put(
+                nativeHandle_,
+                key,
+                0,
+                key.length,
+                value,
+                0,
+                value.length,
+                defaulWriteOptions.getTtlInMillis(),
+                defaulWriteOptions.isUpdateTtlIfExisted());
+    }
+
+    public void put(
+            final byte[] key,
+            int keyOffset,
+            int keyLength,
+            final byte[] value,
+            int valueOffset,
+            int valueLength)
+            throws KVDKException {
+        WriteOptions defaulWriteOptions = new WriteOptions();
+        put(
+                nativeHandle_,
+                key,
+                keyOffset,
+                keyLength,
+                value,
+                valueOffset,
+                valueLength,
+                defaulWriteOptions.getTtlInMillis(),
+                defaulWriteOptions.isUpdateTtlIfExisted());
+    }
+
+    public void put(final byte[] key, final byte[] value, final WriteOptions wOptions)
+            throws KVDKException {
+        put(
+                nativeHandle_,
+                key,
+                0,
+                key.length,
+                value,
+                0,
+                value.length,
+                wOptions.getTtlInMillis(),
+                wOptions.isUpdateTtlIfExisted());
+    }
+
+    public void put(
+            final byte[] key,
+            int keyOffset,
+            int keyLength,
+            final byte[] value,
+            int valueOffset,
+            int valueLength,
+            final WriteOptions wOptions)
+            throws KVDKException {
+        put(
+                nativeHandle_,
+                key,
+                keyOffset,
+                keyLength,
+                value,
+                valueOffset,
+                valueLength,
+                wOptions.getTtlInMillis(),
+                wOptions.isUpdateTtlIfExisted());
+    }
+
+    public void expire(final byte[] key, final long ttlInMillis) throws KVDKException {
+        expire(nativeHandle_, key, 0, key.length, ttlInMillis);
+    }
+
+    public void expire(final byte[] key, int keyOffset, int keyLength, final long ttlInMillis)
+            throws KVDKException {
+        expire(nativeHandle_, key, keyOffset, keyLength, ttlInMillis);
+    }
+
+    public void expire(final NativeBytesHandle nameHandle, final long ttlInMillis)
+            throws KVDKException {
+        expire(nativeHandle_, nameHandle.getNativeHandle(), nameHandle.getLength(), ttlInMillis);
+    }
+
+    /**
+     * @param key
+     * @return Value as byte array, null if the specified key doesn't exist.
+     * @throws KVDKException
+     */
+    public byte[] get(final byte[] key) throws KVDKException {
+        return get(nativeHandle_, key, 0, key.length);
+    }
+
+    /**
+     * @param key
+     * @return Value as byte array, null if the specified key doesn't exist.
+     * @throws KVDKException
+     */
+    public byte[] get(final byte[] key, int keyOffset, int keyLength) throws KVDKException {
+        return get(nativeHandle_, key, keyOffset, keyLength);
+    }
+
+    public void delete(final byte[] key) throws KVDKException {
+        delete(nativeHandle_, key, 0, key.length);
+    }
+
+    public void delete(final byte[] key, int keyOffset, int keyLength) throws KVDKException {
+        delete(nativeHandle_, key, keyOffset, keyLength);
+    }
+
+    public void sortedCreate(final NativeBytesHandle nameHandle) throws KVDKException {
+        sortedCreate(nativeHandle_, nameHandle.getNativeHandle(), nameHandle.getLength());
+    }
+
+    public void sortedDestroy(final NativeBytesHandle nameHandle) throws KVDKException {
+        sortedDestroy(nativeHandle_, nameHandle.getNativeHandle(), nameHandle.getLength());
+    }
+
+    public long sortedSize(final NativeBytesHandle nameHandle) throws KVDKException {
+        return sortedSize(nativeHandle_, nameHandle.getNativeHandle(), nameHandle.getLength());
+    }
+
+    public void sortedPut(final NativeBytesHandle nameHandle, final byte[] key, final byte[] value)
+            throws KVDKException {
+        sortedPut(
+                nativeHandle_,
+                nameHandle.getNativeHandle(),
+                nameHandle.getLength(),
+                key,
+                0,
+                key.length,
+                value,
+                0,
+                value.length);
+    }
+
+    public void sortedPut(
+            final NativeBytesHandle nameHandle,
+            final byte[] key,
+            int keyOffset,
+            int keyLength,
+            final byte[] value,
+            int valueOffset,
+            int valueLength)
+            throws KVDKException {
+        sortedPut(
+                nativeHandle_,
+                nameHandle.getNativeHandle(),
+                nameHandle.getLength(),
+                key,
+                keyOffset,
+                keyLength,
+                value,
+                valueOffset,
+                valueLength);
+    }
+
+    /**
+     * @param nameHandle
+     * @param key
+     * @return Value as byte array, null if the specified key doesn't exist.
+     * @throws KVDKException
+     */
+    public byte[] sortedGet(final NativeBytesHandle nameHandle, final byte[] key)
+            throws KVDKException {
+        return sortedGet(
+                nativeHandle_,
+                nameHandle.getNativeHandle(),
+                nameHandle.getLength(),
+                key,
+                0,
+                key.length);
+    }
+
+    /**
+     * @param nameHandle
+     * @param key
+     * @return Value as byte array, null if the specified key doesn't exist.
+     * @throws KVDKException
+     */
+    public byte[] sortedGet(
+            final NativeBytesHandle nameHandle, final byte[] key, int keyOffset, int keyLength)
+            throws KVDKException {
+        return sortedGet(
+                nativeHandle_,
+                nameHandle.getNativeHandle(),
+                nameHandle.getLength(),
+                key,
+                keyOffset,
+                keyLength);
+    }
+
+    public void sortedDelete(final NativeBytesHandle nameHandle, final byte[] key)
+            throws KVDKException {
+        sortedDelete(
+                nativeHandle_,
+                nameHandle.getNativeHandle(),
+                nameHandle.getLength(),
+                key,
+                0,
+                key.length);
+    }
+
+    public void sortedDelete(
+            final NativeBytesHandle nameHandle, final byte[] key, int keyOffset, int keyLength)
+            throws KVDKException {
+        sortedDelete(
+                nativeHandle_,
+                nameHandle.getNativeHandle(),
+                nameHandle.getLength(),
+                key,
+                keyOffset,
+                keyLength);
+    }
+
+    public Iterator sortedIteratorCreate(final NativeBytesHandle nameHandle) throws KVDKException {
+        long iteratorHandle =
+                sortedIteratorCreate(
+                        nativeHandle_, nameHandle.getNativeHandle(), nameHandle.getLength());
+
+        return new Iterator(iteratorHandle, nativeHandle_);
+    }
+
+    public void sortedIteratorRelease(final Iterator iterator) throws KVDKException {
+        iterator.close();
+    }
+
+    public WriteBatch writeBatchCreate() {
+        long batchHandle = writeBatchCreate(nativeHandle_);
+        return new WriteBatch(batchHandle);
+    }
+
+    public void batchWrite(WriteBatch batch) throws KVDKException {
+        batchWrite(nativeHandle_, batch.getNativeHandle());
+    }
+
+    // Native methods
+    @Override
+    protected final native void closeInternal(long handle);
+
+    private static native long open(final String path, final long cfg_handle) throws KVDKException;
+
+    private native void put(
+            long handle,
+            byte[] key,
+            int keyOffset,
+            int keyLength,
+            byte[] value,
+            int valueOffset,
+            int valueLength,
+            long ttl,
+            boolean updateTtlIfExisted);
+
+    private native void expire(
+            long handle, byte[] key, int keyOffset, int keyLength, long ttlInMillis);
+
+    private native void expire(long handle, long nameHandle, int nameLenth, long ttlInMillis);
+
+    private native byte[] get(long handle, byte[] key, int keyOffset, int keyLength);
+
+    private native void delete(long handle, byte[] key, int keyOffset, int keyLength);
+
+    private native void sortedCreate(long engineHandle, long nameHandle, int nameLenth);
+
+    private native void sortedDestroy(long engineHandle, long nameHandle, int nameLenth);
+
+    private native long sortedSize(long engineHandle, long nameHandle, int nameLenth);
+
+    private native void sortedPut(
+            long engineHandle,
+            long nameHandle,
+            int nameLenth,
+            byte[] key,
+            int keyOffset,
+            int keyLength,
+            byte[] value,
+            int valueOffset,
+            int valueLength);
+
+    private native byte[] sortedGet(
+            long engineHandle,
+            long nameHandle,
+            int nameLenth,
+            byte[] key,
+            int keyOffset,
+            int keyLength);
+
+    private native void sortedDelete(
+            long engineHandle,
+            long nameHandle,
+            int nameLenth,
+            byte[] key,
+            int keyOffset,
+            int keyLength);
+
+    private native long sortedIteratorCreate(long engineHandle, long nameHandle, int nameLenth);
+
+    private native long writeBatchCreate(long handle);
+
+    private native void batchWrite(long engineHandle, long batchHandle);
+
+    private enum LibraryState {
+        NOT_LOADED,
+        LOADING,
+        LOADED
+    }
+
+    /**
+     * Loads the necessary library files. Calling this method twice will have no effect. By default
+     * the method extracts the shared library for loading at java.io.tmpdir, however, you can
+     * override this temporary location by setting the environment variable KVDK_SHARED_LIB_DIR.
+     */
+    public static void loadLibrary() {
+        if (libraryLoaded.get() == LibraryState.LOADED) {
+            return;
         }
-      }
-      if (!success) {
-        libraryLoaded.set(LibraryState.NOT_LOADED);
-        throw err;
-      }
 
-      libraryLoaded.set(LibraryState.LOADED);
-      return;
+        if (libraryLoaded.compareAndSet(LibraryState.NOT_LOADED, LibraryState.LOADING)) {
+            final String tmpDir = System.getenv("KVDK_SHARED_LIB_DIR");
+
+            try {
+                NativeLibraryLoader.getInstance().loadLibrary(tmpDir);
+            } catch (final IOException e) {
+                libraryLoaded.set(LibraryState.NOT_LOADED);
+                throw new RuntimeException("Unable to load the KVDK shared library", e);
+            }
+
+            libraryLoaded.set(LibraryState.LOADED);
+            return;
+        }
+
+        while (libraryLoaded.get() == LibraryState.LOADING) {
+            try {
+                Thread.sleep(10);
+            } catch (final InterruptedException e) {
+                // ignore
+            }
+        }
     }
 
-    while (libraryLoaded.get() == LibraryState.LOADING) {
-      try {
-        Thread.sleep(10);
-      } catch (final InterruptedException e) {
-        // ignore
-      }
+    /**
+     * Tries to load the necessary library files from the given list of directories.
+     *
+     * @param paths a list of strings where each describes a directory of a library.
+     */
+    public static void loadLibrary(final List<String> paths) {
+        if (libraryLoaded.get() == LibraryState.LOADED) {
+            return;
+        }
+
+        if (libraryLoaded.compareAndSet(LibraryState.NOT_LOADED, LibraryState.LOADING)) {
+            boolean success = false;
+            UnsatisfiedLinkError err = null;
+            for (final String path : paths) {
+                try {
+                    System.load(path + "/" + atomicLibraryFileName);
+                    System.load(path + "/" + stdLibraryFileName);
+                    System.load(path + "/" + jniLibraryFileName);
+                    success = true;
+                    break;
+                } catch (final UnsatisfiedLinkError e) {
+                    err = e;
+                }
+            }
+            if (!success) {
+                libraryLoaded.set(LibraryState.NOT_LOADED);
+                throw err;
+            }
+
+            libraryLoaded.set(LibraryState.LOADED);
+            return;
+        }
+
+        while (libraryLoaded.get() == LibraryState.LOADING) {
+            try {
+                Thread.sleep(10);
+            } catch (final InterruptedException e) {
+                // ignore
+            }
+        }
     }
-  }
 }

--- a/java/src/main/java/io/pmem/kvdk/Engine.java
+++ b/java/src/main/java/io/pmem/kvdk/Engine.java
@@ -10,423 +10,295 @@ import java.util.concurrent.atomic.AtomicReference;
 
 /** The KVDK engine, providing the APIs for Key-Value operations. */
 public class Engine extends KVDKObject {
-    private static final String atomicLibraryFileName = "libatomic.so.1";
-    private static final String stdLibraryFileName = "libstdc++.so.6";
-    private static final String jniLibraryFileName = System.mapLibraryName("kvdkjni");
+  private static final String atomicLibraryFileName = "libatomic.so.1";
+  private static final String stdLibraryFileName = "libstdc++.so.6";
+  private static final String jniLibraryFileName = System.mapLibraryName("kvdkjni");
 
-    /**
-     * Current state of loading native library. This must be defined before calling loading
-     * loadLibrary().
-     */
-    private static final AtomicReference<LibraryState> libraryLoaded =
-            new AtomicReference<>(LibraryState.NOT_LOADED);
+  /**
+   * Current state of loading native library. This must be defined before calling loading
+   * loadLibrary().
+   */
+  private static final AtomicReference<LibraryState> libraryLoaded =
+      new AtomicReference<>(LibraryState.NOT_LOADED);
 
-    static {
-        Engine.loadLibrary();
+  static {
+    Engine.loadLibrary();
+  }
+
+  protected Engine(final long nativeHandle) {
+    super(nativeHandle);
+  }
+
+  /**
+   * Open a KVDK engine instance.
+   *
+   * @param path A directory to PMem
+   * @param configs KVDK engine configs
+   * @return
+   * @throws KVDKException
+   */
+  public static Engine open(final String path, final Configs configs) throws KVDKException {
+    final Engine engine = new Engine(open(path, configs.getNativeHandle()));
+    return engine;
+  }
+
+  public void put(final byte[] key, final byte[] value) throws KVDKException {
+    WriteOptions defaulWriteOptions = new WriteOptions();
+    put(nativeHandle_, key, 0, key.length, value, 0, value.length,
+        defaulWriteOptions.getTtlInMillis(), defaulWriteOptions.isUpdateTtlIfExisted());
+  }
+
+  public void put(final byte[] key, int keyOffset, int keyLength, final byte[] value,
+      int valueOffset, int valueLength) throws KVDKException {
+    WriteOptions defaulWriteOptions = new WriteOptions();
+    put(nativeHandle_, key, keyOffset, keyLength, value, valueOffset, valueLength,
+        defaulWriteOptions.getTtlInMillis(), defaulWriteOptions.isUpdateTtlIfExisted());
+  }
+
+  public void put(final byte[] key, final byte[] value, final WriteOptions wOptions)
+      throws KVDKException {
+    put(nativeHandle_, key, 0, key.length, value, 0, value.length, wOptions.getTtlInMillis(),
+        wOptions.isUpdateTtlIfExisted());
+  }
+
+  public void put(final byte[] key, int keyOffset, int keyLength, final byte[] value,
+      int valueOffset, int valueLength, final WriteOptions wOptions) throws KVDKException {
+    put(nativeHandle_, key, keyOffset, keyLength, value, valueOffset, valueLength,
+        wOptions.getTtlInMillis(), wOptions.isUpdateTtlIfExisted());
+  }
+
+  public void expire(final byte[] key, final long ttlInMillis) throws KVDKException {
+    expire(nativeHandle_, key, 0, key.length, ttlInMillis);
+  }
+
+  public void expire(final byte[] key, int keyOffset, int keyLength, final long ttlInMillis)
+      throws KVDKException {
+    expire(nativeHandle_, key, keyOffset, keyLength, ttlInMillis);
+  }
+
+  public void expire(final NativeBytesHandle nameHandle, final long ttlInMillis)
+      throws KVDKException {
+    expire(nativeHandle_, nameHandle.getNativeHandle(), nameHandle.getLength(), ttlInMillis);
+  }
+
+  /**
+   * @param key
+   * @return Value as byte array, null if the specified key doesn't exist.
+   * @throws KVDKException
+   */
+  public byte[] get(final byte[] key) throws KVDKException {
+    return get(nativeHandle_, key, 0, key.length);
+  }
+
+  /**
+   * @param key
+   * @return Value as byte array, null if the specified key doesn't exist.
+   * @throws KVDKException
+   */
+  public byte[] get(final byte[] key, int keyOffset, int keyLength) throws KVDKException {
+    return get(nativeHandle_, key, keyOffset, keyLength);
+  }
+
+  public void delete(final byte[] key) throws KVDKException {
+    delete(nativeHandle_, key, 0, key.length);
+  }
+
+  public void delete(final byte[] key, int keyOffset, int keyLength) throws KVDKException {
+    delete(nativeHandle_, key, keyOffset, keyLength);
+  }
+
+  public void sortedCreate(final NativeBytesHandle nameHandle) throws KVDKException {
+    sortedCreate(nativeHandle_, nameHandle.getNativeHandle(), nameHandle.getLength());
+  }
+
+  public void sortedDestroy(final NativeBytesHandle nameHandle) throws KVDKException {
+    sortedDestroy(nativeHandle_, nameHandle.getNativeHandle(), nameHandle.getLength());
+  }
+
+  public long sortedSize(final NativeBytesHandle nameHandle) throws KVDKException {
+    return sortedSize(nativeHandle_, nameHandle.getNativeHandle(), nameHandle.getLength());
+  }
+
+  public void sortedPut(final NativeBytesHandle nameHandle, final byte[] key, final byte[] value)
+      throws KVDKException {
+    sortedPut(nativeHandle_, nameHandle.getNativeHandle(), nameHandle.getLength(), key, 0,
+        key.length, value, 0, value.length);
+  }
+
+  public void sortedPut(final NativeBytesHandle nameHandle, final byte[] key, int keyOffset,
+      int keyLength, final byte[] value, int valueOffset, int valueLength) throws KVDKException {
+    sortedPut(nativeHandle_, nameHandle.getNativeHandle(), nameHandle.getLength(), key, keyOffset,
+        keyLength, value, valueOffset, valueLength);
+  }
+
+  /**
+   * @param nameHandle
+   * @param key
+   * @return Value as byte array, null if the specified key doesn't exist.
+   * @throws KVDKException
+   */
+  public byte[] sortedGet(final NativeBytesHandle nameHandle, final byte[] key)
+      throws KVDKException {
+    return sortedGet(
+        nativeHandle_, nameHandle.getNativeHandle(), nameHandle.getLength(), key, 0, key.length);
+  }
+
+  /**
+   * @param nameHandle
+   * @param key
+   * @return Value as byte array, null if the specified key doesn't exist.
+   * @throws KVDKException
+   */
+  public byte[] sortedGet(final NativeBytesHandle nameHandle, final byte[] key, int keyOffset,
+      int keyLength) throws KVDKException {
+    return sortedGet(nativeHandle_, nameHandle.getNativeHandle(), nameHandle.getLength(), key,
+        keyOffset, keyLength);
+  }
+
+  public void sortedDelete(final NativeBytesHandle nameHandle, final byte[] key)
+      throws KVDKException {
+    sortedDelete(
+        nativeHandle_, nameHandle.getNativeHandle(), nameHandle.getLength(), key, 0, key.length);
+  }
+
+  public void sortedDelete(final NativeBytesHandle nameHandle, final byte[] key, int keyOffset,
+      int keyLength) throws KVDKException {
+    sortedDelete(nativeHandle_, nameHandle.getNativeHandle(), nameHandle.getLength(), key,
+        keyOffset, keyLength);
+  }
+
+  public Iterator sortedIteratorCreate(final NativeBytesHandle nameHandle) throws KVDKException {
+    long iteratorHandle =
+        sortedIteratorCreate(nativeHandle_, nameHandle.getNativeHandle(), nameHandle.getLength());
+
+    return new Iterator(iteratorHandle, nativeHandle_);
+  }
+
+  public void sortedIteratorRelease(final Iterator iterator) throws KVDKException {
+    iterator.close();
+  }
+
+  public WriteBatch writeBatchCreate() {
+    long batchHandle = writeBatchCreate(nativeHandle_);
+    return new WriteBatch(batchHandle);
+  }
+
+  public void batchWrite(WriteBatch batch) throws KVDKException {
+    batchWrite(nativeHandle_, batch.getNativeHandle());
+  }
+
+  // Native methods
+  @Override protected final native void closeInternal(long handle);
+
+  private static native long open(final String path, final long cfg_handle) throws KVDKException;
+
+  private native void put(long handle, byte[] key, int keyOffset, int keyLength, byte[] value,
+      int valueOffset, int valueLength, long ttl, boolean updateTtlIfExisted);
+
+  private native void expire(
+      long handle, byte[] key, int keyOffset, int keyLength, long ttlInMillis);
+
+  private native void expire(long handle, long nameHandle, int nameLenth, long ttlInMillis);
+
+  private native byte[] get(long handle, byte[] key, int keyOffset, int keyLength);
+
+  private native void delete(long handle, byte[] key, int keyOffset, int keyLength);
+
+  private native void sortedCreate(long engineHandle, long nameHandle, int nameLenth);
+
+  private native void sortedDestroy(long engineHandle, long nameHandle, int nameLenth);
+
+  private native long sortedSize(long engineHandle, long nameHandle, int nameLenth);
+
+  private native void sortedPut(long engineHandle, long nameHandle, int nameLenth, byte[] key,
+      int keyOffset, int keyLength, byte[] value, int valueOffset, int valueLength);
+
+  private native byte[] sortedGet(
+      long engineHandle, long nameHandle, int nameLenth, byte[] key, int keyOffset, int keyLength);
+
+  private native void sortedDelete(
+      long engineHandle, long nameHandle, int nameLenth, byte[] key, int keyOffset, int keyLength);
+
+  private native long sortedIteratorCreate(long engineHandle, long nameHandle, int nameLenth);
+
+  private native long writeBatchCreate(long handle);
+
+  private native void batchWrite(long engineHandle, long batchHandle);
+
+  private enum LibraryState { NOT_LOADED, LOADING, LOADED }
+
+  /**
+   * Loads the necessary library files. Calling this method twice will have no effect. By default
+   * the method extracts the shared library for loading at java.io.tmpdir, however, you can
+   * override this temporary location by setting the environment variable KVDK_SHARED_LIB_DIR.
+   */
+  public static void loadLibrary() {
+    if (libraryLoaded.get() == LibraryState.LOADED) {
+      return;
     }
 
-    protected Engine(final long nativeHandle) {
-        super(nativeHandle);
+    if (libraryLoaded.compareAndSet(LibraryState.NOT_LOADED, LibraryState.LOADING)) {
+      final String tmpDir = System.getenv("KVDK_SHARED_LIB_DIR");
+
+      try {
+        NativeLibraryLoader.getInstance().loadLibrary(tmpDir);
+      } catch (final IOException e) {
+        libraryLoaded.set(LibraryState.NOT_LOADED);
+        throw new RuntimeException("Unable to load the KVDK shared library", e);
+      }
+
+      libraryLoaded.set(LibraryState.LOADED);
+      return;
     }
 
-    /**
-     * Open a KVDK engine instance.
-     *
-     * @param path A directory to PMem
-     * @param configs KVDK engine configs
-     * @return
-     * @throws KVDKException
-     */
-    public static Engine open(final String path, final Configs configs) throws KVDKException {
-        final Engine engine = new Engine(open(path, configs.getNativeHandle()));
-        return engine;
+    while (libraryLoaded.get() == LibraryState.LOADING) {
+      try {
+        Thread.sleep(10);
+      } catch (final InterruptedException e) {
+        // ignore
+      }
+    }
+  }
+
+  /**
+   * Tries to load the necessary library files from the given list of directories.
+   *
+   * @param paths a list of strings where each describes a directory of a library.
+   */
+  public static void loadLibrary(final List<String> paths) {
+    if (libraryLoaded.get() == LibraryState.LOADED) {
+      return;
     }
 
-    public void put(final byte[] key, final byte[] value) throws KVDKException {
-        WriteOptions defaulWriteOptions = new WriteOptions();
-        put(
-                nativeHandle_,
-                key,
-                0,
-                key.length,
-                value,
-                0,
-                value.length,
-                defaulWriteOptions.getTtlInMillis(),
-                defaulWriteOptions.isUpdateTtlIfExisted());
-    }
-
-    public void put(
-            final byte[] key,
-            int keyOffset,
-            int keyLength,
-            final byte[] value,
-            int valueOffset,
-            int valueLength)
-            throws KVDKException {
-        WriteOptions defaulWriteOptions = new WriteOptions();
-        put(
-                nativeHandle_,
-                key,
-                keyOffset,
-                keyLength,
-                value,
-                valueOffset,
-                valueLength,
-                defaulWriteOptions.getTtlInMillis(),
-                defaulWriteOptions.isUpdateTtlIfExisted());
-    }
-
-    public void put(final byte[] key, final byte[] value, final WriteOptions wOptions)
-            throws KVDKException {
-        put(
-                nativeHandle_,
-                key,
-                0,
-                key.length,
-                value,
-                0,
-                value.length,
-                wOptions.getTtlInMillis(),
-                wOptions.isUpdateTtlIfExisted());
-    }
-
-    public void put(
-            final byte[] key,
-            int keyOffset,
-            int keyLength,
-            final byte[] value,
-            int valueOffset,
-            int valueLength,
-            final WriteOptions wOptions)
-            throws KVDKException {
-        put(
-                nativeHandle_,
-                key,
-                keyOffset,
-                keyLength,
-                value,
-                valueOffset,
-                valueLength,
-                wOptions.getTtlInMillis(),
-                wOptions.isUpdateTtlIfExisted());
-    }
-
-    public void expire(final byte[] key, final long ttlInMillis) throws KVDKException {
-        expire(nativeHandle_, key, 0, key.length, ttlInMillis);
-    }
-
-    public void expire(final byte[] key, int keyOffset, int keyLength, final long ttlInMillis)
-            throws KVDKException {
-        expire(nativeHandle_, key, keyOffset, keyLength, ttlInMillis);
-    }
-
-    public void expire(final NativeBytesHandle nameHandle, final long ttlInMillis)
-            throws KVDKException {
-        expire(nativeHandle_, nameHandle.getNativeHandle(), nameHandle.getLength(), ttlInMillis);
-    }
-
-    /**
-     * @param key
-     * @return Value as byte array, null if the specified key doesn't exist.
-     * @throws KVDKException
-     */
-    public byte[] get(final byte[] key) throws KVDKException {
-        return get(nativeHandle_, key, 0, key.length);
-    }
-
-    /**
-     * @param key
-     * @return Value as byte array, null if the specified key doesn't exist.
-     * @throws KVDKException
-     */
-    public byte[] get(final byte[] key, int keyOffset, int keyLength) throws KVDKException {
-        return get(nativeHandle_, key, keyOffset, keyLength);
-    }
-
-    public void delete(final byte[] key) throws KVDKException {
-        delete(nativeHandle_, key, 0, key.length);
-    }
-
-    public void delete(final byte[] key, int keyOffset, int keyLength) throws KVDKException {
-        delete(nativeHandle_, key, keyOffset, keyLength);
-    }
-
-    public void sortedCreate(final NativeBytesHandle nameHandle) throws KVDKException {
-        sortedCreate(nativeHandle_, nameHandle.getNativeHandle(), nameHandle.getLength());
-    }
-
-    public void sortedDestroy(final NativeBytesHandle nameHandle) throws KVDKException {
-        sortedDestroy(nativeHandle_, nameHandle.getNativeHandle(), nameHandle.getLength());
-    }
-
-    public long sortedSize(final NativeBytesHandle nameHandle) throws KVDKException {
-        return sortedSize(nativeHandle_, nameHandle.getNativeHandle(), nameHandle.getLength());
-    }
-
-    public void sortedPut(final NativeBytesHandle nameHandle, final byte[] key, final byte[] value)
-            throws KVDKException {
-        sortedPut(
-                nativeHandle_,
-                nameHandle.getNativeHandle(),
-                nameHandle.getLength(),
-                key,
-                0,
-                key.length,
-                value,
-                0,
-                value.length);
-    }
-
-    public void sortedPut(
-            final NativeBytesHandle nameHandle,
-            final byte[] key,
-            int keyOffset,
-            int keyLength,
-            final byte[] value,
-            int valueOffset,
-            int valueLength)
-            throws KVDKException {
-        sortedPut(
-                nativeHandle_,
-                nameHandle.getNativeHandle(),
-                nameHandle.getLength(),
-                key,
-                keyOffset,
-                keyLength,
-                value,
-                valueOffset,
-                valueLength);
-    }
-
-    /**
-     * @param nameHandle
-     * @param key
-     * @return Value as byte array, null if the specified key doesn't exist.
-     * @throws KVDKException
-     */
-    public byte[] sortedGet(final NativeBytesHandle nameHandle, final byte[] key)
-            throws KVDKException {
-        return sortedGet(
-                nativeHandle_,
-                nameHandle.getNativeHandle(),
-                nameHandle.getLength(),
-                key,
-                0,
-                key.length);
-    }
-
-    /**
-     * @param nameHandle
-     * @param key
-     * @return Value as byte array, null if the specified key doesn't exist.
-     * @throws KVDKException
-     */
-    public byte[] sortedGet(
-            final NativeBytesHandle nameHandle, final byte[] key, int keyOffset, int keyLength)
-            throws KVDKException {
-        return sortedGet(
-                nativeHandle_,
-                nameHandle.getNativeHandle(),
-                nameHandle.getLength(),
-                key,
-                keyOffset,
-                keyLength);
-    }
-
-    public void sortedDelete(final NativeBytesHandle nameHandle, final byte[] key)
-            throws KVDKException {
-        sortedDelete(
-                nativeHandle_,
-                nameHandle.getNativeHandle(),
-                nameHandle.getLength(),
-                key,
-                0,
-                key.length);
-    }
-
-    public void sortedDelete(
-            final NativeBytesHandle nameHandle, final byte[] key, int keyOffset, int keyLength)
-            throws KVDKException {
-        sortedDelete(
-                nativeHandle_,
-                nameHandle.getNativeHandle(),
-                nameHandle.getLength(),
-                key,
-                keyOffset,
-                keyLength);
-    }
-
-    public Iterator sortedIteratorCreate(final NativeBytesHandle nameHandle) throws KVDKException {
-        long iteratorHandle =
-                sortedIteratorCreate(
-                        nativeHandle_, nameHandle.getNativeHandle(), nameHandle.getLength());
-
-        return new Iterator(iteratorHandle, nativeHandle_);
-    }
-
-    public void sortedIteratorRelease(final Iterator iterator) throws KVDKException {
-        iterator.close();
-    }
-
-    public WriteBatch writeBatchCreate() {
-        long batchHandle = writeBatchCreate(nativeHandle_);
-        return new WriteBatch(batchHandle);
-    }
-
-    public void batchWrite(WriteBatch batch) throws KVDKException {
-        batchWrite(nativeHandle_, batch.getNativeHandle());
-    }
-
-    public void releaseAccessThread() {
-        releaseAccessThread(nativeHandle_);
-    }
-
-    // Native methods
-    @Override
-    protected final native void closeInternal(long handle);
-
-    private static native long open(final String path, final long cfg_handle) throws KVDKException;
-
-    private native void put(
-            long handle,
-            byte[] key,
-            int keyOffset,
-            int keyLength,
-            byte[] value,
-            int valueOffset,
-            int valueLength,
-            long ttl,
-            boolean updateTtlIfExisted);
-
-    private native void expire(
-            long handle, byte[] key, int keyOffset, int keyLength, long ttlInMillis);
-
-    private native void expire(long handle, long nameHandle, int nameLenth, long ttlInMillis);
-
-    private native byte[] get(long handle, byte[] key, int keyOffset, int keyLength);
-
-    private native void delete(long handle, byte[] key, int keyOffset, int keyLength);
-
-    private native void sortedCreate(long engineHandle, long nameHandle, int nameLenth);
-
-    private native void sortedDestroy(long engineHandle, long nameHandle, int nameLenth);
-
-    private native long sortedSize(long engineHandle, long nameHandle, int nameLenth);
-
-    private native void sortedPut(
-            long engineHandle,
-            long nameHandle,
-            int nameLenth,
-            byte[] key,
-            int keyOffset,
-            int keyLength,
-            byte[] value,
-            int valueOffset,
-            int valueLength);
-
-    private native byte[] sortedGet(
-            long engineHandle,
-            long nameHandle,
-            int nameLenth,
-            byte[] key,
-            int keyOffset,
-            int keyLength);
-
-    private native void sortedDelete(
-            long engineHandle,
-            long nameHandle,
-            int nameLenth,
-            byte[] key,
-            int keyOffset,
-            int keyLength);
-
-    private native long sortedIteratorCreate(long engineHandle, long nameHandle, int nameLenth);
-
-    private native long writeBatchCreate(long handle);
-
-    private native void batchWrite(long engineHandle, long batchHandle);
-
-    private native void releaseAccessThread(long engineHandle);
-
-    private enum LibraryState {
-        NOT_LOADED,
-        LOADING,
-        LOADED
-    }
-
-    /**
-     * Loads the necessary library files. Calling this method twice will have no effect. By default
-     * the method extracts the shared library for loading at java.io.tmpdir, however, you can
-     * override this temporary location by setting the environment variable KVDK_SHARED_LIB_DIR.
-     */
-    public static void loadLibrary() {
-        if (libraryLoaded.get() == LibraryState.LOADED) {
-            return;
+    if (libraryLoaded.compareAndSet(LibraryState.NOT_LOADED, LibraryState.LOADING)) {
+      boolean success = false;
+      UnsatisfiedLinkError err = null;
+      for (final String path : paths) {
+        try {
+          System.load(path + "/" + atomicLibraryFileName);
+          System.load(path + "/" + stdLibraryFileName);
+          System.load(path + "/" + jniLibraryFileName);
+          success = true;
+          break;
+        } catch (final UnsatisfiedLinkError e) {
+          err = e;
         }
+      }
+      if (!success) {
+        libraryLoaded.set(LibraryState.NOT_LOADED);
+        throw err;
+      }
 
-        if (libraryLoaded.compareAndSet(LibraryState.NOT_LOADED, LibraryState.LOADING)) {
-            final String tmpDir = System.getenv("KVDK_SHARED_LIB_DIR");
-
-            try {
-                NativeLibraryLoader.getInstance().loadLibrary(tmpDir);
-            } catch (final IOException e) {
-                libraryLoaded.set(LibraryState.NOT_LOADED);
-                throw new RuntimeException("Unable to load the KVDK shared library", e);
-            }
-
-            libraryLoaded.set(LibraryState.LOADED);
-            return;
-        }
-
-        while (libraryLoaded.get() == LibraryState.LOADING) {
-            try {
-                Thread.sleep(10);
-            } catch (final InterruptedException e) {
-                // ignore
-            }
-        }
+      libraryLoaded.set(LibraryState.LOADED);
+      return;
     }
 
-    /**
-     * Tries to load the necessary library files from the given list of directories.
-     *
-     * @param paths a list of strings where each describes a directory of a library.
-     */
-    public static void loadLibrary(final List<String> paths) {
-        if (libraryLoaded.get() == LibraryState.LOADED) {
-            return;
-        }
-
-        if (libraryLoaded.compareAndSet(LibraryState.NOT_LOADED, LibraryState.LOADING)) {
-            boolean success = false;
-            UnsatisfiedLinkError err = null;
-            for (final String path : paths) {
-                try {
-                    System.load(path + "/" + atomicLibraryFileName);
-                    System.load(path + "/" + stdLibraryFileName);
-                    System.load(path + "/" + jniLibraryFileName);
-                    success = true;
-                    break;
-                } catch (final UnsatisfiedLinkError e) {
-                    err = e;
-                }
-            }
-            if (!success) {
-                libraryLoaded.set(LibraryState.NOT_LOADED);
-                throw err;
-            }
-
-            libraryLoaded.set(LibraryState.LOADED);
-            return;
-        }
-
-        while (libraryLoaded.get() == LibraryState.LOADING) {
-            try {
-                Thread.sleep(10);
-            } catch (final InterruptedException e) {
-                // ignore
-            }
-        }
+    while (libraryLoaded.get() == LibraryState.LOADING) {
+      try {
+        Thread.sleep(10);
+      } catch (final InterruptedException e) {
+        // ignore
+      }
     }
+  }
 }

--- a/java/src/main/java/io/pmem/kvdk/Status.java
+++ b/java/src/main/java/io/pmem/kvdk/Status.java
@@ -61,13 +61,12 @@ public class Status {
         NotSupported((byte) 0x9),
         PMemMapFileError((byte) 0xA),
         InvalidBatchSize((byte) 0xB),
-        TooManyAccessThreads((byte) 0xC),
-        InvalidDataSize((byte) 0xD),
-        InvalidArgument((byte) 0xE),
-        IOError((byte) 0xF),
-        InvalidConfiguration((byte) 0x10),
-        Fail((byte) 0x11),
-        Abort((byte) 0x12),
+        InvalidDataSize((byte) 0xC),
+        InvalidArgument((byte) 0xD),
+        IOError((byte) 0xE),
+        InvalidConfiguration((byte) 0xF),
+        Fail((byte) 0x10),
+        Abort((byte) 0x11),
         Undefined((byte) 0x7F);
 
         private final byte value;

--- a/java/src/test/java/io/pmem/kvdk/EngineTestBase.java
+++ b/java/src/test/java/io/pmem/kvdk/EngineTestBase.java
@@ -34,7 +34,6 @@ public class EngineTestBase {
 
     @After
     public void teardown() {
-        kvdkEngine.releaseAccessThread();
         kvdkEngine.close();
     }
 }

--- a/scripts/benchmark_impl.py
+++ b/scripts/benchmark_impl.py
@@ -160,7 +160,7 @@ def run_benchmark(
         pmem_size, 
         populate_on_fill, 
         num_kv, 
-        n_thread, 
+        256, 
         n_thread, 
         num_collection, 
         timeout, 

--- a/scripts/benchmark_impl.py
+++ b/scripts/benchmark_impl.py
@@ -160,7 +160,7 @@ def run_benchmark(
         pmem_size, 
         populate_on_fill, 
         num_kv, 
-        256, 
+        n_thread, 
         n_thread, 
         num_collection, 
         timeout, 

--- a/tests/allocator.hpp
+++ b/tests/allocator.hpp
@@ -22,7 +22,6 @@ class AllocatorAdaptor {
  public:
   virtual op_alloc_info wrapped_malloc(uint64_t size) = 0;
   virtual op_alloc_info wrapped_free(op_alloc_info* data) = 0;
-  virtual void InitThread() {}
   virtual ~AllocatorAdaptor(void) {}
 };
 
@@ -45,7 +44,6 @@ class PMemAllocatorWrapper : public AllocatorAdaptor {
   void InitPMemAllocator(const std::string& pmem_path, uint64_t pmem_size,
                          uint64_t num_segment_blocks, uint32_t block_size,
                          uint32_t num_write_threads) {
-    thread_manager_.reset(new ThreadManager(num_write_threads));
     pmem_alloc_ = PMEMAllocator::NewPMEMAllocator(
         pmem_path, pmem_size, num_segment_blocks, block_size, num_write_threads,
         true, false, nullptr);
@@ -71,10 +69,6 @@ class PMemAllocatorWrapper : public AllocatorAdaptor {
     }
   }
 
-  void InitThread() override {
-    thread_manager_->MaybeInitThread(access_thread);
-  }
-
   ~PMemAllocatorWrapper(void) {
     closing_ = true;
     // background thread exit;
@@ -88,5 +82,4 @@ class PMemAllocatorWrapper : public AllocatorAdaptor {
   PMEMAllocator* pmem_alloc_;
   bool closing_ = false;
   std::vector<std::thread> background;
-  std::shared_ptr<ThreadManager> thread_manager_;
 };

--- a/tests/pmem_allocator_bench.cpp
+++ b/tests/pmem_allocator_bench.cpp
@@ -98,7 +98,7 @@ class AllocatorBench {
     std::vector<std::vector<op_alloc_info>> records(num_thread);
     double elapesd_time = 0;
     auto RandomBench = [&](uint64_t id) {
-      allocator->InitThread();
+      ThreadManager::Get()->MaybeInitThread(access_thread);
       std::vector<op_alloc_info> work_sets(iter_num);
       std::chrono::system_clock::time_point to_begin =
           std::chrono::high_resolution_clock::now();
@@ -126,7 +126,7 @@ class AllocatorBench {
               << elapesd_time << " seconds\n";
 
     // Clear all memory to avoid memory leak
-    allocator->InitThread();
+    ThreadManager::Get()->MaybeInitThread(access_thread);
     for (auto record : records) {
       for (auto r : record) {
         allocator->wrapped_free(&r);

--- a/tests/pmem_allocator_bench.cpp
+++ b/tests/pmem_allocator_bench.cpp
@@ -98,7 +98,6 @@ class AllocatorBench {
     std::vector<std::vector<op_alloc_info>> records(num_thread);
     double elapesd_time = 0;
     auto RandomBench = [&](uint64_t id) {
-      ThreadManager::Get()->MaybeInitThread(access_thread);
       std::vector<op_alloc_info> work_sets(iter_num);
       std::chrono::system_clock::time_point to_begin =
           std::chrono::high_resolution_clock::now();
@@ -125,8 +124,6 @@ class AllocatorBench {
     std::cout << "Total execute time: " << std::fixed << std::setprecision(5)
               << elapesd_time << " seconds\n";
 
-    // Clear all memory to avoid memory leak
-    ThreadManager::Get()->MaybeInitThread(access_thread);
     for (auto record : records) {
       for (auto r : record) {
         allocator->wrapped_free(&r);

--- a/tests/test_pmem_allocator.cpp
+++ b/tests/test_pmem_allocator.cpp
@@ -58,8 +58,6 @@ TEST_F(EnginePMemAllocatorTest, TestBasicAlloc) {
   for (auto num_segment_block : num_segment_blocks) {
     for (auto block_size : block_sizes) {
       for (auto num_thread : num_threads) {
-        // init pmem allocator and thread_manager.
-        ThreadManager* thread_manager = ThreadManager::Get();
         PMEMAllocator* pmem_alloc = PMEMAllocator::NewPMEMAllocator(
             pmem_path, pmem_size, num_segment_block, block_size, num_thread,
             true, false, nullptr);
@@ -73,7 +71,6 @@ TEST_F(EnginePMemAllocatorTest, TestBasicAlloc) {
         // Test function: allocate all pmem, and free all under multi-threaded
         // scenario.
         auto TestPmemAlloc = [&](size_t) {
-          thread_manager->MaybeInitThread(access_thread);
           std::vector<SpaceEntry> records;
           for (uint64_t j = 0; j < num_segment_block; ++j) {
             auto space_entry = pmem_alloc->Allocate(alloc_size);
@@ -90,8 +87,6 @@ TEST_F(EnginePMemAllocatorTest, TestBasicAlloc) {
         free_list->MoveCachedEntriesToPool();
         free_list->MergeSpaceInPool();
 
-        // Then allocate all pmem.
-        thread_manager->MaybeInitThread(access_thread);
         int alloc_cnt = 0;
         while (true) {
           SpaceEntry space_entry = pmem_alloc->Allocate(alloc_size);
@@ -113,7 +108,6 @@ TEST_F(EnginePMemAllocatorTest, TestPMemFragmentation) {
   uint64_t num_segment_block = 1024;
   uint64_t block_size = 64;
   std::vector<uint64_t> alloc_size{8 * 64, 8 * 64, 16 * 64, 32 * 64};
-  ThreadManager* thread_manager = ThreadManager::Get();
   PMEMAllocator* pmem_alloc = PMEMAllocator::NewPMEMAllocator(
       pmem_path, pmem_size, num_segment_block, block_size, num_thread, true,
       false, nullptr);
@@ -123,7 +117,6 @@ TEST_F(EnginePMemAllocatorTest, TestPMemFragmentation) {
    * | 8 | 8 | 16 | 32 | 8 | 8 | 16 | 32 | 8 | 8 | 16 | 32 | 8 | 8 | 16 | 32 |
    */
   std::vector<SpaceEntry> records(num_thread);
-  thread_manager->MaybeInitThread(access_thread);
   for (uint32_t i = 0; i < records.size(); ++i) {
     SpaceEntry space_entry = pmem_alloc->Allocate(alloc_size[i % 4]);
     records[i] = space_entry;
@@ -136,7 +129,6 @@ TEST_F(EnginePMemAllocatorTest, TestPMemFragmentation) {
    */
   // Notice threads (more than one) may share the same list of space pool.
   auto TestPmemFree = [&](uint64_t id) {
-    thread_manager->MaybeInitThread(access_thread);
     if ((id + 1) % 4 != 0) {
       pmem_alloc->Free(records[id]);
     }
@@ -147,7 +139,6 @@ TEST_F(EnginePMemAllocatorTest, TestPMemFragmentation) {
   free_list->MoveCachedEntriesToPool();
   free_list->MergeSpaceInPool();
   // Test merge free memory
-  thread_manager->MaybeInitThread(access_thread);
   for (uint32_t id = 0; id < num_thread / 4; ++id) {
     SpaceEntry space_entry = pmem_alloc->Allocate(alloc_size[3]);
     ASSERT_NE(space_entry.size, 0);
@@ -162,13 +153,11 @@ TEST_F(EnginePMemAllocatorTest, TestPMemAllocFreeList) {
   uint64_t block_size = 64;
   uint64_t pmem_size = num_segment_block * block_size * num_thread;
   std::deque<SpaceEntry> records;
-  ThreadManager* thread_manager = ThreadManager::Get();
   PMEMAllocator* pmem_alloc = PMEMAllocator::NewPMEMAllocator(
       pmem_path, pmem_size, num_segment_block, block_size, num_thread, true,
       false, nullptr);
   ASSERT_NE(pmem_alloc, nullptr);
 
-  thread_manager->MaybeInitThread(access_thread);
   // allocate 1024 bytes
   records.push_back(pmem_alloc->Allocate(1024ULL));
   ASSERT_EQ(pmem_alloc->PMemUsageInBytes(), 1024LL);

--- a/tests/test_pmem_allocator.cpp
+++ b/tests/test_pmem_allocator.cpp
@@ -27,7 +27,6 @@ class EnginePMemAllocatorTest : public testing::Test {
  protected:
   Engine* engine = nullptr;
   Configs configs;
-  std::shared_ptr<ThreadManager> thread_manager_;
   std::string pmem_path;
 
   virtual void SetUp() override {
@@ -62,7 +61,7 @@ TEST_F(EnginePMemAllocatorTest, TestBasicAlloc) {
     for (auto block_size : block_sizes) {
       for (auto num_thread : num_threads) {
         // init pmem allocator and thread_manager.
-        thread_manager_.reset(new ThreadManager(num_thread));
+        ThreadManager* thread_manager = ThreadManager::Get();
         PMEMAllocator* pmem_alloc = PMEMAllocator::NewPMEMAllocator(
             pmem_path, pmem_size, num_segment_block, block_size, num_thread,
             true, false, nullptr);
@@ -76,7 +75,7 @@ TEST_F(EnginePMemAllocatorTest, TestBasicAlloc) {
         // Test function: allocate all pmem, and free all under multi-threaded
         // scenario.
         auto TestPmemAlloc = [&](size_t) {
-          thread_manager_->MaybeInitThread(access_thread);
+          thread_manager->MaybeInitThread(access_thread);
           std::vector<SpaceEntry> records;
           for (uint64_t j = 0; j < num_segment_block; ++j) {
             auto space_entry = pmem_alloc->Allocate(alloc_size);
@@ -95,7 +94,7 @@ TEST_F(EnginePMemAllocatorTest, TestBasicAlloc) {
         access_thread.Release();
 
         // Then allocate all pmem.
-        thread_manager_->MaybeInitThread(access_thread);
+        thread_manager->MaybeInitThread(access_thread);
         int alloc_cnt = 0;
         while (true) {
           SpaceEntry space_entry = pmem_alloc->Allocate(alloc_size);
@@ -117,7 +116,7 @@ TEST_F(EnginePMemAllocatorTest, TestPMemFragmentation) {
   uint64_t num_segment_block = 1024;
   uint64_t block_size = 64;
   std::vector<uint64_t> alloc_size{8 * 64, 8 * 64, 16 * 64, 32 * 64};
-  thread_manager_.reset(new ThreadManager(num_thread));
+  ThreadManager* thread_manager = ThreadManager::Get();
   PMEMAllocator* pmem_alloc = PMEMAllocator::NewPMEMAllocator(
       pmem_path, pmem_size, num_segment_block, block_size, num_thread, true,
       false, nullptr);
@@ -127,7 +126,7 @@ TEST_F(EnginePMemAllocatorTest, TestPMemFragmentation) {
    * | 8 | 8 | 16 | 32 | 8 | 8 | 16 | 32 | 8 | 8 | 16 | 32 | 8 | 8 | 16 | 32 |
    */
   std::vector<SpaceEntry> records(num_thread);
-  thread_manager_->MaybeInitThread(access_thread);
+  thread_manager->MaybeInitThread(access_thread);
   for (uint32_t i = 0; i < records.size(); ++i) {
     SpaceEntry space_entry = pmem_alloc->Allocate(alloc_size[i % 4]);
     records[i] = space_entry;
@@ -141,7 +140,7 @@ TEST_F(EnginePMemAllocatorTest, TestPMemFragmentation) {
    */
   // Notice threads (more than one) may share the same list of space pool.
   auto TestPmemFree = [&](uint64_t id) {
-    thread_manager_->MaybeInitThread(access_thread);
+    thread_manager->MaybeInitThread(access_thread);
     if ((id + 1) % 4 != 0) {
       pmem_alloc->Free(records[id]);
     }
@@ -153,7 +152,7 @@ TEST_F(EnginePMemAllocatorTest, TestPMemFragmentation) {
   free_list->MoveCachedEntriesToPool();
   free_list->MergeSpaceInPool();
   // Test merge free memory
-  thread_manager_->MaybeInitThread(access_thread);
+  thread_manager->MaybeInitThread(access_thread);
   for (uint32_t id = 0; id < num_thread / 4; ++id) {
     SpaceEntry space_entry = pmem_alloc->Allocate(alloc_size[3]);
     ASSERT_NE(space_entry.size, 0);
@@ -168,13 +167,13 @@ TEST_F(EnginePMemAllocatorTest, TestPMemAllocFreeList) {
   uint64_t block_size = 64;
   uint64_t pmem_size = num_segment_block * block_size * num_thread;
   std::deque<SpaceEntry> records;
-  thread_manager_.reset(new ThreadManager(num_thread));
+  ThreadManager* thread_manager = ThreadManager::Get();
   PMEMAllocator* pmem_alloc = PMEMAllocator::NewPMEMAllocator(
       pmem_path, pmem_size, num_segment_block, block_size, num_thread, true,
       false, nullptr);
   ASSERT_NE(pmem_alloc, nullptr);
 
-  thread_manager_->MaybeInitThread(access_thread);
+  thread_manager->MaybeInitThread(access_thread);
   // allocate 1024 bytes
   records.push_back(pmem_alloc->Allocate(1024ULL));
   ASSERT_EQ(pmem_alloc->PMemUsageInBytes(), 1024LL);

--- a/tests/test_pmem_allocator.cpp
+++ b/tests/test_pmem_allocator.cpp
@@ -37,16 +37,14 @@ class EnginePMemAllocatorTest : public testing::Test {
     int res __attribute__((unused)) = system(cmd);
   }
 
-  void RemovePathAndReleaseThread() {
-    // Release thread.
-    access_thread.Release();
+  void RemovePath() {
     // delete db_path.
     char cmd[1024];
     sprintf(cmd, "rm -rf %s\n", pmem_path.c_str());
     int res __attribute__((unused)) = system(cmd);
   }
 
-  virtual void TearDown() { RemovePathAndReleaseThread(); }
+  virtual void TearDown() { RemovePath(); }
 };
 
 TEST_F(EnginePMemAllocatorTest, TestBasicAlloc) {
@@ -91,7 +89,6 @@ TEST_F(EnginePMemAllocatorTest, TestBasicAlloc) {
         Freelist* free_list = pmem_alloc->GetFreeList();
         free_list->MoveCachedEntriesToPool();
         free_list->MergeSpaceInPool();
-        access_thread.Release();
 
         // Then allocate all pmem.
         thread_manager->MaybeInitThread(access_thread);
@@ -104,7 +101,7 @@ TEST_F(EnginePMemAllocatorTest, TestBasicAlloc) {
         }
         ASSERT_EQ(pmem_size / block_size, alloc_cnt);
         delete pmem_alloc;
-        RemovePathAndReleaseThread();
+        RemovePath();
       }
     }
   }
@@ -132,7 +129,6 @@ TEST_F(EnginePMemAllocatorTest, TestPMemFragmentation) {
     records[i] = space_entry;
     ASSERT_NE(space_entry.size, 0);
   }
-  access_thread.Release();
 
   /* Allocated pmem status:
    * | null | null | null | 32 | null | null | null | 32 | null | null | null
@@ -145,7 +141,6 @@ TEST_F(EnginePMemAllocatorTest, TestPMemFragmentation) {
       pmem_alloc->Free(records[id]);
     }
   };
-  access_thread.Release();
 
   LaunchNThreads(num_thread, TestPmemFree);
   Freelist* free_list = pmem_alloc->GetFreeList();

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -56,7 +56,7 @@ class EngineBasicTest : public testing::Test {
     configs.pmem_segment_blocks = 8 * 1024;
     // For faster test, no interval so it would not block engine closing
     configs.background_work_interval = 0.1;
-    configs.max_access_threads = 1;
+    configs.max_access_threads = 8;
     db_path = FLAGS_path;
     backup_path = FLAGS_path + "_backup";
     backup_log = FLAGS_path + ".backup";
@@ -119,9 +119,6 @@ class EngineBasicTest : public testing::Test {
   // Return the current configuration.
   Configs CurrentConfigs() {
     switch (config_option_) {
-      case MultiThread:
-        configs.max_access_threads = 16;
-        break;
       case OptRestore:
         configs.opt_large_sorted_collection_recovery = true;
         break;
@@ -508,7 +505,6 @@ TEST_F(EngineBasicTest, TypeOfKey) {
 TEST_F(EngineBasicTest, TestBasicSnapshot) {
   uint32_t num_threads = 16;
   int count = 100;
-  configs.max_access_threads = num_threads;
   ASSERT_EQ(Engine::Open(db_path.c_str(), &engine, configs, stdout),
             Status::Ok);
 
@@ -839,7 +835,6 @@ TEST_F(EngineBasicTest, TestStringModify) {
   int num_threads = 16;
   int ops_per_thread = 1000;
   uint64_t incr_by = 5;
-  configs.max_access_threads = num_threads;
 
   ASSERT_EQ(Engine::Open(db_path.c_str(), &engine, configs, stdout),
             Status::Ok);
@@ -870,7 +865,6 @@ TEST_F(EngineBasicTest, TestStringModify) {
 
 TEST_F(BatchWriteTest, Sorted) {
   size_t num_threads = 1;
-  configs.max_access_threads = num_threads + 1;
   for (int index_with_hashtable : {0, 1}) {
     ASSERT_EQ(Engine::Open(db_path.c_str(), &engine, configs, stdout),
               Status::Ok);
@@ -952,7 +946,6 @@ TEST_F(BatchWriteTest, Sorted) {
 
 TEST_F(BatchWriteTest, String) {
   size_t num_threads = 16;
-  configs.max_access_threads = num_threads;
   ASSERT_EQ(Engine::Open(db_path.c_str(), &engine, configs, stdout),
             Status::Ok);
   size_t batch_size = 100;
@@ -1023,7 +1016,6 @@ TEST_F(BatchWriteTest, String) {
 
 TEST_F(BatchWriteTest, Hash) {
   size_t num_threads = 16;
-  configs.max_access_threads = num_threads + 1;
   ASSERT_EQ(Engine::Open(db_path.c_str(), &engine, configs, stdout),
             Status::Ok);
   size_t batch_size = 100;
@@ -1171,7 +1163,6 @@ TEST_F(EngineBasicTest, TestSeek) {
 
 TEST_F(EngineBasicTest, TestStringRestore) {
   size_t num_threads = 16;
-  configs.max_access_threads = num_threads;
   ASSERT_EQ(Engine::Open(db_path.c_str(), &engine, configs, stdout),
             Status::Ok);
   // insert and delete some keys, then re-insert some deleted keys
@@ -1251,7 +1242,6 @@ TEST_F(EngineBasicTest, TestStringLargeValue) {
 
 TEST_F(EngineBasicTest, TestSortedRestore) {
   size_t num_threads = 16;
-  configs.max_access_threads = num_threads;
   for (int opt_large_sorted_collection_recovery : {0, 1}) {
     for (int index_with_hashtable : {0, 1}) {
       SortedCollectionConfigs s_configs;
@@ -1310,7 +1300,6 @@ TEST_F(EngineBasicTest, TestSortedRestore) {
       GlobalLogger.Debug(
           "Restore with opt_large_sorted_collection_restore: %d\n",
           opt_large_sorted_collection_recovery);
-      configs.max_access_threads = num_threads;
       configs.opt_large_sorted_collection_recovery =
           opt_large_sorted_collection_recovery;
       // reopen and restore engine and try gets
@@ -1427,7 +1416,6 @@ TEST_F(EngineBasicTest, TestSortedRestore) {
 TEST_F(EngineBasicTest, TestMultiThreadSortedRestore) {
   size_t num_threads = 16;
   size_t num_collections = 16;
-  configs.max_access_threads = num_threads;
   configs.opt_large_sorted_collection_recovery = true;
   ASSERT_EQ(Engine::Open(db_path.c_str(), &engine, configs, stdout),
             Status::Ok);
@@ -1494,7 +1482,6 @@ TEST_F(EngineBasicTest, TestMultiThreadSortedRestore) {
 TEST_F(EngineBasicTest, TestList) {
   size_t num_threads = 1;
   size_t count = 1000;
-  configs.max_access_threads = num_threads + 1;
   ASSERT_EQ(Engine::Open(db_path.c_str(), &engine, configs, stdout),
             Status::Ok);
   std::vector<std::vector<std::string>> elems_vec(num_threads);
@@ -1765,7 +1752,6 @@ TEST_F(EngineBasicTest, TestList) {
 TEST_F(EngineBasicTest, TestHash) {
   size_t num_threads = 1;
   size_t count = 1000;
-  configs.max_access_threads = num_threads + 1;
   ASSERT_EQ(Engine::Open(db_path.c_str(), &engine, configs, stdout),
             Status::Ok);
   std::string key{"Hash"};
@@ -1911,7 +1897,6 @@ TEST_F(EngineBasicTest, TestHash) {
 TEST_F(EngineBasicTest, TestStringHotspot) {
   size_t n_thread_reading = 16;
   size_t n_thread_writing = 16;
-  configs.max_access_threads = n_thread_writing + n_thread_reading;
   ASSERT_EQ(Engine::Open(db_path.c_str(), &engine, configs, stdout),
             Status::Ok);
 
@@ -1962,7 +1947,6 @@ TEST_F(EngineBasicTest, TestStringHotspot) {
 TEST_F(EngineBasicTest, TestSortedHotspot) {
   size_t n_thread_reading = 16;
   size_t n_thread_writing = 16;
-  configs.max_access_threads = n_thread_writing + n_thread_reading;
   ASSERT_EQ(Engine::Open(db_path.c_str(), &engine, configs, stdout),
             Status::Ok);
 
@@ -2021,7 +2005,6 @@ TEST_F(EngineBasicTest, TestSortedHotspot) {
 TEST_F(EngineBasicTest, TestSortedCustomCompareFunction) {
   using kvpair = std::pair<std::string, std::string>;
   size_t num_threads = 16;
-  configs.max_access_threads = num_threads;
   ASSERT_EQ(Engine::Open(db_path.c_str(), &engine, configs, stdout),
             Status::Ok);
 
@@ -2127,8 +2110,7 @@ TEST_F(EngineBasicTest, TestSortedCustomCompareFunction) {
 }
 
 TEST_F(EngineBasicTest, TestHashTableIterator) {
-  size_t threads = 32;
-  configs.max_access_threads = threads;
+  size_t num_threads = 32;
   ASSERT_EQ(Engine::Open(db_path.c_str(), &engine, configs, stdout),
             Status::Ok);
   std::string collection_name = "sortedcollection";
@@ -2144,7 +2126,7 @@ TEST_F(EngineBasicTest, TestHashTableIterator) {
           Status::Ok);
     }
   };
-  LaunchNThreads(threads, MixedPut);
+  LaunchNThreads(num_threads, MixedPut);
 
   auto test_kvengine = static_cast<KVEngine*>(engine);
   auto hash_table = test_kvengine->GetHashTable();
@@ -2195,15 +2177,12 @@ TEST_F(EngineBasicTest, TestHashTableIterator) {
       }
       hashtable_iter.Next();
     }
-    ASSERT_EQ(total_entry_num, threads + 1);
+    ASSERT_EQ(total_entry_num, num_threads + 1);
   }
   delete engine;
 }
 
 TEST_F(EngineBasicTest, TestExpireAPI) {
-  size_t n_thread_reading = 1;
-  size_t n_thread_writing = 1;
-  configs.max_access_threads = n_thread_writing + n_thread_reading;
   ASSERT_EQ(Engine::Open(db_path.c_str(), &engine, configs, stdout),
             Status::Ok);
 
@@ -2361,7 +2340,6 @@ TEST_F(EngineBasicTest, TestExpireAPI) {
 
 TEST_F(EngineBasicTest, TestbackgroundDestroyCollections) {
   size_t n_thread_writing = 16;
-  configs.max_access_threads = n_thread_writing;
   ASSERT_EQ(Engine::Open(db_path.c_str(), &engine, configs, stdout),
             Status::Ok);
   TTLType ttl = 1000;  // 1s
@@ -2435,7 +2413,6 @@ TEST_F(EngineBasicTest, TestbackgroundDestroyCollections) {
 
 TEST_F(BatchWriteTest, SortedRollback) {
   size_t num_threads = 1;
-  configs.max_access_threads = num_threads + 1;
   for (int index_with_hashtable : {0, 1}) {
     // Test crash before commit
     SyncPoint::GetInstance()->EnableCrashPoint(
@@ -2558,7 +2535,6 @@ TEST_F(BatchWriteTest, StringRollBack) {
   // another thread may reuse this id and the old batch log file
   // is overwritten.
   size_t num_threads = 1;
-  configs.max_access_threads = num_threads;
   ASSERT_EQ(Engine::Open(db_path.c_str(), &engine, configs, stdout),
             Status::Ok);
   size_t batch_size = 100;
@@ -2633,7 +2609,6 @@ TEST_F(BatchWriteTest, StringRollBack) {
 
 TEST_F(BatchWriteTest, HashRollback) {
   size_t num_threads = 1;
-  configs.max_access_threads = num_threads + 1;
   ASSERT_EQ(Engine::Open(db_path.c_str(), &engine, configs, stdout),
             Status::Ok);
   size_t batch_size = 100;
@@ -2722,7 +2697,6 @@ TEST_F(BatchWriteTest, ListBatchOperationRollback) {
         *((std::atomic_bool*)close_reclaimer) = true;
         return;
       });
-  configs.max_access_threads = 1;
   ASSERT_EQ(Engine::Open(db_path.c_str(), &engine, configs, stdout),
             Status::Ok);
   size_t count = 100;
@@ -2835,7 +2809,6 @@ TEST_F(BatchWriteTest, ListBatchOperationRollback) {
 // Then Repair
 TEST_F(EngineBasicTest, TestSortedRecoverySyncPointCaseOne) {
   Configs test_config = configs;
-  test_config.max_access_threads = 16;
 
   std::atomic<int> update_num(1);
   int cnt = 20;
@@ -2926,7 +2899,6 @@ TEST_F(EngineBasicTest, TestSortedRecoverySyncPointCaseTwo) {
       });
   SyncPoint::GetInstance()->EnableProcessing();
 
-  test_config.max_access_threads = 16;
   ASSERT_EQ(Engine::Open(db_path.c_str(), &engine, test_config, stdout),
             Status::Ok);
 
@@ -2988,7 +2960,6 @@ TEST_F(EngineBasicTest, TestSortedRecoverySyncPointCaseTwo) {
 //   thread2: iter
 TEST_F(EngineBasicTest, TestSortedSyncPoint) {
   Configs test_config = configs;
-  test_config.max_access_threads = 16;
   ASSERT_EQ(Engine::Open(db_path.c_str(), &engine, test_config, stdout),
             Status::Ok);
   std::vector<std::thread> ths;
@@ -3043,8 +3014,6 @@ TEST_F(EngineBasicTest, TestSortedSyncPoint) {
 }
 
 TEST_F(EngineBasicTest, TestHashTableRangeIter) {
-  uint64_t threads = 16;
-  configs.max_access_threads = threads;
   ASSERT_EQ(Engine::Open(db_path.c_str(), &engine, configs, stdout),
             Status::Ok);
   std::string key = "stringkey";
@@ -3101,7 +3070,6 @@ TEST_F(EngineBasicTest, TestBackGroundCleaner) {
       });
   SyncPoint::GetInstance()->EnableProcessing();
 
-  configs.max_access_threads = 16;
   ASSERT_EQ(Engine::Open(db_path.c_str(), &engine, configs, stdout),
             Status::Ok);
 
@@ -3313,8 +3281,6 @@ TEST_F(EngineBasicTest, TestBackGroundIterNoHashIndexSkiplist) {
       {{"KVEngine::BackgroundCleaner::IterSkiplist::UnlinkDeleteRecord",
         "KVEngine::SkiplistNoHashIndex::Put"}});
   SyncPoint::GetInstance()->EnableProcessing();
-  uint64_t threads = 16;
-  configs.max_access_threads = threads;
   ASSERT_EQ(Engine::Open(db_path.c_str(), &engine, configs, stdout),
             Status::Ok);
   std::string collection_name = "Skiplist_with_hash_index";
@@ -3403,7 +3369,6 @@ TEST_F(EngineBasicTest, TestDynamicCleaner) {
                                           return;
                                         });
   SyncPoint::GetInstance()->EnableProcessing();
-  configs.max_access_threads = 32;
   configs.hash_bucket_num = 256;
   configs.clean_threads = 8;
   ASSERT_EQ(Engine::Open(db_path.c_str(), &engine, configs, stdout),


### PR DESCRIPTION
### What problem does this PR solve?

 - Remove limitation on foreground thread and instance number

### What is changed and how it works?

Make thread manager global (singleton) and allocate thread id incrementally, foreground thread access kvdk instance with id % max_access_thread, and acquire lock for synchronization.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Stress test
