### PR TITLE
Align reference of std::string in header files to StringView 

### DIFF
--- a/engine/engine.cpp
+++ b/engine/engine.cpp
@@ -7,15 +7,15 @@
 #include "kv_engine.hpp"
 
 namespace KVDK_NAMESPACE {
-Status Engine::Open(const std::string& name, Engine** engine_ptr,
+Status Engine::Open(const StringView name, Engine** engine_ptr,
                     const Configs& configs, FILE* log_file) {
   GlobalLogger.Init(log_file, configs.log_level);
   Status s = KVEngine::Open(name, engine_ptr, configs);
   return s;
 }
 
-Status Engine::Restore(const std::string& engine_path,
-                       const std::string& backup_file, Engine** engine_ptr,
+Status Engine::Restore(const StringView engine_path,
+                       const StringView backup_file, Engine** engine_ptr,
                        const Configs& configs, FILE* log_file) {
   GlobalLogger.Init(log_file, configs.log_level);
   Status s = KVEngine::Restore(engine_path, backup_file, engine_ptr, configs);

--- a/engine/kv_engine.cpp
+++ b/engine/kv_engine.cpp
@@ -57,11 +57,13 @@ KVEngine::~KVEngine() {
   GlobalLogger.Info("Instance closed\n");
 }
 
-Status KVEngine::Open(const std::string& name, Engine** engine_ptr,
+Status KVEngine::Open(const StringView engine_path, Engine** engine_ptr,
                       const Configs& configs) {
-  GlobalLogger.Info("Opening kvdk instance from %s ...\n", name.c_str());
+  std::string engine_path_str(string_view_2_string(engine_path));
+  GlobalLogger.Info("Opening kvdk instance from %s ...\n",
+                    engine_path_str.c_str());
   KVEngine* engine = new KVEngine(configs);
-  Status s = engine->init(name, configs);
+  Status s = engine->init(engine_path_str, configs);
   if (s == Status::Ok) {
     s = engine->restoreExistingData();
   }
@@ -76,16 +78,18 @@ Status KVEngine::Open(const std::string& name, Engine** engine_ptr,
   return s;
 }
 
-Status KVEngine::Restore(const std::string& engine_path,
-                         const std::string& backup_log, Engine** engine_ptr,
+Status KVEngine::Restore(const StringView engine_path,
+                         const StringView backup_log, Engine** engine_ptr,
                          const Configs& configs) {
+  std::string engine_path_str(string_view_2_string(engine_path));
+  std::string backup_log_str(string_view_2_string(backup_log));
   GlobalLogger.Info(
       "Restoring kvdk instance from backup log %s to engine path %s\n",
-      backup_log.c_str(), engine_path.c_str());
+      backup_log_str.c_str(), engine_path_str.c_str());
   KVEngine* engine = new KVEngine(configs);
-  Status s = engine->init(engine_path, configs);
+  Status s = engine->init(engine_path_str, configs);
   if (s == Status::Ok) {
-    s = engine->restoreDataFromBackup(backup_log);
+    s = engine->restoreDataFromBackup(backup_log_str);
   }
 
   if (s == Status::Ok) {
@@ -94,7 +98,7 @@ Status KVEngine::Restore(const std::string& engine_path,
     engine->ReportPMemUsage();
   } else {
     GlobalLogger.Error("Restore kvdk instance from backup log %s failed: %d\n",
-                       backup_log.c_str(), s);
+                       backup_log_str.c_str(), s);
     delete engine;
   }
   return s;
@@ -158,12 +162,12 @@ Status KVEngine::init(const std::string& name, const Configs& configs) {
       return Status::IOError;
     }
 
-    db_file_ = data_file();
+    data_file_ = data_file();
     configs_ = configs;
 
   } else {
     configs_ = configs;
-    db_file_ = name;
+    data_file_ = name;
 
     // The devdax mode need to execute the shell scripts/init_devdax.sh,
     // then a fsdax model namespace will be created and the
@@ -185,7 +189,7 @@ Status KVEngine::init(const std::string& name, const Configs& configs) {
   }
 
   pmem_allocator_.reset(PMEMAllocator::NewPMEMAllocator(
-      db_file_, configs_.pmem_file_size, configs_.pmem_segment_blocks,
+      data_file_, configs_.pmem_file_size, configs_.pmem_segment_blocks,
       configs_.pmem_block_size, configs_.max_access_threads,
       configs_.populate_pmem_space, configs_.use_devdax_mode,
       &version_controller_));

--- a/engine/kv_engine.hpp
+++ b/engine/kv_engine.hpp
@@ -48,11 +48,11 @@ class KVEngine : public Engine {
  public:
   ~KVEngine();
 
-  static Status Open(const std::string& name, Engine** engine_ptr,
+  static Status Open(const StringView engine_path, Engine** engine_ptr,
                      const Configs& configs);
 
-  static Status Restore(const std::string& engine_path,
-                        const std::string& backup_log, Engine** engine_ptr,
+  static Status Restore(const StringView engine_path,
+                        const StringView backup_log, Engine** engine_ptr,
                         const Configs& configs);
 
   Snapshot* GetSnapshot(bool make_checkpoint) final;
@@ -356,11 +356,10 @@ class KVEngine : public Engine {
                   "Invalid type!");
     return std::is_same<CollectionType, Skiplist>::value
                ? RecordType::SortedRecord
-               : std::is_same<CollectionType, List>::value
-                     ? RecordType::ListRecord
-                     : std::is_same<CollectionType, HashList>::value
-                           ? RecordType::HashRecord
-                           : RecordType::Empty;
+           : std::is_same<CollectionType, List>::value ? RecordType::ListRecord
+           : std::is_same<CollectionType, HashList>::value
+               ? RecordType::HashRecord
+               : RecordType::Empty;
   }
 
   static PointerType pointerType(RecordType rtype) {
@@ -641,7 +640,7 @@ class KVEngine : public Engine {
 
   std::string dir_;
   std::string batch_log_dir_;
-  std::string db_file_;
+  std::string data_file_;
   std::unique_ptr<PMEMAllocator> pmem_allocator_;
   Configs configs_;
   bool closing_{false};

--- a/engine/kv_engine.hpp
+++ b/engine/kv_engine.hpp
@@ -356,10 +356,11 @@ class KVEngine : public Engine {
                   "Invalid type!");
     return std::is_same<CollectionType, Skiplist>::value
                ? RecordType::SortedRecord
-           : std::is_same<CollectionType, List>::value ? RecordType::ListRecord
-           : std::is_same<CollectionType, HashList>::value
-               ? RecordType::HashRecord
-               : RecordType::Empty;
+               : std::is_same<CollectionType, List>::value
+                     ? RecordType::ListRecord
+                     : std::is_same<CollectionType, HashList>::value
+                           ? RecordType::HashRecord
+                           : RecordType::Empty;
   }
 
   static PointerType pointerType(RecordType rtype) {

--- a/engine/transaction_impl.cpp
+++ b/engine/transaction_impl.cpp
@@ -23,8 +23,8 @@ TransactionImpl::TransactionImpl(KVEngine* engine)
 
 TransactionImpl::~TransactionImpl() { Rollback(); }
 
-Status TransactionImpl::StringPut(const std::string& key,
-                                  const std::string& value) {
+Status TransactionImpl::StringPut(const StringView key,
+                                  const StringView value) {
   auto hash_table = engine_->GetHashTable();
   if (!tryLock(hash_table->GetLock(key))) {
     status_ = Status::Timeout;
@@ -35,7 +35,7 @@ Status TransactionImpl::StringPut(const std::string& key,
   return Status::Ok;
 }
 
-Status TransactionImpl::StringDelete(const std::string& key) {
+Status TransactionImpl::StringDelete(const StringView key) {
   auto hash_table = engine_->GetHashTable();
   if (!tryLock(hash_table->GetLock(key))) {
     status_ = Status::Timeout;
@@ -46,7 +46,7 @@ Status TransactionImpl::StringDelete(const std::string& key) {
   return Status::Ok;
 }
 
-Status TransactionImpl::StringGet(const std::string& key, std::string* value) {
+Status TransactionImpl::StringGet(const StringView key, std::string* value) {
   auto op = batch_->StringGet(key);
   if (op != nullptr) {
     if (op->op == WriteOp::Delete) {
@@ -65,9 +65,9 @@ Status TransactionImpl::StringGet(const std::string& key, std::string* value) {
   }
 }
 
-Status TransactionImpl::SortedPut(const std::string& collection,
-                                  const std::string& key,
-                                  const std::string& value) {
+Status TransactionImpl::SortedPut(const StringView collection,
+                                  const StringView key,
+                                  const StringView value) {
   acquireCollectionTransaction();
   auto hash_table = engine_->GetHashTable();
   auto lookup_result =
@@ -87,8 +87,8 @@ Status TransactionImpl::SortedPut(const std::string& collection,
   return Status::Ok;
 }
 
-Status TransactionImpl::SortedDelete(const std::string& collection,
-                                     const std::string& key) {
+Status TransactionImpl::SortedDelete(const StringView collection,
+                                     const StringView key) {
   acquireCollectionTransaction();
   auto hash_table = engine_->GetHashTable();
   auto lookup_result =
@@ -108,8 +108,8 @@ Status TransactionImpl::SortedDelete(const std::string& collection,
   return Status::Ok;
 }
 
-Status TransactionImpl::SortedGet(const std::string& collection,
-                                  const std::string& key, std::string* value) {
+Status TransactionImpl::SortedGet(const StringView collection,
+                                  const StringView key, std::string* value) {
   auto op = batch_->SortedGet(collection, key);
   if (op != nullptr) {
     if (op->op == WriteOp::Delete) {
@@ -138,9 +138,8 @@ Status TransactionImpl::SortedGet(const std::string& collection,
   }
 }
 
-Status TransactionImpl::HashPut(const std::string& collection,
-                                const std::string& key,
-                                const std::string& value) {
+Status TransactionImpl::HashPut(const StringView collection,
+                                const StringView key, const StringView value) {
   acquireCollectionTransaction();
   auto hash_table = engine_->GetHashTable();
   auto lookup_result =
@@ -160,8 +159,8 @@ Status TransactionImpl::HashPut(const std::string& collection,
   return Status::Ok;
 }
 
-Status TransactionImpl::HashDelete(const std::string& collection,
-                                   const std::string& key) {
+Status TransactionImpl::HashDelete(const StringView collection,
+                                   const StringView key) {
   acquireCollectionTransaction();
   auto hash_table = engine_->GetHashTable();
   auto lookup_result =
@@ -181,8 +180,8 @@ Status TransactionImpl::HashDelete(const std::string& collection,
   return Status::Ok;
 }
 
-Status TransactionImpl::HashGet(const std::string& collection,
-                                const std::string& key, std::string* value) {
+Status TransactionImpl::HashGet(const StringView collection,
+                                const StringView key, std::string* value) {
   auto op = batch_->HashGet(collection, key);
   if (op != nullptr) {
     if (op->op == WriteOp::Delete) {

--- a/engine/transaction_impl.hpp
+++ b/engine/transaction_impl.hpp
@@ -100,20 +100,18 @@ class TransactionImpl final : public Transaction {
  public:
   TransactionImpl(KVEngine* engine);
   ~TransactionImpl() final;
-  Status StringPut(const std::string& key, const std::string& value) final;
-  Status StringDelete(const std::string& key) final;
-  Status StringGet(const std::string& key, std::string* value) final;
-  Status SortedPut(const std::string& collection, const std::string& key,
-                   const std::string& value) final;
-  Status SortedDelete(const std::string& collection,
-                      const std::string& key) final;
-  Status SortedGet(const std::string& collection, const std::string& key,
+  Status StringPut(const StringView key, const StringView value) final;
+  Status StringDelete(const StringView key) final;
+  Status StringGet(const StringView key, std::string* value) final;
+  Status SortedPut(const StringView collection, const StringView key,
+                   const StringView value) final;
+  Status SortedDelete(const StringView collection, const StringView key) final;
+  Status SortedGet(const StringView collection, const StringView key,
                    std::string* value) final;
-  Status HashPut(const std::string& collection, const std::string& key,
-                 const std::string& value) final;
-  Status HashDelete(const std::string& collection,
-                    const std::string& key) final;
-  Status HashGet(const std::string& collection, const std::string& key,
+  Status HashPut(const StringView collection, const StringView key,
+                 const StringView value) final;
+  Status HashDelete(const StringView collection, const StringView key) final;
+  Status HashGet(const StringView collection, const StringView key,
                  std::string* value) final;
   Status Commit() final;
   void Rollback() final;

--- a/engine/write_batch_impl.hpp
+++ b/engine/write_batch_impl.hpp
@@ -17,12 +17,22 @@ namespace KVDK_NAMESPACE {
 class WriteBatchImpl final : public WriteBatch {
  public:
   struct StringOp {
+    StringOp(WriteOp o, const StringView& k, const StringView& v)
+        : op(o), key(string_view_2_string(k)), value(string_view_2_string(v)) {}
+
     WriteOp op;
     std::string key;
     std::string value;
   };
 
   struct SortedOp {
+    SortedOp(WriteOp o, const StringView& c, const StringView& k,
+             const StringView& v)
+        : op(o),
+          collection(string_view_2_string(c)),
+          key(string_view_2_string(k)),
+          value(string_view_2_string(v)) {}
+
     WriteOp op;
     std::string collection;
     std::string key;
@@ -30,6 +40,13 @@ class WriteBatchImpl final : public WriteBatch {
   };
 
   struct HashOp {
+    HashOp(WriteOp o, const StringView& c, const StringView& k,
+           const StringView& v)
+        : op(o),
+          collection(string_view_2_string(c)),
+          key(string_view_2_string(k)),
+          value(string_view_2_string(v)) {}
+
     WriteOp op;
     std::string collection;
     std::string key;
@@ -57,40 +74,39 @@ class WriteBatchImpl final : public WriteBatch {
     }
   };
 
-  void StringPut(std::string const& key, std::string const& value) final {
+  void StringPut(const StringView key, const StringView value) final {
     StringOp op{WriteOp::Put, key, value};
     string_ops_.erase(op);
     string_ops_.insert(op);
   }
 
-  void StringDelete(std::string const& key) final {
+  void StringDelete(const StringView key) final {
     StringOp op{WriteOp::Delete, key, std::string{}};
     string_ops_.erase(op);
     string_ops_.insert(op);
   }
 
-  void SortedPut(std::string const& collection, std::string const& key,
-                 std::string const& value) final {
+  void SortedPut(const StringView collection, const StringView key,
+                 const StringView value) final {
     SortedOp op{WriteOp::Put, collection, key, value};
     sorted_ops_.erase(op);
     sorted_ops_.insert(op);
   }
 
-  void SortedDelete(std::string const& collection,
-                    std::string const& key) final {
+  void SortedDelete(const StringView collection, const StringView key) final {
     SortedOp op{WriteOp::Delete, collection, key, std::string{}};
     sorted_ops_.erase(op);
     sorted_ops_.insert(op);
   }
 
-  void HashPut(std::string const& collection, std::string const& key,
-               std::string const& value) final {
+  void HashPut(const StringView collection, const StringView key,
+               const StringView value) final {
     HashOp op{WriteOp::Put, collection, key, value};
     hash_ops_.erase(op);
     hash_ops_.insert(op);
   }
 
-  void HashDelete(std::string const& collection, std::string const& key) final {
+  void HashDelete(const StringView collection, const StringView key) final {
     HashOp op{WriteOp::Delete, collection, key, std::string{}};
     hash_ops_.erase(op);
     hash_ops_.insert(op);
@@ -98,7 +114,7 @@ class WriteBatchImpl final : public WriteBatch {
 
   // Get a string op from this batch
   // if key not exist in this batch, return nullptr
-  const StringOp* StringGet(std::string const& key) {
+  const StringOp* StringGet(const StringView key) {
     StringOp op{WriteOp::Put, key, ""};
     auto iter = string_ops_.find(op);
     if (iter == string_ops_.end()) {
@@ -109,8 +125,7 @@ class WriteBatchImpl final : public WriteBatch {
 
   // Get a sorted op from this batch
   // if collection key not exist in this batch, return nullptr
-  const SortedOp* SortedGet(const std::string& collection,
-                            const std::string& key) {
+  const SortedOp* SortedGet(const StringView collection, const StringView key) {
     SortedOp op{WriteOp::Put, collection, key, ""};
     auto iter = sorted_ops_.find(op);
     if (iter == sorted_ops_.end()) {
@@ -121,7 +136,7 @@ class WriteBatchImpl final : public WriteBatch {
 
   // Get a hash op from this batch
   // if the collection key not exist in this batch, return nullptr
-  const HashOp* HashGet(std::string const& collection, std::string const& key) {
+  const HashOp* HashGet(const StringView collection, const StringView key) {
     HashOp op{WriteOp::Put, collection, key, ""};
     auto iter = hash_ops_.find(op);
     if (iter == hash_ops_.end()) {

--- a/include/kvdk/engine.hpp
+++ b/include/kvdk/engine.hpp
@@ -32,7 +32,7 @@ class Engine {
   // Return Status::Ok on sucess, return other status for any error
   //
   // To close the instance, just delete *engine_ptr.
-  static Status Open(const std::string& engine_path, Engine** engine_ptr,
+  static Status Open(const StringView engine_path, Engine** engine_ptr,
                      const Configs& configs, FILE* log_file = stdout);
 
   // Restore a KVDK instance from a backup log file.
@@ -49,8 +49,8 @@ class Engine {
   //
   // Notice:
   // "engine_path" should be an empty dir
-  static Status Restore(const std::string& engine_path,
-                        const std::string& backup_log, Engine** engine_ptr,
+  static Status Restore(const StringView engine_path,
+                        const StringView backup_log, Engine** engine_ptr,
                         const Configs& configs, FILE* log_file = stdout);
 
   virtual Status TypeOf(StringView key, ValueType* type) = 0;

--- a/include/kvdk/transaction.hpp
+++ b/include/kvdk/transaction.hpp
@@ -12,22 +12,20 @@ namespace KVDK_NAMESPACE {
 class Transaction {
  public:
   // TODO: use StringView instead of std::string
-  virtual Status StringPut(const std::string& key,
-                           const std::string& value) = 0;
-  virtual Status StringDelete(const std::string& key) = 0;
-  virtual Status StringGet(const std::string& key, std::string* value) = 0;
-  virtual Status SortedPut(const std::string& collection,
-                           const std::string& key,
-                           const std::string& value) = 0;
-  virtual Status SortedDelete(const std::string& collection,
-                              const std::string& key) = 0;
-  virtual Status SortedGet(const std::string& collection,
-                           const std::string& key, std::string* value) = 0;
-  virtual Status HashPut(const std::string& collection, const std::string& key,
-                         const std::string& value) = 0;
-  virtual Status HashDelete(const std::string& collection,
-                            const std::string& key) = 0;
-  virtual Status HashGet(const std::string& collection, const std::string& key,
+  virtual Status StringPut(const StringView key, const StringView value) = 0;
+  virtual Status StringDelete(const StringView key) = 0;
+  virtual Status StringGet(const StringView key, std::string* value) = 0;
+  virtual Status SortedPut(const StringView collection, const StringView key,
+                           const StringView value) = 0;
+  virtual Status SortedDelete(const StringView collection,
+                              const StringView key) = 0;
+  virtual Status SortedGet(const StringView collection, const StringView key,
+                           std::string* value) = 0;
+  virtual Status HashPut(const StringView collection, const StringView key,
+                         const StringView value) = 0;
+  virtual Status HashDelete(const StringView collection,
+                            const StringView key) = 0;
+  virtual Status HashGet(const StringView collection, const StringView key,
                          std::string* value) = 0;
 
   virtual Status Commit() = 0;

--- a/include/kvdk/write_batch.hpp
+++ b/include/kvdk/write_batch.hpp
@@ -12,18 +12,18 @@ namespace KVDK_NAMESPACE {
 
 class WriteBatch {
  public:
-  virtual void StringPut(std::string const& key, std::string const& value) = 0;
-  virtual void StringDelete(std::string const& key) = 0;
+  virtual void StringPut(const StringView key, const StringView value) = 0;
+  virtual void StringDelete(const StringView key) = 0;
 
-  virtual void SortedPut(std::string const& collection, std::string const& key,
-                         std::string const& value) = 0;
-  virtual void SortedDelete(std::string const& collection,
-                            std::string const& key) = 0;
+  virtual void SortedPut(const StringView collection, const StringView key,
+                         const StringView value) = 0;
+  virtual void SortedDelete(const StringView collection,
+                            const StringView key) = 0;
 
-  virtual void HashPut(std::string const& collection, std::string const& key,
-                       std::string const& value) = 0;
-  virtual void HashDelete(std::string const& collection,
-                          std::string const& key) = 0;
+  virtual void HashPut(const StringView collection, const StringView key,
+                       const StringView value) = 0;
+  virtual void HashDelete(const StringView collection,
+                          const StringView key) = 0;
 
   virtual void Clear() = 0;
 


### PR DESCRIPTION
### What problem does this PR solve?

Some of API in header files use const std::string& to pass string, and some of then use StringView.

### What is changed and how it works?

Align reference of std::string in header files to StringView 

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Stress test
